### PR TITLE
Run rustfmt on stable on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,19 @@
 language: rust
 
 rust:
-    - stable
-    - beta
-    - nightly
+  - stable
+  - beta
+  - nightly
 
 script:
-    cargo build -v;
-    if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then cargo test -v; fi;
-    cargo doc -v;
+  - cargo build -v
+  - if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then cargo test -v; fi
+  - |
+    if [ "$TRAVIS_RUST_VERSION" = "stable" ]; then
+      rustup component add rustfmt
+      cargo fmt --all -- --check
+    fi
+  - cargo doc -v
 
 after_success:
-    - curl http://docs.piston.rs/travis-doc-upload.sh | sh
+  - curl http://docs.piston.rs/travis-doc-upload.sh | sh


### PR DESCRIPTION
Fixes #343 
I think we don't have to run rustfmt for all targets so make it run only stable.