### PR TITLE
fix #383

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,2 @@
+[target.wasm32-unknown-unknown]
+runner = 'wasm-bindgen-test-runner'

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,12 @@ script:
   - cargo build -v
   - if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then cargo test -v; fi
   - |
+    if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then
+      rustup target add wasm32-unknown-unknown --toolchain nightly
+      cargo install wasm-bindgen-cli --vers "0.2.50"
+      cargo test -v --target wasm32-unknown-unknown
+    fi
+  - |
     if [ "$TRAVIS_RUST_VERSION" = "stable" ]; then
       rustup component add rustfmt
       cargo fmt --all -- --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ rulinalg = "0.4.2"
 assert_approx_eq = "1.0.0"
 image = "0.22.2"
 quickcheck = "0.8"
+wasm-bindgen-test = "0.2"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/region_labelling.rs
+++ b/src/region_labelling.rs
@@ -244,13 +244,18 @@ where
 
 #[cfg(test)]
 mod tests {
+    extern crate wasm_bindgen_test;
+
     use super::connected_components;
     use super::Connectivity::{Eight, Four};
     use crate::definitions::{HasBlack, HasWhite};
     use ::test;
     use image::{GrayImage, ImageBuffer, Luma};
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::*;
 
-    #[test]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_connected_components_eight_white_background() {
         let image = gray_image!(
               1, 255,   2,   1;
@@ -280,7 +285,8 @@ mod tests {
         })
     }
 
-    #[test]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_connected_components_eight_chessboard() {
         let image = chessboard(30, 30);
         let components = connected_components(&image, Eight, Luma::black());
@@ -288,7 +294,8 @@ mod tests {
         assert_eq!(max_component, Some(1u32));
     }
 
-    #[test]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_connected_components_four_chessboard() {
         let image = chessboard(30, 30);
         let components = connected_components(&image, Four, Luma::black());

--- a/src/region_labelling.rs
+++ b/src/region_labelling.rs
@@ -129,7 +129,7 @@ where
 {
     let (width, height) = image.dimensions();
     let image_size = width as usize * height as usize;
-    if image_size >= 2usize.pow(32) {
+    if image_size >= 2usize.saturating_pow(32) {
         panic!("Images with 2^32 or more pixels are not supported");
     }
 


### PR DESCRIPTION
fix #383 by:
- extending tests for `region_labelling` to run on `wasm32`
- changing implementation of size check in `connected_components` to work on wasm32 