### PR TITLE
Switch from unmaintained rulinalg to nalgebra

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ rusttype = "0.8.1"
 rayon = "1.0"
 quickcheck = { version = "0.8", optional = true }
 sdl2 = { version = "0.32", optional = true, default-features = false, features = ["bundled"] }
-rulinalg = "0.4.2"
+nalgebra = "0.19.0"
 
 [dev-dependencies]
 assert_approx_eq = "1.0.0"

--- a/src/geometric_transformations.rs
+++ b/src/geometric_transformations.rs
@@ -170,7 +170,7 @@ impl Projection {
         match &svd {
             SVD { v_t: Some(v), .. } => {
                 // rank(a) must be 8, but not 7
-                if svd.rank(0.01) != 8 {
+                if svd.rank(0.01) == 7 {
                     None
                 } else {
                     let transform = normalize(v.row(8).map(|x| x as f32).into());


### PR DESCRIPTION
`rulinalg` was initially used due to the belief that the `nalgebra-lapack` (which requires the system to have LAPACK) crate would need to be used instead of the pure-Rust `nalgebra`. However, this is incorrect, as nalgebra 0.13.0 added a pure-Rust SVD.