### PR TITLE
Modified Template Matching / Integral Image to use Image instead of GrayImage

### DIFF
--- a/examples/template_matching.rs
+++ b/examples/template_matching.rs
@@ -98,7 +98,7 @@ fn run_match_template(
     method: MatchTemplateMethod,
 ) -> RgbImage {
     // Match the template and convert to u8 depth to display
-    let result = match_template(&image, &template, method);
+    let result = match_template(image, template, method);
     let result_scaled = convert_to_gray_image(&result);
 
     // Pad the result to the same size as the input image, to make them easier to compare

--- a/src/integral_image.rs
+++ b/src/integral_image.rs
@@ -49,9 +49,9 @@ use num::traits::*;
 /// ```
 pub fn integral_image<P, T>(image: &Image<P>) -> Image<ChannelMap<P, T>>
 where
-    P: Pixel<Subpixel = u8> + WithChannel<T> + 'static,
+    P: Pixel + WithChannel<T> + 'static,
     P::Subpixel: NumCast,
-    T: Primitive + NumAssign + 'static,
+    T: NumAssign + 'static + Primitive,
 {
     integral_image_impl(image, false)
 }
@@ -249,8 +249,8 @@ impl<T: Primitive + 'static> ArrayData for Rgba<T> {
 ///
 /// The of `ArrayData` here is due to lack of const generics. This library contains
 /// implementations of `ArrayData` for `Luma`, `Rgb` and `Rgba` for any element type `T` that
-/// implements `Primitive`. In that case, this function returns `[T; 1]` for an image
-/// whose pixels are of type `Luma`, `[T; 3]` for `Rgb` pixels and `[T; 4]` for `Rgba` pixels.
+/// implements `Primitive`. In that case, this function returns `vec![T; 1]` for an image
+/// whose pixels are of type `Luma`, `vec![T; 3]` for `Rgb` pixels and `vec![T; 4]` for `Rgba` pixels.
 ///
 /// See the [`integral_image`](fn.integral_image.html) documentation for examples.
 pub fn sum_image_pixels<P>(

--- a/src/integral_image.rs
+++ b/src/integral_image.rs
@@ -47,7 +47,16 @@ use std::ops::AddAssign;
 /// assert_eq!(sum_image_pixels(&integral, 0, 0, 2, 0)[0], 1 + 2 + 3);
 /// # }
 /// ```
-pub fn integral_image<I, T>(image: &I) -> Image<ChannelMap<I::Pixel, T>>
+pub fn integral_image<P, T>(image: &Image<P>) -> Image<ChannelMap<P, T>>
+    where
+        P: Pixel<Subpixel = u8> + WithChannel<T> + 'static,
+        T: From<u8> + Primitive + AddAssign + 'static
+{
+    integral_image_impl(image, false)
+}
+
+/// Same as integral_image but for a GenericImageView
+pub fn integral_image_view<T, I>(image: &I) -> Image<ChannelMap<I::Pixel, T>>
     where
         I: GenericImageView,
         I::Pixel: Pixel + WithChannel<T> + 'static,
@@ -87,7 +96,17 @@ pub fn integral_image<I, T>(image: &I) -> Image<ChannelMap<I::Pixel, T>>
 /// assert_eq!(sum_image_pixels(&integral, 0, 0, 2, 0)[0], 1 + 4 + 9);
 /// # }
 /// ```
-pub fn integral_squared_image<I, T>(image: &I) -> Image<ChannelMap<I::Pixel, T>>
+///
+pub fn integral_squared_image<P, T>(image: &Image<P>) -> Image<ChannelMap<P, T>>
+    where
+        P: Pixel<Subpixel = u8> + WithChannel<T> + 'static,
+        T: From<u8> + Primitive + AddAssign + 'static
+{
+    integral_image_impl(image, true)
+}
+
+/// Same as integral_squared_image but for a GenericImageView
+pub fn integral_squared_image_view<T, I>(image: &I) -> Image<ChannelMap<I::Pixel, T>>
 where
     I: GenericImageView,
     I::Pixel: Pixel + WithChannel<T> + 'static,

--- a/src/integral_image.rs
+++ b/src/integral_image.rs
@@ -161,6 +161,9 @@ pub trait ArrayData {
 
     /// Subtract the elements of two data arrays elementwise.
     fn sub(lhs: Self::DataType, other: Self::DataType) -> Self::DataType;
+
+    /// Convert DataType back into Pixel
+    fn data_to_pixel(data: Self::DataType) -> Self;
 }
 
 impl<T: Primitive + 'static> ArrayData for Luma<T> {
@@ -177,6 +180,10 @@ impl<T: Primitive + 'static> ArrayData for Luma<T> {
     fn sub(lhs: Self::DataType, rhs: Self::DataType) -> Self::DataType {
         [lhs[0] - rhs[0]]
     }
+
+    fn data_to_pixel(data: Self::DataType) -> Self {
+        Self{ 0: data }
+    }
 }
 
 impl<T: Primitive + 'static> ArrayData for Rgb<T> {
@@ -192,6 +199,10 @@ impl<T: Primitive + 'static> ArrayData for Rgb<T> {
 
     fn sub(lhs: Self::DataType, rhs: Self::DataType) -> Self::DataType {
         [lhs[0] - rhs[0], lhs[1] - rhs[1], lhs[2] - rhs[2]]
+    }
+
+    fn data_to_pixel(data: Self::DataType) -> Self {
+        Self{ 0: data }
     }
 }
 
@@ -224,6 +235,10 @@ impl<T: Primitive + 'static> ArrayData for Rgba<T> {
             lhs[3] - rhs[3],
         ]
     }
+
+    fn data_to_pixel(data: Self::DataType) -> Self {
+        Self{ 0: data }
+    }
 }
 
 /// Sums the pixels in positions [left, right] * [top, bottom] in F, where `integral_image` is the
@@ -241,7 +256,7 @@ pub fn sum_image_pixels<P>(
     top: u32,
     right: u32,
     bottom: u32,
-) -> P::DataType
+) -> Vec<P::Subpixel>
 where
     P: Pixel + ArrayData + Copy + 'static,
 {
@@ -253,7 +268,8 @@ where
         integral_image.get_pixel(right + 1, top).data(),
         integral_image.get_pixel(left, bottom + 1).data(),
     );
-    P::sub(P::sub(P::add(a, b), c), d)
+
+    P::data_to_pixel(P::sub(P::sub(P::add(a, b), c), d)).channels().to_vec()
 }
 
 /// Computes the variance of [left, right] * [top, bottom] in F, where `integral_image` is the

--- a/src/integral_image.rs
+++ b/src/integral_image.rs
@@ -185,7 +185,7 @@ impl<T: Primitive + 'static> ArrayData for Luma<T> {
     }
 
     fn data_to_pixel(data: Self::DataType) -> Self {
-        Self{ 0: data }
+        Self { 0: data }
     }
 }
 
@@ -205,7 +205,7 @@ impl<T: Primitive + 'static> ArrayData for Rgb<T> {
     }
 
     fn data_to_pixel(data: Self::DataType) -> Self {
-        Self{ 0: data }
+        Self { 0: data }
     }
 }
 
@@ -240,7 +240,7 @@ impl<T: Primitive + 'static> ArrayData for Rgba<T> {
     }
 
     fn data_to_pixel(data: Self::DataType) -> Self {
-        Self{ 0: data }
+        Self { 0: data }
     }
 }
 
@@ -272,7 +272,9 @@ where
         integral_image.get_pixel(left, bottom + 1).data(),
     );
 
-    P::data_to_pixel(P::sub(P::sub(P::add(a, b), c), d)).channels().to_vec()
+    P::data_to_pixel(P::sub(P::sub(P::add(a, b), c), d))
+        .channels()
+        .to_vec()
 }
 
 /// Computes the variance of [left, right] * [top, bottom] in F, where `integral_image` is the

--- a/src/template_matching.rs
+++ b/src/template_matching.rs
@@ -128,7 +128,7 @@ where
 fn sum_squares<P>(template: &Image<P>) -> f32
 where
     P: Pixel + 'static,
-    P::Subpixel: AddAssign + Primitive + ToPrimitive + 'static,
+    P::Subpixel: NumAssign + 'static,
 {
     template.pixels().map(|p| p.channels().iter().map(|pv| pv.to_f32().unwrap().powf(2.0)).sum::<f32>()).sum()
 }
@@ -142,7 +142,7 @@ fn normalization_term<P>(
 ) -> f32
 where
     P: Pixel + 'static + ArrayData,
-    P::Subpixel: AddAssign + Primitive + ToPrimitive + 'static,
+    P::Subpixel: AddAssign + 'static,
 {
 
     let image_sum = sum_image_pixels(
@@ -342,7 +342,7 @@ mod tests {
         let actual = match_template(&image, &template, MatchTemplateMethod::SumOfSquaredErrorsNormalized);
         // Not yet correct expected
         let expected = gray_image!(type: f32,
-            3.0, 39.0, 183.0
+            0.007280524, 0.07134486, 0.26518285
         );
 
         assert_pixels_eq!(actual, expected);

--- a/src/template_matching.rs
+++ b/src/template_matching.rs
@@ -280,6 +280,27 @@ mod tests {
     }
 
     #[test]
+    fn match_template_rgb_sum_of_squared_errors() {
+        let image = rgb_image!(
+            [1,  2,  3], [ 4,  5,  6], [7, 8, 9];
+            [10,  11,  12], [13, 14, 15], [16, 17, 18];
+            [1,  2,  3], [ 4,  5,  6], [7, 8, 9]);
+
+        let template = rgb_image!(
+            [1, 2, 3];
+            [11, 12, 13]
+        );
+
+        let actual = match_template(&image, &template, MatchTemplateMethod::SumOfSquaredErrors);
+        let expected = gray_image!(type: f32,
+            3.0, 39.0, 183.0;
+            543.0, 579.0, 723.0
+        );
+
+        assert_pixels_eq!(actual, expected);
+    }
+
+    #[test]
     fn match_template_sum_of_squared_errors_normalized() {
         let image = gray_image!(
             1, 4, 2;
@@ -300,6 +321,26 @@ mod tests {
         let expected = gray_image!(type: f32,
             14.0 / (22.0 * tss).sqrt(), 14.0 / (30.0 * tss).sqrt();
             3.0 / (23.0 * tss).sqrt(), 1.0 / (35.0 * tss).sqrt()
+        );
+
+        assert_pixels_eq!(actual, expected);
+    }
+
+    #[test]
+    fn match_template_rgb_sum_of_squared_errors_normalized() {
+        let image = rgb_image!(
+            [1,  2,  3], [ 4,  5,  6], [7, 8, 9];
+            [10,  11,  12], [13, 14, 15], [16, 17, 18]);
+
+        let template = rgb_image!(
+            [1, 2, 3];
+            [11, 12, 13]
+        );
+
+        let actual = match_template(&image, &template, MatchTemplateMethod::SumOfSquaredErrorsNormalized);
+        // Not yet correct expected
+        let expected = gray_image!(type: f32,
+            3.0, 39.0, 183.0
         );
 
         assert_pixels_eq!(actual, expected);

--- a/src/template_matching.rs
+++ b/src/template_matching.rs
@@ -6,7 +6,9 @@ use image::{Primitive, GenericImageView, Pixel};
 use image::Luma;
 use std::ops::AddAssign;
 use crate::map::WithChannel;
-use num::ToPrimitive;
+use num::{ToPrimitive, NumCast};
+use num::traits::NumAssign;
+
 
 /// Method used to compute the matching score between a template and an image region.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -42,9 +44,9 @@ pub fn match_template<P>(
     method: MatchTemplateMethod,
 ) -> Image<Luma<f32>>
 where
-    P: Pixel + 'static + WithChannel<< P as Pixel>::Subpixel> + ArrayData,
-    P::Subpixel: AddAssign + Primitive + ToPrimitive + 'static,
-    <P as WithChannel<<P as Pixel>::Subpixel>>::Pixel: ArrayData,
+    P: Pixel + 'static + WithChannel<f32> + ArrayData,
+    P::Subpixel: NumAssign + NumCast + 'static,
+    <P as WithChannel<f32>>::Pixel: ArrayData,
 {
     let (image_width, image_height) = image.dimensions();
     let (template_width, template_height) = template.dimensions();
@@ -65,7 +67,7 @@ where
     };
 
     let image_squared_integral = if should_normalize {
-        Some(integral_squared_image(image))
+        Some(integral_squared_image::<_, f32>(image))
     } else {
         None
     };

--- a/src/template_matching.rs
+++ b/src/template_matching.rs
@@ -58,7 +58,7 @@ pub fn match_template(
         _ => false,
     };
     let image_squared_integral = if should_normalize {
-        Some(integral_squared_image(&image))
+        Some(integral_squared_image(image))
     } else {
         None
     };

--- a/src/template_matching.rs
+++ b/src/template_matching.rs
@@ -370,6 +370,27 @@ mod tests {
     }
 
     #[test]
+    fn match_template_rgb_cross_correlation() {
+        let image = rgb_image!(
+            [1,  2,  3], [ 4,  5,  6], [7, 8, 9];
+            [10,  11,  12], [13, 14, 15], [16, 17, 18];
+            [1,  2,  3], [ 4,  5,  6], [7, 8, 9]);
+
+        let template = rgb_image!(
+            [1, 2, 3];
+            [11, 12, 13]
+        );
+
+        let actual = match_template(&image, &template, MatchTemplateMethod::CrossCorrelation);
+        let expected = gray_image!(type: f32,
+            412.0, 538.0, 664.0;
+            142.0, 268.0, 394.0
+        );
+
+        assert_pixels_eq!(actual, expected);
+    }
+
+    #[test]
     fn match_template_cross_correlation_normalized() {
         let image = gray_image!(
             1, 4, 2;
@@ -390,6 +411,27 @@ mod tests {
         let expected = gray_image!(type: f32,
             19.0 / (22.0 * tss).sqrt(), 23.0 / (30.0 * tss).sqrt();
             25.0 / (23.0 * tss).sqrt(), 32.0 / (35.0 * tss).sqrt()
+        );
+
+        assert_pixels_eq!(actual, expected);
+    }
+
+    #[test]
+    fn match_template_rgb_cross_correlation_normalised() {
+        let image = rgb_image!(
+            [1,  2,  3], [ 4,  5,  6], [7, 8, 9];
+            [10,  11,  12], [13, 14, 15], [16, 17, 18];
+            [1,  2,  3], [ 4,  5,  6], [7, 8, 9]);
+
+        let template = rgb_image!(
+            [1, 2, 3];
+            [11, 12, 13]
+        );
+
+        let actual = match_template(&image, &template, MatchTemplateMethod::CrossCorrelationNormalized);
+        let expected = gray_image!(type: f32,
+            0.9998586, 0.9841932, 0.96219355;
+            0.34461147, 0.49026725, 0.57094014
         );
 
         assert_pixels_eq!(actual, expected);


### PR DESCRIPTION
I decided to add a pull request to make it easier to see the changes discussed in #312. 

I had to change some API to make this work, of which I don't know whether it would be approved. Specifically the sum_image_pixels in [integral_image](src/integral_image.rs). The issue is that when changing to use GenericImageView, the compiler didn't like accessing the returned array stating it could index into the variable. I changed (at least temporarily) to return a Pixel rather than the array.

While I don't expect this specific change to be accepted, if there are any suggestions as to how best to deal with it it would be appreciated. I also still need to write tests for multi-channel images.