### PR TITLE
Added a contours finding function

### DIFF
--- a/src/contours.rs
+++ b/src/contours.rs
@@ -1,0 +1,187 @@
+//! Functions for detecting contours of polygons in an image and approximating
+//! polygon from set of points.
+
+use crate::definitions::Point;
+use image::GrayImage;
+use num::{cast, Num, NumCast};
+use std::collections::VecDeque;
+
+/// Contour struct containing its points, is_outer flag to determine whether the
+/// contour is an outer border or hole border, and the parent option (the index
+/// of the parent contour in the contours vec)
+#[derive(Debug)]
+pub struct Contour<T: Num + NumCast + Copy + PartialEq + Eq> {
+  /// All the points on the contour
+  pub points: Vec<Point<T>>,
+  /// Flag to determine whether the contour is an outer border or hole border
+  pub is_outer: bool,
+  /// the index of the parent contour in the contours vec, or None if the
+  /// contour is the outermost contour in the image
+  pub parent: Option<usize>,
+}
+impl<T: Num + NumCast + Copy + PartialEq + Eq> Contour<T> {
+  /// Construct a contour.
+  pub fn new(points: Vec<Point<T>>, is_outer: bool, parent: Option<usize>) -> Self {
+    Contour {
+      points,
+      is_outer,
+      parent,
+    }
+  }
+}
+
+/// Finds all the points on the contours on the provided image.
+/// Handles all non-zero pixels as 1.
+pub fn find_contours<T: Num + NumCast + Copy + PartialEq + Eq>(
+  original_image: &GrayImage,
+) -> Vec<Contour<T>> {
+  find_contours_with_thresh(original_image, 0)
+}
+
+/// Finds all contours (contour - all the points on the edge of a polygon)
+/// in the provided image. The algorithm works only with a binarized image,
+/// therefore, the `thresh` param defines the value for which every pixel with
+/// value higher then `thresh` will be considered as 1, and 0 otherwise.
+///
+/// Based on the algorithm proposed by Suzuki and Abe: Topological Structural
+/// Analysis of Digitized Binary Images by Border Following
+///
+pub fn find_contours_with_thresh<T: Num + NumCast + Copy + PartialEq + Eq>(
+  original_image: &GrayImage,
+  thresh: u8,
+) -> Vec<Contour<T>> {
+  let width = original_image.width() as usize;
+  let height = original_image.height() as usize;
+  let mut image_values = vec![vec![0i32; height]; width];
+
+  for y in 0..height {
+    for x in 0..width {
+      if original_image.get_pixel(x as u32, y as u32).0[0] > thresh {
+        image_values[x][y] = 1;
+      }
+    }
+  }
+  let mut neighbour_indices_diffs = VecDeque::from(vec![
+    (-1, 0),  // w
+    (-1, -1), // nw
+    (0, -1),  // n
+    (1, -1),  // ne
+    (1, 0),   // e
+    (1, 1),   // se
+    (0, 1),   // s
+    (-1, 1),  // sw
+  ]);
+  let mut x = 0;
+  let mut y = 0;
+  let last_pixel = (width - 1, height - 1);
+
+  let mut contours: Vec<Contour<T>> = Vec::new();
+  let mut skip_tracing;
+  let mut nbd = 1;
+  let mut lnbd = 1;
+  let mut pos2 = Point::new(0, 0);
+
+  while (x, y) != last_pixel {
+    if image_values[x][y] != 0 {
+      skip_tracing = false;
+      if image_values[x][y] == 1 && x > 0 && image_values[x - 1][y] == 0 {
+        nbd += 1;
+        pos2 = Point::new(x - 1, y);
+      } else if image_values[x][y] > 0 && x + 1 < width && image_values[x + 1][y] == 0 {
+        nbd += 1;
+        pos2 = Point::new(x + 1, y);
+        if image_values[x][y] > 1 {
+          lnbd = image_values[x][y] as usize;
+        }
+      } else {
+        skip_tracing = true;
+      }
+
+      if !skip_tracing {
+        let parent = if lnbd < 2 { None } else { Some(lnbd - 2) };
+        let mut is_outer = true;
+        if let Some(p_idx) = &parent {
+          is_outer = !contours[*p_idx].is_outer;
+        }
+
+        let initial_pos_diff = (pos2.x as i32 - x as i32, pos2.y as i32 - y as i32);
+        let rotate_pos = neighbour_indices_diffs
+          .iter()
+          .position(|&x| x == initial_pos_diff)
+          .unwrap();
+        neighbour_indices_diffs.rotate_left(rotate_pos);
+        if let Some(pos1) = neighbour_indices_diffs.iter().find_map(|(x_diff, y_diff)| {
+          get_position_if_non_zero_pixel(&image_values, x as i32 + *x_diff, y as i32 + *y_diff)
+        }) {
+          pos2 = pos1;
+          let mut pos3 = Point::new(x, y);
+          let mut contour_points = Vec::new();
+          loop {
+            contour_points.push(Point::new(cast(pos3.x).unwrap(), cast(pos3.y).unwrap()));
+            let initial_pos_diff = (pos2.x as i32 - pos3.x as i32, pos2.y as i32 - pos3.y as i32);
+            let rotate_pos = neighbour_indices_diffs
+              .iter()
+              .position(|&x| x == initial_pos_diff)
+              .unwrap();
+            neighbour_indices_diffs.rotate_left(rotate_pos);
+            let pos4 = neighbour_indices_diffs
+              .iter()
+              .rev() // counter-clockwise
+              .find_map(|(x_diff, y_diff)| {
+                get_position_if_non_zero_pixel(
+                  &image_values,
+                  pos3.x as i32 + *x_diff,
+                  pos3.y as i32 + *y_diff,
+                )
+              })
+              .unwrap();
+
+            if pos3.x + 1 < width && image_values[pos3.x + 1][pos3.y] == 0 {
+              image_values[pos3.x][pos3.y] = -nbd;
+            } else if image_values[pos3.x][pos3.y] == 1 {
+              image_values[pos3.x][pos3.y] = nbd;
+            }
+            if pos4.x == x && pos4.y == y && pos3 == pos1 {
+              break;
+            }
+            pos2 = pos3;
+            pos3 = pos4;
+          }
+
+          contours.push(Contour::new(contour_points, is_outer, parent));
+        } else {
+          image_values[x][y] = -nbd;
+        }
+      }
+
+      if image_values[x][y] != 1 {
+        lnbd = image_values[x][y].abs() as usize;
+      }
+    }
+    if x == last_pixel.0 {
+      x = 0;
+      y += 1;
+      lnbd = 1;
+    } else {
+      x += 1;
+    }
+  }
+
+  contours
+}
+
+fn get_position_if_non_zero_pixel(
+  image: &[Vec<i32>],
+  curr_x: i32,
+  curr_y: i32,
+) -> Option<Point<usize>> {
+  if curr_x > -1
+    && curr_x < image.len() as i32
+    && curr_y > -1
+    && curr_y < image[0].len() as i32
+    && image[curr_x as usize][curr_y as usize] != 0
+  {
+    return Some(Point::new(curr_x as usize, curr_y as usize));
+  }
+  None
+}

--- a/src/contours.rs
+++ b/src/contours.rs
@@ -11,31 +11,31 @@ use std::collections::VecDeque;
 /// of the parent contour in the contours vec)
 #[derive(Debug)]
 pub struct Contour<T: Num + NumCast + Copy + PartialEq + Eq> {
-  /// All the points on the contour
-  pub points: Vec<Point<T>>,
-  /// Flag to determine whether the contour is an outer border or hole border
-  pub is_outer: bool,
-  /// the index of the parent contour in the contours vec, or None if the
-  /// contour is the outermost contour in the image
-  pub parent: Option<usize>,
+    /// All the points on the contour
+    pub points: Vec<Point<T>>,
+    /// Flag to determine whether the contour is an outer border or hole border
+    pub is_outer: bool,
+    /// the index of the parent contour in the contours vec, or None if the
+    /// contour is the outermost contour in the image
+    pub parent: Option<usize>,
 }
 impl<T: Num + NumCast + Copy + PartialEq + Eq> Contour<T> {
-  /// Construct a contour.
-  pub fn new(points: Vec<Point<T>>, is_outer: bool, parent: Option<usize>) -> Self {
-    Contour {
-      points,
-      is_outer,
-      parent,
+    /// Construct a contour.
+    pub fn new(points: Vec<Point<T>>, is_outer: bool, parent: Option<usize>) -> Self {
+        Contour {
+            points,
+            is_outer,
+            parent,
+        }
     }
-  }
 }
 
 /// Finds all the points on the contours on the provided image.
 /// Handles all non-zero pixels as 1.
 pub fn find_contours<T: Num + NumCast + Copy + PartialEq + Eq>(
-  original_image: &GrayImage,
+    original_image: &GrayImage,
 ) -> Vec<Contour<T>> {
-  find_contours_with_thresh(original_image, 0)
+    find_contours_with_thresh(original_image, 0)
 }
 
 /// Finds all contours (contour - all the points on the edge of a polygon)
@@ -47,142 +47,147 @@ pub fn find_contours<T: Num + NumCast + Copy + PartialEq + Eq>(
 /// Analysis of Digitized Binary Images by Border Following
 ///
 pub fn find_contours_with_thresh<T: Num + NumCast + Copy + PartialEq + Eq>(
-  original_image: &GrayImage,
-  thresh: u8,
+    original_image: &GrayImage,
+    thresh: u8,
 ) -> Vec<Contour<T>> {
-  let width = original_image.width() as usize;
-  let height = original_image.height() as usize;
-  let mut image_values = vec![vec![0i32; height]; width];
+    let width = original_image.width() as usize;
+    let height = original_image.height() as usize;
+    let mut image_values = vec![vec![0i32; height]; width];
 
-  for y in 0..height {
-    for x in 0..width {
-      if original_image.get_pixel(x as u32, y as u32).0[0] > thresh {
-        image_values[x][y] = 1;
-      }
+    for y in 0..height {
+        for x in 0..width {
+            if original_image.get_pixel(x as u32, y as u32).0[0] > thresh {
+                image_values[x][y] = 1;
+            }
+        }
     }
-  }
-  let mut diffs = VecDeque::from(vec![
-    (-1, 0),  // w
-    (-1, -1), // nw
-    (0, -1),  // n
-    (1, -1),  // ne
-    (1, 0),   // e
-    (1, 1),   // se
-    (0, 1),   // s
-    (-1, 1),  // sw
-  ]);
-  let mut x = 0;
-  let mut y = 0;
-  let last_pixel = (width - 1, height - 1);
+    let mut diffs = VecDeque::from(vec![
+        (-1, 0),  // w
+        (-1, -1), // nw
+        (0, -1),  // n
+        (1, -1),  // ne
+        (1, 0),   // e
+        (1, 1),   // se
+        (0, 1),   // s
+        (-1, 1),  // sw
+    ]);
+    let mut x = 0;
+    let mut y = 0;
+    let last_pixel = (width - 1, height - 1);
 
-  let mut contours: Vec<Contour<T>> = Vec::new();
-  let mut skip_tracing;
-  let mut nbd = 1;
-  let mut lnbd = 1;
-  let mut pos2 = Point::new(0, 0);
+    let mut contours: Vec<Contour<T>> = Vec::new();
+    let mut skip_tracing;
+    let mut nbd = 1;
+    let mut lnbd = 1;
+    let mut pos2 = Point::new(0, 0);
 
-  while (x, y) != last_pixel {
-    if image_values[x][y] != 0 {
-      skip_tracing = false;
-      if image_values[x][y] == 1 && x > 0 && image_values[x - 1][y] == 0 {
-        nbd += 1;
-        pos2 = Point::new(x - 1, y);
-      } else if image_values[x][y] > 0 && x + 1 < width && image_values[x + 1][y] == 0 {
-        nbd += 1;
-        pos2 = Point::new(x + 1, y);
-        if image_values[x][y] > 1 {
-          lnbd = image_values[x][y] as usize;
-        }
-      } else {
-        skip_tracing = true;
-      }
-
-      if !skip_tracing {
-        let parent = if lnbd < 2 { None } else { Some(lnbd - 2) };
-        let mut is_outer = true;
-        if let Some(p_idx) = &parent {
-          is_outer = !contours[*p_idx].is_outer;
-        }
-
-        rotate_to_value(
-          &mut diffs,
-          (pos2.x as i32 - x as i32, pos2.y as i32 - y as i32),
-        );
-        if let Some(pos1) = diffs.iter().find_map(|(x_diff, y_diff)| {
-          get_position_if_non_zero_pixel(&image_values, x as i32 + *x_diff, y as i32 + *y_diff)
-        }) {
-          pos2 = pos1;
-          let mut pos3 = Point::new(x, y);
-          let mut contour_points = Vec::new();
-          loop {
-            contour_points.push(Point::new(cast(pos3.x).unwrap(), cast(pos3.y).unwrap()));
-            rotate_to_value(
-              &mut diffs,
-              (pos2.x as i32 - pos3.x as i32, pos2.y as i32 - pos3.y as i32),
-            );
-            let pos4 = diffs
-              .iter()
-              .rev() // counter-clockwise
-              .find_map(|(x_diff, y_diff)| {
-                get_position_if_non_zero_pixel(
-                  &image_values,
-                  pos3.x as i32 + *x_diff,
-                  pos3.y as i32 + *y_diff,
-                )
-              })
-              .unwrap();
-
-            if pos3.x + 1 < width && image_values[pos3.x + 1][pos3.y] == 0 {
-              image_values[pos3.x][pos3.y] = -nbd;
-            } else if image_values[pos3.x][pos3.y] == 1 {
-              image_values[pos3.x][pos3.y] = nbd;
+    while (x, y) != last_pixel {
+        if image_values[x][y] != 0 {
+            skip_tracing = false;
+            if image_values[x][y] == 1 && x > 0 && image_values[x - 1][y] == 0 {
+                nbd += 1;
+                pos2 = Point::new(x - 1, y);
+            } else if image_values[x][y] > 0 && x + 1 < width && image_values[x + 1][y] == 0 {
+                nbd += 1;
+                pos2 = Point::new(x + 1, y);
+                if image_values[x][y] > 1 {
+                    lnbd = image_values[x][y] as usize;
+                }
+            } else {
+                skip_tracing = true;
             }
-            if pos4.x == x && pos4.y == y && pos3 == pos1 {
-              break;
-            }
-            pos2 = pos3;
-            pos3 = pos4;
-          }
 
-          contours.push(Contour::new(contour_points, is_outer, parent));
+            if !skip_tracing {
+                let parent = if lnbd < 2 { None } else { Some(lnbd - 2) };
+                let mut is_outer = true;
+                if let Some(p_idx) = &parent {
+                    is_outer = !contours[*p_idx].is_outer;
+                }
+
+                rotate_to_value(
+                    &mut diffs,
+                    (pos2.x as i32 - x as i32, pos2.y as i32 - y as i32),
+                );
+                if let Some(pos1) = diffs.iter().find_map(|(x_diff, y_diff)| {
+                    get_position_if_non_zero_pixel(
+                        &image_values,
+                        x as i32 + *x_diff,
+                        y as i32 + *y_diff,
+                    )
+                }) {
+                    pos2 = pos1;
+                    let mut pos3 = Point::new(x, y);
+                    let mut contour_points = Vec::new();
+                    loop {
+                        contour_points
+                            .push(Point::new(cast(pos3.x).unwrap(), cast(pos3.y).unwrap()));
+                        rotate_to_value(
+                            &mut diffs,
+                            (pos2.x as i32 - pos3.x as i32, pos2.y as i32 - pos3.y as i32),
+                        );
+                        let pos4 = diffs
+                            .iter()
+                            .rev() // counter-clockwise
+                            .find_map(|(x_diff, y_diff)| {
+                                get_position_if_non_zero_pixel(
+                                    &image_values,
+                                    pos3.x as i32 + *x_diff,
+                                    pos3.y as i32 + *y_diff,
+                                )
+                            })
+                            .unwrap();
+
+                        if pos3.x + 1 < width && image_values[pos3.x + 1][pos3.y] == 0 {
+                            image_values[pos3.x][pos3.y] = -nbd;
+                        } else if image_values[pos3.x][pos3.y] == 1 {
+                            image_values[pos3.x][pos3.y] = nbd;
+                        }
+                        if pos4.x == x && pos4.y == y && pos3 == pos1 {
+                            break;
+                        }
+                        pos2 = pos3;
+                        pos3 = pos4;
+                    }
+
+                    contours.push(Contour::new(contour_points, is_outer, parent));
+                } else {
+                    image_values[x][y] = -nbd;
+                }
+            }
+
+            if image_values[x][y] != 1 {
+                lnbd = image_values[x][y].abs() as usize;
+            }
+        }
+        if x == last_pixel.0 {
+            x = 0;
+            y += 1;
+            lnbd = 1;
         } else {
-          image_values[x][y] = -nbd;
+            x += 1;
         }
-      }
-
-      if image_values[x][y] != 1 {
-        lnbd = image_values[x][y].abs() as usize;
-      }
     }
-    if x == last_pixel.0 {
-      x = 0;
-      y += 1;
-      lnbd = 1;
-    } else {
-      x += 1;
-    }
-  }
 
-  contours
+    contours
 }
 
 fn rotate_to_value(values: &mut VecDeque<(i32, i32)>, value: (i32, i32)) {
-  let rotate_pos = values.iter().position(|&x| x == value).unwrap();
-  values.rotate_left(rotate_pos);
+    let rotate_pos = values.iter().position(|&x| x == value).unwrap();
+    values.rotate_left(rotate_pos);
 }
 
 fn get_position_if_non_zero_pixel(
-  image: &[Vec<i32>],
-  curr_x: i32,
-  curr_y: i32,
+    image: &[Vec<i32>],
+    curr_x: i32,
+    curr_y: i32,
 ) -> Option<Point<usize>> {
-  if curr_x > -1
-    && curr_x < image.len() as i32
-    && curr_y > -1
-    && curr_y < image[0].len() as i32
-    && image[curr_x as usize][curr_y as usize] != 0
-  {
-    return Some(Point::new(curr_x as usize, curr_y as usize));
-  }
-  None
+    if curr_x > -1
+        && curr_x < image.len() as i32
+        && curr_y > -1
+        && curr_y < image[0].len() as i32
+        && image[curr_x as usize][curr_y as usize] != 0
+    {
+        return Some(Point::new(curr_x as usize, curr_y as usize));
+    }
+    None
 }

--- a/src/definitions.rs
+++ b/src/definitions.rs
@@ -12,6 +12,22 @@ use std::{i16, u16, u8};
 /// with contiguous storage.
 pub type Image<P> = ImageBuffer<P, Vec<<P as Pixel>::Subpixel>>;
 
+/// A 2D point.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct Point<T: Copy + PartialEq + Eq> {
+    /// x-coordinate.
+    pub x: T,
+    /// y-coordinate.
+    pub y: T,
+}
+
+impl<T: Copy + PartialEq + Eq> Point<T> {
+    /// Construct a point at (x, y).
+    pub fn new(x: T, y: T) -> Point<T> {
+        Point::<T> { x, y }
+    }
+}
+
 /// Pixels which have a named Black value.
 pub trait HasBlack {
     /// Returns a black pixel of this type.

--- a/src/drawing/mod.rs
+++ b/src/drawing/mod.rs
@@ -22,7 +22,7 @@ pub use self::line::{
 };
 
 mod polygon;
-pub use self::polygon::{draw_polygon, draw_polygon_mut, Point};
+pub use self::polygon::{draw_polygon, draw_polygon_mut};
 
 mod rect;
 pub use self::rect::{

--- a/src/drawing/polygon.rs
+++ b/src/drawing/polygon.rs
@@ -6,7 +6,7 @@ use std::cmp::{max, min};
 use std::f32;
 use std::i32;
 
-/// Draws as much of a filled convex polygon as lies within image bounds. The provided
+/// Draws as much of a filled polygon as lies within image bounds. The provided
 /// list of points should be an open path, i.e. the first and last points must not be equal.
 /// An implicit edge is added from the last to the first point in the slice.
 pub fn draw_polygon<I>(image: &I, poly: &[Point<i32>], color: I::Pixel) -> Image<I::Pixel>

--- a/src/drawing/polygon.rs
+++ b/src/drawing/polygon.rs
@@ -1,4 +1,4 @@
-use crate::definitions::Image;
+use crate::definitions::{Image, Point};
 use crate::drawing::line::draw_line_segment_mut;
 use crate::drawing::Canvas;
 use image::{GenericImage, ImageBuffer};
@@ -6,21 +6,7 @@ use std::cmp::{max, min};
 use std::f32;
 use std::i32;
 
-/// A 2D point.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub struct Point<T: Copy + PartialEq + Eq> {
-    x: T,
-    y: T,
-}
-
-impl<T: Copy + PartialEq + Eq> Point<T> {
-    /// Construct a point at (x, y).
-    pub fn new(x: T, y: T) -> Point<T> {
-        Point::<T> { x, y }
-    }
-}
-
-/// Draws as much of a filled polygon as lies within image bounds. The provided
+/// Draws as much of a filled convex polygon as lies within image bounds. The provided
 /// list of points should be an open path, i.e. the first and last points must not be equal.
 /// An implicit edge is added from the last to the first point in the slice.
 pub fn draw_polygon<I>(image: &I, poly: &[Point<i32>], color: I::Pixel) -> Image<I::Pixel>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ extern crate assert_approx_eq;
 
 #[macro_use]
 pub mod utils;
+pub mod contours;
 pub mod contrast;
 pub mod corners;
 pub mod definitions;

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -10,7 +10,7 @@
 extern crate imageproc;
 
 use image::{DynamicImage, GrayImage, ImageBuffer, Luma, Pixel, Rgb, RgbImage, Rgba, RgbaImage};
-use imageproc::definitions::{Clamp, HasBlack, HasWhite, Point};
+use imageproc::definitions::{Clamp, HasBlack, HasWhite};
 use imageproc::edges::canny;
 use imageproc::filter::{gaussian_blur_f32, sharpen3x3};
 use imageproc::geometric_transformations::{rotate_about_center, warp, Interpolation, Projection};
@@ -681,108 +681,4 @@ fn test_hough_line_detection() {
         let truth = load_truth_image("hough_lines.png").to_rgb();
         assert_pixels_eq!(lines_image, truth);
     }
-}
-
-#[test]
-fn test_contours_structured() {
-    use imageproc::contours::find_contours;
-    use imageproc::drawing::draw_polygon_mut;
-
-    let white = Luma([255u8]);
-    let black = Luma([0u8]);
-
-    let mut image = GrayImage::from_pixel(300, 300, black);
-    // border 1 (outer)
-    draw_polygon_mut(
-        &mut image,
-        &[
-            Point::new(20, 20),
-            Point::new(280, 20),
-            Point::new(280, 280),
-            Point::new(20, 280),
-        ],
-        white,
-    );
-    // border 2 (hole)
-    draw_polygon_mut(
-        &mut image,
-        &[
-            Point::new(40, 40),
-            Point::new(260, 40),
-            Point::new(260, 260),
-            Point::new(40, 260),
-        ],
-        black,
-    );
-    // border 3 (outer)
-    draw_polygon_mut(
-        &mut image,
-        &[
-            Point::new(60, 60),
-            Point::new(240, 60),
-            Point::new(240, 240),
-            Point::new(60, 240),
-        ],
-        white,
-    );
-    // border 4 (hole)
-    draw_polygon_mut(
-        &mut image,
-        &[
-            Point::new(80, 80),
-            Point::new(220, 80),
-            Point::new(220, 220),
-            Point::new(80, 220),
-        ],
-        black,
-    );
-    // rectangle in the corner (outer)
-    draw_polygon_mut(
-        &mut image,
-        &[
-            Point::new(290, 290),
-            Point::new(300, 290),
-            Point::new(300, 300),
-            Point::new(290, 300),
-        ],
-        white,
-    );
-    let contours = find_contours::<i32>(&image);
-
-    assert_eq!(contours.len(), 5);
-    // border 1
-    assert!(contours[0].points.contains(&Point::new(20, 20)));
-    assert!(contours[0].points.contains(&Point::new(280, 20)));
-    assert!(contours[0].points.contains(&Point::new(280, 280)));
-    assert!(contours[0].points.contains(&Point::new(20, 280)));
-    assert!(contours[0].is_outer, true);
-    assert_eq!(contours[0].parent, None);
-    // border 2
-    assert!(contours[1].points.contains(&Point::new(39, 40)));
-    assert!(contours[1].points.contains(&Point::new(261, 40)));
-    assert!(contours[1].points.contains(&Point::new(261, 260)));
-    assert!(contours[1].points.contains(&Point::new(39, 260)));
-    assert_eq!(contours[1].is_outer, false);
-    assert_eq!(contours[1].parent, Some(0));
-    // border 3
-    assert!(contours[2].points.contains(&Point::new(60, 60)));
-    assert!(contours[2].points.contains(&Point::new(240, 60)));
-    assert!(contours[2].points.contains(&Point::new(240, 240)));
-    assert!(contours[2].points.contains(&Point::new(60, 240)));
-    assert_eq!(contours[2].is_outer, true);
-    assert_eq!(contours[2].parent, Some(1));
-    // border 4
-    assert!(contours[3].points.contains(&Point::new(79, 80)));
-    assert!(contours[3].points.contains(&Point::new(221, 80)));
-    assert!(contours[3].points.contains(&Point::new(221, 220)));
-    assert!(contours[3].points.contains(&Point::new(79, 220)));
-    assert_eq!(contours[3].is_outer, false);
-    assert_eq!(contours[3].parent, Some(2));
-    // rectangle in the corner
-    assert!(contours[4].points.contains(&Point::new(290, 290)));
-    assert!(contours[4].points.contains(&Point::new(299, 290)));
-    assert!(contours[4].points.contains(&Point::new(299, 299)));
-    assert!(contours[4].points.contains(&Point::new(290, 299)));
-    assert_eq!(contours[4].is_outer, true);
-    assert_eq!(contours[4].parent, None);
 }


### PR DESCRIPTION
Implementing a contours tracing algorithm (https://www.semanticscholar.org/paper/Topological-structural-analysis-of-digitized-binary-Suzuki-Abe/cf021db5e811fd5b67ee3aa4db0a6a0351d276d2)

Within the `find_contours_with_thresh` fn, I'm handling the coordinates as `usize` (since its values are in range [0..width) and [0..height), and it is easier to use for indexing the image_values matrix), with occasional conversions to `i32` for an easier neighbour position calculation and out of bounds check, but at the end, since the function is written with generics (with a limitation on the numeric types using the `num` crate), when storing the contour points the coordinates are converted to that generic type.

Also, I've moved the `Point<T>` struct from `src/drawing/polygon.rs` to `src/definitions.rs`, since it is a base struct that can be reused on other places as well (like https://github.com/image-rs/imageproc/blob/master/src/drawing/line.rs#L188, or https://github.com/image-rs/imageproc/blob/master/src/drawing/bezier.rs#L28)

Issue: https://github.com/image-rs/imageproc/issues/317