### PR TITLE
better use of methods provided by std

### DIFF
--- a/src/geometric_transformations.rs
+++ b/src/geometric_transformations.rs
@@ -76,8 +76,7 @@ impl Projection {
     /// A clockwise rotation around the top-left corner of the image by theta radians.
     #[rustfmt::skip]
     pub fn rotate(theta: f32) -> Projection {
-        let s = theta.sin();
-        let c = theta.cos();
+        let (s, c) = theta.sin_cos();
         Projection {
             transform: [
                   c,  -s, 0.0,

--- a/src/hough.rs
+++ b/src/hough.rs
@@ -49,7 +49,7 @@ pub fn detect_lines(image: &GrayImage, options: LineDetectionOptions) -> Vec<Pol
 
     // Precalculate values of (cos(m), sin(m))
     let lut: Vec<(f32, f32)> = (0..180u32)
-        .map(f32::to_radians)
+        .map(|deg| (deg as f32).to_radians())
         .map(f32::sin_cos)
         .collect();
 

--- a/src/hough.rs
+++ b/src/hough.rs
@@ -49,8 +49,8 @@ pub fn detect_lines(image: &GrayImage, options: LineDetectionOptions) -> Vec<Pol
 
     // Precalculate values of (cos(m), sin(m))
     let lut: Vec<(f32, f32)> = (0..180u32)
-        .map(degrees_to_radians)
-        .map(|t| (t.cos(), t.sin()))
+        .map(f32::to_radians)
+        .map(f32::sin_cos)
         .collect();
 
     for y in 0..height {
@@ -58,7 +58,7 @@ pub fn detect_lines(image: &GrayImage, options: LineDetectionOptions) -> Vec<Pol
             let p = unsafe { image.unsafe_get_pixel(x, y)[0] };
 
             if p > 0 {
-                for (m, (c, s)) in lut.iter().enumerate() {
+                for (m, (s, c)) in lut.iter().enumerate() {
                     let r = (x as f32) * c + (y as f32) * s;
                     let d = r as i32 + rmax;
 
@@ -159,8 +159,7 @@ fn intersection_points(
     }
 
     let theta = degrees_to_radians(m);
-    let sin = theta.sin();
-    let cos = theta.cos();
+    let (sin, cos) = theta.sin_cos();
 
     let right_y = cos.mul_add(-w, r) / sin;
     let left_y = r / sin;
@@ -201,10 +200,6 @@ fn intersection_points(
     }
 
     None
-}
-
-fn degrees_to_radians(degrees: u32) -> f32 {
-    degrees as f32 * f32::consts::PI / 180.0
 }
 
 #[cfg(test)]

--- a/src/hough.rs
+++ b/src/hough.rs
@@ -158,7 +158,7 @@ fn intersection_points(
         };
     }
 
-    let theta = degrees_to_radians(m);
+    let theta = (m as f32).to_radians();
     let (sin, cos) = theta.sin_cos();
 
     let right_y = cos.mul_add(-w, r) / sin;


### PR DESCRIPTION
## Summary

- change `let (s, c) = (deg.sin(), deg.cos)` to `let (s, c) = deg.sin_cos()`
- use the `f32::to_radians()` provided by std instead of reinventing the wheel