### PR TITLE
fix-doc-typo

### DIFF
--- a/src/contrast.rs
+++ b/src/contrast.rs
@@ -11,7 +11,7 @@ use std::cmp::{max, min};
 /// Applies an adaptive threshold to an image.
 ///
 /// This algorithm compares each pixel's brightness with the average brightness of the pixels
-/// in the (2 * `block_radius` + 1) square block centered on it. If the pixel if at least as bright
+/// in the (2 * `block_radius` + 1) square block centered on it. If the pixel is at least as bright
 /// as the threshold then it will have a value of 255 in the output image, otherwise 0.
 pub fn adaptive_threshold(image: &GrayImage, block_radius: u32) -> GrayImage {
     assert!(block_radius > 0);


### PR DESCRIPTION
Fix a document typo in `contrast.rs`.