### PR TITLE
Map iter

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -149,7 +149,6 @@ where
     // UNSAFE JUSTIFICATION:
     // - no need to check bounds
     // - `out` is created from the dimensions of `image`
-    // iter_pixels!(image).for_each(|(x, y, pixel)| unsafe { out.unsafe_put_pixel(x, y, f(pixel)) });
     image
         .pixels()
         .for_each(|(x, y, pixel)| unsafe { out.unsafe_put_pixel(x, y, f(pixel)) });
@@ -184,9 +183,8 @@ where
 pub fn map_colors<I, P, Q, F>(image: &I, f: F) -> Image<Q>
 where
     I: GenericImage<Pixel = P> + Send + Sync,
-    P: Pixel + Send + Sync,
-    Q: Pixel + 'static + Send + Sync,
-    <Q as Pixel>::Subpixel: Send + Sync,
+    P: Pixel + Send,
+    Q: Pixel + 'static + Send,
     F: Fn(P) -> Q + Send + Sync,
 {
     let (width, height) = image.dimensions();
@@ -337,7 +335,7 @@ where
 pub fn red_channel<I, C>(image: &I) -> Image<Luma<C>>
 where
     I: GenericImage<Pixel = Rgb<C>> + Send + Sync,
-    C: Primitive + 'static + Send + Sync,
+    C: Primitive + 'static + Send,
 {
     map_colors(image, |p| Luma([p[0]]))
 }
@@ -368,7 +366,7 @@ where
 pub fn as_red_channel<I, C>(image: &I) -> Image<Rgb<C>>
 where
     I: GenericImage<Pixel = Luma<C>> + Send + Sync,
-    C: Primitive + 'static + Send + Sync,
+    C: Primitive + 'static + Send,
 {
     map_colors(image, |p| {
         let mut cs = [C::zero(); 3];
@@ -403,7 +401,7 @@ where
 pub fn green_channel<I, C>(image: &I) -> Image<Luma<C>>
 where
     I: GenericImage<Pixel = Rgb<C>> + Send + Sync,
-    C: Primitive + 'static + Send + Sync,
+    C: Primitive + 'static + Send,
 {
     map_colors(image, |p| Luma([p[1]]))
 }
@@ -434,7 +432,7 @@ where
 pub fn as_green_channel<I, C>(image: &I) -> Image<Rgb<C>>
 where
     I: GenericImage<Pixel = Luma<C>> + Send + Sync,
-    C: Primitive + 'static + Send + Sync,
+    C: Primitive + 'static + Send,
 {
     map_colors(image, |p| {
         let mut cs = [C::zero(); 3];
@@ -469,7 +467,7 @@ where
 pub fn blue_channel<I, C>(image: &I) -> Image<Luma<C>>
 where
     I: GenericImage<Pixel = Rgb<C>> + Send + Sync,
-    C: Primitive + 'static + Send + Sync,
+    C: Primitive + 'static + Send,
 {
     map_colors(image, |p| Luma([p[2]]))
 }
@@ -500,7 +498,7 @@ where
 pub fn as_blue_channel<I, C>(image: &I) -> Image<Rgb<C>>
 where
     I: GenericImage<Pixel = Luma<C>> + Send + Sync,
-    C: Primitive + 'static + Send + Sync,
+    C: Primitive + 'static + Send,
 {
     map_colors(image, |p| {
         let mut cs = [C::zero(); 3];


### PR DESCRIPTION
Closes #429 
Related to #98 
### Description
Functions under `src/map.rs` are subject to parallelization. Thus, we can use [rayon](https://github.com/rayon-rs/rayon) to distribute them across threads.

### Implementation
- Refactored everything in `src/map.rs` from a loop to use Iterators from [Pixels](https://docs.rs/image/0.23.11/image/struct.Pixels.html). This provides a suitable structure to parallelize it.
- Under the `rayon` feature, compile a version of `map_colors()` that uses `par_bridge`.

### TODO
Before continuing with the rest of the functions, I'd like to know if this is a good direction:
- [ ] Is there a better way to flush the pixels into the ImageBuffer? Currently, the pixels are parallelized and transformed into a `Vec`, to then gather them (single thread) into a ImageBuffer with `unsafe_put_pixel`. Alternatively, a channel could be considered like in the [rust cookbook](https://rust-lang-nursery.github.io/rust-cookbook/concurrency/threads.html#draw-fractal-dispatching-work-to-a-thread-pool).
- [ ] _Implemented [in this other branch](https://github.com/carrascomj/imageproc/blob/pixeliter/src/map.rs)_: should an additional custom struct that implements iterator over `GenericImage` be introduced instead? That would allow for using `unsafe_get_pixel` (like it is on master), but I am unsure if that would have a strong justification. [The implementation of `Iterator` of `Pixels`](https://docs.rs/image/0.23.11/src/image/image.rs.html#566) is safe and does bound checking.