### PR TITLE
Modified convex_hull fn to handle coordinates with negative values

### DIFF
--- a/src/contours.rs
+++ b/src/contours.rs
@@ -437,6 +437,9 @@ fn rotating_calipers<T: Num + NumCast + Copy + PartialEq + Eq>(
 fn convex_hull<T: Num + NumCast + Copy + PartialEq + Eq + Ord + Bounded>(
     points_slice: &[Point<T>],
 ) -> Vec<Point<T>> {
+    if points_slice.is_empty() {
+        return Vec::new();
+    }
     let mut points: Vec<Point<T>> = points_slice.to_vec();
     let (start_point_pos, start_point) = points.iter().enumerate().fold(
         (usize::MAX, Point::new(T::max_value(), T::max_value())),
@@ -777,6 +780,12 @@ mod tests {
                 Point::new(60, 25)
             ]
         );
+    }
+
+    #[test]
+    fn get_convex_hull_points_empty_vec() {
+        let points = convex_hull::<i32>(&vec![]);
+        assert_eq!(points, []);
     }
 
     #[test]

--- a/src/contours.rs
+++ b/src/contours.rs
@@ -3,7 +3,7 @@
 
 use crate::definitions::Point;
 use image::GrayImage;
-use num::{cast, traits::bounds::Bounded, Num, NumCast};
+use num::{cast, Num, NumCast};
 use std::cmp::{Ord, Ordering};
 use std::collections::VecDeque;
 use std::f64::consts::PI;
@@ -311,7 +311,7 @@ fn perpendicular_distance<T: Num + NumCast + Copy + PartialEq + Eq>(
 /// Finds the minimal area rectangle that covers all of the points in the input
 /// contour in the following order -> (TL, TR, BR, BL).
 ///
-pub fn min_area_rect<T: Num + NumCast + Copy + PartialEq + Eq + Ord + Bounded>(
+pub fn min_area_rect<T: Num + NumCast + Copy + PartialEq + Eq + Ord>(
     contour: &[Point<T>],
 ) -> Vec<Point<T>> {
     let hull = convex_hull(&contour);
@@ -434,22 +434,21 @@ fn rotating_calipers<T: Num + NumCast + Copy + PartialEq + Eq>(
 /// Based on the [Graham scan algorithm].
 ///
 /// [Graham scan algorithm]: https://en.wikipedia.org/wiki/Graham_scan
-fn convex_hull<T: Num + NumCast + Copy + PartialEq + Eq + Ord + Bounded>(
+fn convex_hull<T: Num + NumCast + Copy + PartialEq + Eq + Ord>(
     points_slice: &[Point<T>],
 ) -> Vec<Point<T>> {
     if points_slice.is_empty() {
         return Vec::new();
     }
     let mut points: Vec<Point<T>> = points_slice.to_vec();
-    let (start_point_pos, start_point) = points.iter().enumerate().fold(
-        (usize::MAX, Point::new(T::max_value(), T::max_value())),
-        |(pos, acc_point), (i, &point)| {
-            if point.y < acc_point.y || point.y == acc_point.y && point.x < acc_point.x {
-                return (i, point);
-            }
-            (pos, acc_point)
-        },
-    );
+    let mut start_point_pos = 0;
+    let mut start_point = points[0];
+    for (i, &point) in points.iter().enumerate().skip(1) {
+        if point.y < start_point.y || point.y == start_point.y && point.x < start_point.x {
+            start_point_pos = i;
+            start_point = point;
+        }
+    }
     points.swap(0, start_point_pos);
     points.remove(0);
     points.sort_by(|a, b| {

--- a/src/contours.rs
+++ b/src/contours.rs
@@ -437,15 +437,12 @@ fn rotating_calipers<T: Num + NumCast + Copy + PartialEq + Eq>(
 fn convex_hull<T: Num + NumCast + Copy + PartialEq + Eq>(
     points_slice: &[Point<T>],
 ) -> Vec<Point<T>> {
-    let mut points: Vec<Point<usize>> = points_slice
+    let mut points: Vec<Point<i32>> = points_slice
         .iter()
-        .map(|p| Point::new(p.x.to_usize().unwrap(), p.y.to_usize().unwrap()))
+        .map(|p| Point::new(p.x.to_i32().unwrap(), p.y.to_i32().unwrap()))
         .collect();
     let (start_point_pos, start_point) = points.iter().enumerate().fold(
-        (
-            std::usize::MAX,
-            Point::new(std::usize::MAX, std::usize::MAX),
-        ),
+        (usize::MAX, Point::new(i32::MAX, i32::MAX)),
         |(pos, acc_point), (i, &point)| {
             if point.y < acc_point.y || point.y == acc_point.y && point.x < acc_point.x {
                 return (i, point);
@@ -782,6 +779,33 @@ mod tests {
                 Point::new(130, 60),
                 Point::new(80, 55),
                 Point::new(60, 25)
+            ]
+        );
+    }
+
+    #[test]
+    fn get_convex_hull_points_with_negative_values() {
+        let star = vec![
+            Point::new(100, -20),
+            Point::new(90, 5),
+            Point::new(60, -15),
+            Point::new(90, 0),
+            Point::new(80, 15),
+            Point::new(101, 10),
+            Point::new(130, 20),
+            Point::new(115, 5),
+            Point::new(140, -10),
+            Point::new(120, -5),
+        ];
+        let points = convex_hull(&star);
+        assert_eq!(
+            points,
+            [
+                Point::new(100, -20),
+                Point::new(140, -10),
+                Point::new(130, 20),
+                Point::new(80, 15),
+                Point::new(60, -15)
             ]
         );
     }


### PR DESCRIPTION
The `convex_hull` fn param -> `points_slice: &[Point<T>]` is a set of points, there is no specific limit (like `x = {0,width}` and `y = {0,height}` when the param is an image).
Since in the original implementation I was converting it to `usize` it was failing when the generic type T included negative values.
Actually, that conversion can be avoided by including `Ord` ~~and `Bounded`~~ trait~~s~~ to the generic type definition.