### PR TITLE
Add function to get rendered size of text

### DIFF
--- a/examples/font.rs
+++ b/examples/font.rs
@@ -1,7 +1,7 @@
 //! An example of drawing text. Writes to the user-provided target file.
 
 use image::{Rgb, RgbImage};
-use imageproc::drawing::draw_text_mut;
+use imageproc::drawing::{draw_text_mut, text_size};
 use rusttype::{Font, Scale};
 use std::env;
 use std::path::Path;
@@ -25,15 +25,11 @@ fn main() {
         x: height * 2.0,
         y: height,
     };
-    draw_text_mut(
-        &mut image,
-        Rgb([0u8, 0u8, 255u8]),
-        0,
-        0,
-        scale,
-        &font,
-        "Hello, world!",
-    );
+
+    let text = "Hello, world!";
+    draw_text_mut(&mut image, Rgb([0u8, 0u8, 255u8]), 0, 0, scale, &font, text);
+    let (w, h) = text_size(scale, &font, text);
+    println!("Text size: {}x{}", w, h);
 
     let _ = image.save(path).unwrap();
 }

--- a/src/drawing/mod.rs
+++ b/src/drawing/mod.rs
@@ -30,7 +30,7 @@ pub use self::rect::{
 };
 
 mod text;
-pub use self::text::{draw_text, draw_text_mut};
+pub use self::text::{draw_text, draw_text_mut, text_size};
 
 // Set pixel at (x, y) to color if this point lies within image bounds,
 // otherwise do nothing.

--- a/src/drawing/text.rs
+++ b/src/drawing/text.rs
@@ -6,9 +6,36 @@ use std::f32;
 use std::i32;
 
 use crate::pixelops::weighted_sum;
-use rusttype::{point, Font, PositionedGlyph, Scale};
+use rusttype::{point, Font, PositionedGlyph, Rect, Scale};
+use std::cmp::max;
 
-/// Draws colored text on an image in place. `scale` is augmented font scaling on both the x and y axis (in pixels). Note that this function *does not* support newlines, you must do this manually
+fn layout_glyphs(
+    scale: Scale,
+    font: &Font,
+    text: &str,
+    mut f: impl FnMut(PositionedGlyph, Rect<i32>),
+) -> (i32, i32) {
+    let v_metrics = font.v_metrics(scale);
+
+    let (mut w, mut h) = (0, 0);
+
+    for g in font.layout(text, scale, point(0.0, v_metrics.ascent)) {
+        if let Some(bb) = g.pixel_bounding_box() {
+            w = max(w, bb.max.x);
+            h = max(h, bb.max.y);
+            f(g, bb);
+        }
+    }
+
+    (w, h)
+}
+
+/// Get the width and height of the given text, rendered with the given font and scale. Note that this function *does not* support newlines, you must do this manually.
+pub fn text_size(scale: Scale, font: &Font, text: &str) -> (i32, i32) {
+    layout_glyphs(scale, font, text, |_, _| {})
+}
+
+/// Draws colored text on an image in place. `scale` is augmented font scaling on both the x and y axis (in pixels). Note that this function *does not* support newlines, you must do this manually.
 pub fn draw_text_mut<'a, C>(
     canvas: &'a mut C,
     color: C::Pixel,
@@ -21,34 +48,27 @@ pub fn draw_text_mut<'a, C>(
     C: Canvas,
     <C::Pixel as Pixel>::Subpixel: ValueInto<f32> + Clamp<f32>,
 {
-    let v_metrics = font.v_metrics(scale);
-    let offset = point(0.0, v_metrics.ascent);
+    let image_width = canvas.width() as i32;
+    let image_height = canvas.height() as i32;
 
-    let glyphs: Vec<PositionedGlyph<'_>> = font.layout(text, scale, offset).collect();
+    layout_glyphs(scale, font, text, |g, bb| {
+        g.draw(|gx, gy, gv| {
+            let gx = gx as i32 + bb.min.x;
+            let gy = gy as i32 + bb.min.y;
 
-    for g in glyphs {
-        if let Some(bb) = g.pixel_bounding_box() {
-            g.draw(|gx, gy, gv| {
-                let gx = gx as i32 + bb.min.x;
-                let gy = gy as i32 + bb.min.y;
+            let image_x = gx + x as i32;
+            let image_y = gy + y as i32;
 
-                let image_x = gx + x as i32;
-                let image_y = gy + y as i32;
-
-                let image_width = canvas.width() as i32;
-                let image_height = canvas.height() as i32;
-
-                if image_x >= 0 && image_x < image_width && image_y >= 0 && image_y < image_height {
-                    let pixel = canvas.get_pixel(image_x as u32, image_y as u32);
-                    let weighted_color = weighted_sum(pixel, color, 1.0 - gv, gv);
-                    canvas.draw_pixel(image_x as u32, image_y as u32, weighted_color);
-                }
-            })
-        }
-    }
+            if (0..image_width).contains(&image_x) && (0..image_height).contains(&image_y) {
+                let pixel = canvas.get_pixel(image_x as u32, image_y as u32);
+                let weighted_color = weighted_sum(pixel, color, 1.0 - gv, gv);
+                canvas.draw_pixel(image_x as u32, image_y as u32, weighted_color);
+            }
+        })
+    });
 }
 
-/// Draws colored text on an image in place. `scale` is augmented font scaling on both the x and y axis (in pixels). Note that this function *does not* support newlines, you must do this manually
+/// Draws colored text on an image in place. `scale` is augmented font scaling on both the x and y axis (in pixels). Note that this function *does not* support newlines, you must do this manually.
 pub fn draw_text<'a, I>(
     image: &'a mut I,
     color: I::Pixel,


### PR DESCRIPTION
This PR adds a simple `text_size` function that returns the width and height of text that would be rendered with a given font and scale. This is useful to avoid having to manually call `rusttype`'s layout functions, and ensure the results match the actual text rendered with `draw_text`/`draw_text_mut`.

The `drawing` module may not be the best place for this function since it doesn't actually draw anything - I'd be happy to move it to another module if appropriate.

It would probably be good to additionally update `draw_text` or `draw_text_mut` to also return rendered text size, but this would be a breaking change as far as I'm aware.