### PR TITLE
add `and_then` method for `Projection`

### DIFF
--- a/src/geometric_transformations.rs
+++ b/src/geometric_transformations.rs
@@ -55,6 +55,12 @@ impl Projection {
         })
     }
 
+    /// Combine the transformation with another one. The resulting transformation is equivalent to
+    /// applying this transformation followed by the `other` transformation.
+    pub fn and_then(self, other: Projection) -> Projection {
+        other * self
+    }
+
     /// A translation by (tx, ty).
     #[rustfmt::skip]
     pub fn translate(tx: f32, ty: f32) -> Projection {


### PR DESCRIPTION
It might be more intuitive for people who are not familiar with linear algebra.
This also benefit from method name hints in IDEs/text editors.