### PR TITLE
Fix assert! macro string literal warning

### DIFF
--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -91,11 +91,9 @@ impl<'a, K: Num + Copy + 'a> Kernel<'a, K> {
         assert!(width > 0 && height > 0, "width and height must be non-zero");
         assert!(
             width * height == data.len() as u32,
-            format!(
-                "Invalid kernel len: expecting {}, found {}",
-                width * height,
-                data.len()
-            )
+            "Invalid kernel len: expecting {}, found {}",
+            width * height,
+            data.len()
         );
         Kernel {
             data,


### PR DESCRIPTION
This PR fixed macro `assert!` usage warning:
```
warning: panic message is not a string literal
  --> src/filter/mod.rs:94:13
   |
94 | /             format!(
95 | |                 "Invalid kernel len: expecting {}, found {}",
96 | |                 width * height,
97 | |                 data.len()
98 | |             )
   | |_____________^
   |
   = note: `#[warn(non_fmt_panic)]` on by default
   = note: this is no longer accepted in Rust 2021
   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

warning: 1 warning emitted
```
The warning has been fixed in this PR by using *string literal* instead.