### PR TITLE
Allowed negative values for the draw_text_mut position x/y

### DIFF
--- a/src/drawing/text.rs
+++ b/src/drawing/text.rs
@@ -39,8 +39,8 @@ pub fn text_size(scale: Scale, font: &Font, text: &str) -> (i32, i32) {
 pub fn draw_text_mut<'a, C>(
     canvas: &'a mut C,
     color: C::Pixel,
-    x: u32,
-    y: u32,
+    x: i32,
+    y: i32,
     scale: Scale,
     font: &'a Font<'a>,
     text: &'a str,
@@ -56,8 +56,8 @@ pub fn draw_text_mut<'a, C>(
             let gx = gx as i32 + bb.min.x;
             let gy = gy as i32 + bb.min.y;
 
-            let image_x = gx + x as i32;
-            let image_y = gy + y as i32;
+            let image_x = gx + x;
+            let image_y = gy + y;
 
             if (0..image_width).contains(&image_x) && (0..image_height).contains(&image_y) {
                 let pixel = canvas.get_pixel(image_x as u32, image_y as u32);
@@ -72,8 +72,8 @@ pub fn draw_text_mut<'a, C>(
 pub fn draw_text<'a, I>(
     image: &'a mut I,
     color: I::Pixel,
-    x: u32,
-    y: u32,
+    x: i32,
+    y: i32,
     scale: Scale,
     font: &'a Font<'a>,
     text: &'a str,


### PR DESCRIPTION
Support negative x/y position for `draw_text_mut`/`draw_text`.

For example:
```diff
diff --git a/examples/font.rs b/examples/font.rs
index b73e35b..3e39fdc 100644
--- a/examples/font.rs
+++ b/examples/font.rs
@@ -27,7 +27,7 @@ fn main() {
     };
 
     let text = "Hello, world!";
-    draw_text_mut(&mut image, Rgb([0u8, 0u8, 255u8]), 0, 0, scale, &font, text);
+    draw_text_mut(&mut image, Rgb([0u8, 0u8, 255u8]), -8, -4, scale, &font, text);
     let (w, h) = text_size(scale, &font, text);
     println!("Text size: {}x{}", w, h);
```

![negative-hello](https://user-images.githubusercontent.com/2971112/113567965-92d34e00-964a-11eb-8dab-8e5557b4418b.png)
