### PR TITLE
Fix assert_pixels_eq! macro string literal warning

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -368,7 +368,7 @@ macro_rules! assert_pixels_eq {
         $crate::assert_dimensions_match!($actual, $expected);
         match $crate::utils::pixel_diff_summary(&$actual, &$expected) {
             None => {}
-            Some(err) => panic!(err),
+            Some(err) => panic!("{}", err),
         };
     }};
 }
@@ -407,9 +407,10 @@ macro_rules! assert_pixels_eq_within {
             large_diff
         });
         if !diffs.is_empty() {
-            panic!($crate::utils::describe_pixel_diffs(
-                &$actual, &$expected, &diffs
-            ))
+            panic!(
+                "{}",
+                $crate::utils::describe_pixel_diffs(&$actual, &$expected, &diffs,)
+            )
         }
     }};
 }


### PR DESCRIPTION
Using the `assert_pixels_eq!` macro currently produces the following warning, using both stable and nightly toolchains.
```
warning: panic message is not a string literal
   --> tests/regression.rs:120:9
    |
120 |         assert_pixels_eq_within!(*actual, truth, tol);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(non_fmt_panics)]` on by default
    = note: this usage of panic!() is deprecated; it will be a hard error in Rust 2021
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
    = note: this warning originates in the macro `assert_pixels_eq_within` (in Nightly builds, run with -Z macro-backtrace for more info)
```

This PR fixes the linter warning and Rust 2021 incompatibility.
See https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html