### PR TITLE
Tidy up the description of functions in the `drawing` module

### DIFF
--- a/src/drawing/bezier.rs
+++ b/src/drawing/bezier.rs
@@ -5,7 +5,9 @@ use image::{GenericImage, ImageBuffer};
 use std::f32;
 use std::i32;
 
-/// Draws as much of a cubic bezier curve as lies within image bounds.
+/// Draws a cubic Bézier curve on a new copy of an image.
+///
+/// Draws as much of the curve as lies within image bounds.
 pub fn draw_cubic_bezier_curve<I>(
     image: &I,
     start: (f32, f32),
@@ -24,7 +26,9 @@ where
     out
 }
 
-/// Draws as much of a cubic bezier curve as lies within image bounds.
+/// Draws a cubic Bézier curve on an image in place.
+///
+/// Draws as much of the curve as lies within image bounds.
 pub fn draw_cubic_bezier_curve_mut<C>(
     canvas: &mut C,
     start: (f32, f32),

--- a/src/drawing/conics.rs
+++ b/src/drawing/conics.rs
@@ -7,7 +7,9 @@ use std::f32;
 use std::i32;
 
 /// Draw as much of an ellipse as lies inside the image bounds.
-/// Uses Midpoint Ellipse Drawing Algorithm. (Modified from Bresenham's algorithm) (http://tutsheap.com/c/mid-point-ellipse-drawing-algorithm/)
+///
+/// Uses the [Midpoint Ellipse Drawing Algorithm](https://web.archive.org/web/20160128020853/http://tutsheap.com/c/mid-point-ellipse-drawing-algorithm/).
+/// (Modified from Bresenham's algorithm)
 ///
 /// The ellipse is axis-aligned and satisfies the following equation:
 ///
@@ -30,7 +32,9 @@ where
 }
 
 /// Draw as much of an ellipse as lies inside the image bounds.
-/// Uses Midpoint Ellipse Drawing Algorithm. (Modified from Bresenham's algorithm) (http://tutsheap.com/c/mid-point-ellipse-drawing-algorithm/)
+///
+/// Uses the [Midpoint Ellipse Drawing Algorithm](https://web.archive.org/web/20160128020853/http://tutsheap.com/c/mid-point-ellipse-drawing-algorithm/).
+/// (Modified from Bresenham's algorithm)
 ///
 /// The ellipse is axis-aligned and satisfies the following equation:
 ///
@@ -62,7 +66,9 @@ pub fn draw_hollow_ellipse_mut<C>(
 }
 
 /// Draw as much of an ellipse, including its contents, as lies inside the image bounds.
-/// Uses Midpoint Ellipse Drawing Algorithm. (Modified from Bresenham's algorithm) (http://tutsheap.com/c/mid-point-ellipse-drawing-algorithm/)
+///
+/// Uses the [Midpoint Ellipse Drawing Algorithm](https://web.archive.org/web/20160128020853/http://tutsheap.com/c/mid-point-ellipse-drawing-algorithm/).
+/// (Modified from Bresenham's algorithm)
 ///
 /// The ellipse is axis-aligned and satisfies the following equation:
 ///
@@ -85,7 +91,9 @@ where
 }
 
 /// Draw as much of an ellipse, including its contents, as lies inside the image bounds.
-/// Uses Midpoint Ellipse Drawing Algorithm. (Modified from Bresenham's algorithm) (http://tutsheap.com/c/mid-point-ellipse-drawing-algorithm/)
+///
+/// Uses the [Midpoint Ellipse Drawing Algorithm](https://web.archive.org/web/20160128020853/http://tutsheap.com/c/mid-point-ellipse-drawing-algorithm/).
+/// (Modified from Bresenham's algorithm)
 ///
 /// The ellipse is axis-aligned and satisfies the following equation:
 ///
@@ -124,7 +132,8 @@ pub fn draw_filled_ellipse_mut<C>(
     draw_ellipse(draw_line_pairs, center, width_radius, height_radius);
 }
 
-// Implements the Midpoint Ellipse Drawing Algorithm. (Modified from Bresenham's algorithm) (http://tutsheap.com/c/mid-point-ellipse-drawing-algorithm/)
+// Implements the Midpoint Ellipse Drawing Algorithm https://web.archive.org/web/20160128020853/http://tutsheap.com/c/mid-point-ellipse-drawing-algorithm/). (Modified from Bresenham's algorithm)
+//
 // Takes a function that determines how to render the points on the ellipse.
 fn draw_ellipse<F>(mut render_func: F, center: (i32, i32), width_radius: i32, height_radius: i32)
 where

--- a/src/drawing/conics.rs
+++ b/src/drawing/conics.rs
@@ -6,7 +6,9 @@ use image::{GenericImage, ImageBuffer};
 use std::f32;
 use std::i32;
 
-/// Draw as much of an ellipse as lies inside the image bounds.
+/// Draws the outline of an ellipse on a new copy of an image.
+///
+/// Draws as much of an ellipse as lies inside the image bounds.
 ///
 /// Uses the [Midpoint Ellipse Drawing Algorithm](https://web.archive.org/web/20160128020853/http://tutsheap.com/c/mid-point-ellipse-drawing-algorithm/).
 /// (Modified from Bresenham's algorithm)
@@ -31,7 +33,9 @@ where
     out
 }
 
-/// Draw as much of an ellipse as lies inside the image bounds.
+/// Draws the outline of an ellipse on an image in place.
+///
+/// Draws as much of an ellipse as lies inside the image bounds.
 ///
 /// Uses the [Midpoint Ellipse Drawing Algorithm](https://web.archive.org/web/20160128020853/http://tutsheap.com/c/mid-point-ellipse-drawing-algorithm/).
 /// (Modified from Bresenham's algorithm)
@@ -65,7 +69,9 @@ pub fn draw_hollow_ellipse_mut<C>(
     draw_ellipse(draw_quad_pixels, center, width_radius, height_radius);
 }
 
-/// Draw as much of an ellipse, including its contents, as lies inside the image bounds.
+/// Draws an ellipse and its contents on a new copy of the image.
+///
+/// Draw as much of the ellipse and its contents as lies inside the image bounds.
 ///
 /// Uses the [Midpoint Ellipse Drawing Algorithm](https://web.archive.org/web/20160128020853/http://tutsheap.com/c/mid-point-ellipse-drawing-algorithm/).
 /// (Modified from Bresenham's algorithm)
@@ -90,7 +96,9 @@ where
     out
 }
 
-/// Draw as much of an ellipse, including its contents, as lies inside the image bounds.
+/// Draws an ellipse and its contents on an image in place.
+///
+/// Draw as much of the ellipse and its contents as lies inside the image bounds.
 ///
 /// Uses the [Midpoint Ellipse Drawing Algorithm](https://web.archive.org/web/20160128020853/http://tutsheap.com/c/mid-point-ellipse-drawing-algorithm/).
 /// (Modified from Bresenham's algorithm)
@@ -182,7 +190,9 @@ where
     }
 }
 
-/// Draw as much of a circle as lies inside the image bounds.
+/// Draws the outline of a circle on a new copy of an image.
+///
+/// Draw as much of the circle as lies inside the image bounds.
 pub fn draw_hollow_circle<I>(
     image: &I,
     center: (i32, i32),
@@ -199,7 +209,9 @@ where
     out
 }
 
-/// Draw as much of a circle as lies inside the image bounds.
+/// Draws the outline of a circle on an image in place.
+///
+/// Draw as much of the circle as lies inside the image bounds.
 pub fn draw_hollow_circle_mut<C>(canvas: &mut C, center: (i32, i32), radius: i32, color: C::Pixel)
 where
     C: Canvas,
@@ -231,7 +243,9 @@ where
     }
 }
 
-/// Draw as much of a circle, including its contents, as lies inside the image bounds.
+/// Draws a circle and its contents on an image in place.
+///
+/// Draws as much of a circle and its contents as lies inside the image bounds.
 pub fn draw_filled_circle_mut<C>(canvas: &mut C, center: (i32, i32), radius: i32, color: C::Pixel)
 where
     C: Canvas,
@@ -279,7 +293,9 @@ where
     }
 }
 
-/// Draw as much of a circle and its contents as lies inside the image bounds.
+/// Draws a circle and its contents on a new copy of the image.
+///
+/// Draws as much of a circle and its contents as lies inside the image bounds.
 pub fn draw_filled_circle<I>(
     image: &I,
     center: (i32, i32),

--- a/src/drawing/cross.rs
+++ b/src/drawing/cross.rs
@@ -3,7 +3,9 @@ use crate::drawing::Canvas;
 use image::{GenericImage, ImageBuffer};
 use std::i32;
 
-/// Draws a colored cross on an image in place. Handles coordinates outside image bounds.
+/// Draws a colored cross on an image in place.
+///
+/// Handles coordinates outside image bounds.
 #[rustfmt::skip]
 pub fn draw_cross_mut<C>(canvas: &mut C, color: C::Pixel, x: i32, y: i32)
 where
@@ -34,7 +36,9 @@ where
     }
 }
 
-/// Draws a colored cross on an image. Handles coordinates outside image bounds.
+/// Draws a colored cross on a new copy of an image.
+///
+/// Handles coordinates outside image bounds.
 pub fn draw_cross<I>(image: &I, color: I::Pixel, x: i32, y: i32) -> Image<I::Pixel>
 where
     I: GenericImage,

--- a/src/drawing/line.rs
+++ b/src/drawing/line.rs
@@ -165,7 +165,10 @@ impl<'a, P: Pixel + 'static> Iterator for BresenhamLinePixelIterMut<'a, P> {
     }
 }
 
+/// Draws a line segment on a new copy of an image.
+///
 /// Draws as much of the line segment between start and end as lies inside the image bounds.
+///
 /// Uses [Bresenham's line drawing algorithm](https://en.wikipedia.org/wiki/Bresenham%27s_line_algorithm).
 pub fn draw_line_segment<I>(
     image: &I,
@@ -183,7 +186,10 @@ where
     out
 }
 
+/// Draws a line segment on an image in place.
+///
 /// Draws as much of the line segment between start and end as lies inside the image bounds.
+///
 /// Uses [Bresenham's line drawing algorithm](https://en.wikipedia.org/wiki/Bresenham%27s_line_algorithm).
 pub fn draw_line_segment_mut<C>(canvas: &mut C, start: (f32, f32), end: (f32, f32), color: C::Pixel)
 where
@@ -205,9 +211,13 @@ where
     }
 }
 
-/// Draws as much of the line segment between start and end as lies inside the image bounds.
+/// Draws an antialised line segment on a new copy of an image.
+///
+/// Draws as much of the line segment between `start` and `end` as lies inside the image bounds.
+///
 /// The parameters of blend are (line color, original color, line weight).
 /// Consider using [`interpolate`](fn.interpolate.html) for blend.
+///
 /// Uses [Xu's line drawing algorithm](https://en.wikipedia.org/wiki/Xiaolin_Wu%27s_line_algorithm).
 pub fn draw_antialiased_line_segment<I, B>(
     image: &I,
@@ -227,9 +237,13 @@ where
     out
 }
 
-/// Draws as much of the line segment between start and end as lies inside the image bounds.
+/// Draws an antialised line segment on an image in place.
+///
+/// Draws as much of the line segment between `start` and `end` as lies inside the image bounds.
+///
 /// The parameters of blend are (line color, original color, line weight).
 /// Consider using [`interpolate`](fn.interpolate.html) for blend.
+///
 /// Uses [Xu's line drawing algorithm](https://en.wikipedia.org/wiki/Xiaolin_Wu%27s_line_algorithm).
 pub fn draw_antialiased_line_segment_mut<I, B>(
     image: &mut I,

--- a/src/drawing/mod.rs
+++ b/src/drawing/mod.rs
@@ -1,4 +1,7 @@
 //! Helpers for drawing basic shapes on images.
+//!
+//! Every `draw_` function comes in two variants: one creates a new copy of the input image, one modifies the image in place.
+//! The latter is more memory efficient, but you lose the original image.
 
 mod bezier;
 pub use self::bezier::{draw_cubic_bezier_curve, draw_cubic_bezier_curve_mut};

--- a/src/drawing/polygon.rs
+++ b/src/drawing/polygon.rs
@@ -7,6 +7,8 @@ use std::cmp::{max, min};
 use std::f32;
 use std::i32;
 
+/// Draws a polygon and its contents on a new copy of an image.
+///
 /// Draws as much of a filled polygon as lies within image bounds. The provided
 /// list of points should be an open path, i.e. the first and last points must not be equal.
 /// An implicit edge is added from the last to the first point in the slice.
@@ -21,6 +23,8 @@ where
     out
 }
 
+/// Draws a polygon and its contents on an image in place.
+///
 /// Draws as much of a filled polygon as lies within image bounds. The provided
 /// list of points should be an open path, i.e. the first and last points must not be equal.
 /// An implicit edge is added from the last to the first point in the slice.

--- a/src/drawing/rect.rs
+++ b/src/drawing/rect.rs
@@ -5,7 +5,9 @@ use crate::rect::Rect;
 use image::{GenericImage, ImageBuffer};
 use std::f32;
 
-/// Draws as much of the boundary of a rectangle as lies inside the image bounds.
+/// Draws the outline of a rectangle on a new copy of an image.
+///
+/// Draws as much of the boundary of the rectangle as lies inside the image bounds.
 pub fn draw_hollow_rect<I>(image: &I, rect: Rect, color: I::Pixel) -> Image<I::Pixel>
 where
     I: GenericImage,
@@ -17,7 +19,9 @@ where
     out
 }
 
-/// Draws as much of the boundary of a rectangle as lies inside the image bounds.
+/// Draws the outline of a rectangle on an image in place.
+///
+/// Draws as much of the boundary of the rectangle as lies inside the image bounds.
 pub fn draw_hollow_rect_mut<C>(canvas: &mut C, rect: Rect, color: C::Pixel)
 where
     C: Canvas,
@@ -34,7 +38,9 @@ where
     draw_line_segment_mut(canvas, (right, top), (right, bottom), color);
 }
 
-/// Draw as much of a rectangle, including its boundary, as lies inside the image bounds.
+/// Draws a rectangle and its contents on a new copy of an image.
+///
+/// Draws as much of the rectangle and its contents as lies inside the image bounds.
 pub fn draw_filled_rect<I>(image: &I, rect: Rect, color: I::Pixel) -> Image<I::Pixel>
 where
     I: GenericImage,
@@ -46,7 +52,9 @@ where
     out
 }
 
-/// Draw as much of a rectangle, including its boundary, as lies inside the image bounds.
+/// Draws a rectangle and its contents on an image in place.
+///
+/// Draws as much of the rectangle and its contents as lies inside the image bounds.
 pub fn draw_filled_rect_mut<C>(canvas: &mut C, rect: Rect, color: C::Pixel)
 where
     C: Canvas,

--- a/src/drawing/text.rs
+++ b/src/drawing/text.rs
@@ -30,12 +30,18 @@ fn layout_glyphs(
     (w, h)
 }
 
-/// Get the width and height of the given text, rendered with the given font and scale. Note that this function *does not* support newlines, you must do this manually.
+/// Get the width and height of the given text, rendered with the given font and scale.
+///
+/// Note that this function *does not* support newlines, you must do this manually.
 pub fn text_size(scale: Scale, font: &Font, text: &str) -> (i32, i32) {
     layout_glyphs(scale, font, text, |_, _| {})
 }
 
-/// Draws colored text on an image in place. `scale` is augmented font scaling on both the x and y axis (in pixels). Note that this function *does not* support newlines, you must do this manually.
+/// Draws colored text on an image in place.
+///
+/// `scale` is augmented font scaling on both the x and y axis (in pixels).
+///
+/// Note that this function *does not* support newlines, you must do this manually.
 pub fn draw_text_mut<'a, C>(
     canvas: &'a mut C,
     color: C::Pixel,
@@ -68,7 +74,11 @@ pub fn draw_text_mut<'a, C>(
     });
 }
 
-/// Draws colored text on a new copy of the image. `scale` is augmented font scaling on both the x and y axis (in pixels). Note that this function *does not* support newlines, you must do this manually.
+/// Draws colored text on a new copy of an image.
+///
+/// `scale` is augmented font scaling on both the x and y axis (in pixels).
+///
+/// Note that this function *does not* support newlines, you must do this manually.
 pub fn draw_text<'a, I>(
     image: &'a mut I,
     color: I::Pixel,


### PR DESCRIPTION
* I've edited the descriptions so they just get a one-line description in the module overview, making it easier to skim
* I've tweaked the wording so every function is consistent about how it describes, e.g. a filled shape vs the outline of a shape
* I've added consistent wording for "in place" vs "on a new copy of the image", and added a sentence clarifying what the difference between the two variants of function are
* I've fixed a broken link to a description of the midpoint ellipse drawing algorithm

Before:

<img width="1272" alt="Screenshot 2022-01-09 at 13 47 12" src="https://user-images.githubusercontent.com/301220/148684902-82989c23-5c61-425f-a041-a40dc6f349a2.png">

After:

<img width="1272" alt="Screenshot 2022-01-09 at 13 47 15" src="https://user-images.githubusercontent.com/301220/148684909-fbcf54b0-451f-47e2-bdfa-2bbbed6633a1.png">

Closes https://github.com/image-rs/imageproc/issues/482