### PR TITLE
Add must_use attribute to non-mutating functions.

### DIFF
--- a/src/drawing/bezier.rs
+++ b/src/drawing/bezier.rs
@@ -8,6 +8,7 @@ use std::i32;
 /// Draws a cubic Bézier curve on a new copy of an image.
 ///
 /// Draws as much of the curve as lies within image bounds.
+#[must_use = "the function does not modify the original image"]
 pub fn draw_cubic_bezier_curve<I>(
     image: &I,
     start: (f32, f32),

--- a/src/drawing/conics.rs
+++ b/src/drawing/conics.rs
@@ -16,6 +16,7 @@ use std::i32;
 /// The ellipse is axis-aligned and satisfies the following equation:
 ///
 /// (`x^2 / width_radius^2) + (y^2 / height_radius^2) = 1`
+#[must_use = "the function does not modify the original image"]
 pub fn draw_hollow_ellipse<I>(
     image: &I,
     center: (i32, i32),
@@ -79,6 +80,7 @@ pub fn draw_hollow_ellipse_mut<C>(
 /// The ellipse is axis-aligned and satisfies the following equation:
 ///
 /// `(x^2 / width_radius^2) + (y^2 / height_radius^2) <= 1`
+#[must_use = "the function does not modify the original image"]
 pub fn draw_filled_ellipse<I>(
     image: &I,
     center: (i32, i32),
@@ -193,6 +195,7 @@ where
 /// Draws the outline of a circle on a new copy of an image.
 ///
 /// Draw as much of the circle as lies inside the image bounds.
+#[must_use = "the function does not modify the original image"]
 pub fn draw_hollow_circle<I>(
     image: &I,
     center: (i32, i32),
@@ -296,6 +299,7 @@ where
 /// Draws a circle and its contents on a new copy of the image.
 ///
 /// Draws as much of a circle and its contents as lies inside the image bounds.
+#[must_use = "the function does not modify the original image"]
 pub fn draw_filled_circle<I>(
     image: &I,
     center: (i32, i32),

--- a/src/drawing/cross.rs
+++ b/src/drawing/cross.rs
@@ -39,6 +39,7 @@ where
 /// Draws a colored cross on a new copy of an image.
 ///
 /// Handles coordinates outside image bounds.
+#[must_use = "the function does not modify the original image"]
 pub fn draw_cross<I>(image: &I, color: I::Pixel, x: i32, y: i32) -> Image<I::Pixel>
 where
     I: GenericImage,

--- a/src/drawing/line.rs
+++ b/src/drawing/line.rs
@@ -170,6 +170,7 @@ impl<'a, P: Pixel + 'static> Iterator for BresenhamLinePixelIterMut<'a, P> {
 /// Draws as much of the line segment between start and end as lies inside the image bounds.
 ///
 /// Uses [Bresenham's line drawing algorithm](https://en.wikipedia.org/wiki/Bresenham%27s_line_algorithm).
+#[must_use = "the function does not modify the original image"]
 pub fn draw_line_segment<I>(
     image: &I,
     start: (f32, f32),
@@ -219,6 +220,7 @@ where
 /// Consider using [`interpolate`](fn.interpolate.html) for blend.
 ///
 /// Uses [Xu's line drawing algorithm](https://en.wikipedia.org/wiki/Xiaolin_Wu%27s_line_algorithm).
+#[must_use = "the function does not modify the original image"]
 pub fn draw_antialiased_line_segment<I, B>(
     image: &I,
     start: (i32, i32),

--- a/src/drawing/polygon.rs
+++ b/src/drawing/polygon.rs
@@ -12,6 +12,7 @@ use std::i32;
 /// Draws as much of a filled polygon as lies within image bounds. The provided
 /// list of points should be an open path, i.e. the first and last points must not be equal.
 /// An implicit edge is added from the last to the first point in the slice.
+#[must_use = "the function does not modify the original image"]
 pub fn draw_polygon<I>(image: &I, poly: &[Point<i32>], color: I::Pixel) -> Image<I::Pixel>
 where
     I: GenericImage,

--- a/src/drawing/rect.rs
+++ b/src/drawing/rect.rs
@@ -8,6 +8,7 @@ use std::f32;
 /// Draws the outline of a rectangle on a new copy of an image.
 ///
 /// Draws as much of the boundary of the rectangle as lies inside the image bounds.
+#[must_use = "the function does not modify the original image"]
 pub fn draw_hollow_rect<I>(image: &I, rect: Rect, color: I::Pixel) -> Image<I::Pixel>
 where
     I: GenericImage,
@@ -41,6 +42,7 @@ where
 /// Draws a rectangle and its contents on a new copy of an image.
 ///
 /// Draws as much of the rectangle and its contents as lies inside the image bounds.
+#[must_use = "the function does not modify the original image"]
 pub fn draw_filled_rect<I>(image: &I, rect: Rect, color: I::Pixel) -> Image<I::Pixel>
 where
     I: GenericImage,

--- a/src/drawing/text.rs
+++ b/src/drawing/text.rs
@@ -79,8 +79,9 @@ pub fn draw_text_mut<'a, C>(
 /// `scale` is augmented font scaling on both the x and y axis (in pixels).
 ///
 /// Note that this function *does not* support newlines, you must do this manually.
+#[must_use = "the function does not modify the original image"]
 pub fn draw_text<'a, I>(
-    image: &'a mut I,
+    image: &'a I,
     color: I::Pixel,
     x: i32,
     y: i32,

--- a/src/filter/median.rs
+++ b/src/filter/median.rs
@@ -105,6 +105,7 @@ use std::cmp::{max, min};
 /// assert_pixels_eq!(median_filter(&image, 2, 1), filtered);
 /// # }
 /// ```
+#[must_use = "the function does not modify the original image"]
 pub fn median_filter<P>(image: &Image<P>, x_radius: u32, y_radius: u32) -> Image<P>
 where
     P: Pixel<Subpixel = u8> + 'static,

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -49,6 +49,7 @@ use std::f32;
 /// let image = gray_bench_image(500, 500);
 /// let filtered = bilateral_filter(&image, 10, 10., 3.);
 /// ```
+#[must_use = "the function does not modify the original image"]
 pub fn bilateral_filter(
     image: &GrayImage,
     window_size: u32,
@@ -162,6 +163,7 @@ pub fn bilateral_filter(
 // TODO: for small kernels we probably want to do the convolution
 // TODO: directly instead of using an integral image.
 // TODO: more formats!
+#[must_use = "the function does not modify the original image"]
 pub fn box_filter(image: &GrayImage, x_radius: u32, y_radius: u32) -> Image<Luma<u8>> {
     let (width, height) = image.dimensions();
     let mut out = ImageBuffer::new(width, height);
@@ -304,6 +306,7 @@ fn gaussian_kernel_f32(sigma: f32) -> Vec<f32> {
 ///
 /// Panics if `sigma <= 0.0`.
 // TODO: Integer type kernel, approximations via repeated box filter.
+#[must_use = "the function does not modify the original image"]
 pub fn gaussian_blur_f32<P>(image: &Image<P>, sigma: f32) -> Image<P>
 where
     P: Pixel + 'static,
@@ -316,6 +319,7 @@ where
 
 /// Returns 2d correlation of view with the outer product of the 1d
 /// kernels `h_kernel` and `v_kernel`.
+#[must_use = "the function does not modify the original image"]
 pub fn separable_filter<P, K>(image: &Image<P>, h_kernel: &[K], v_kernel: &[K]) -> Image<P>
 where
     P: Pixel + 'static,
@@ -328,6 +332,7 @@ where
 
 /// Returns 2d correlation of an image with the outer product of the 1d
 /// kernel filter with itself.
+#[must_use = "the function does not modify the original image"]
 pub fn separable_filter_equal<P, K>(image: &Image<P>, kernel: &[K]) -> Image<P>
 where
     P: Pixel + 'static,
@@ -339,6 +344,7 @@ where
 
 /// Returns 2d correlation of an image with a 3x3 row-major kernel. Intermediate calculations are
 /// performed at type K, and the results clamped to subpixel type S. Pads by continuity.
+#[must_use = "the function does not modify the original image"]
 pub fn filter3x3<P, K, S>(image: &Image<P>, kernel: &[K]) -> Image<ChannelMap<P, S>>
 where
     P::Subpixel: ValueInto<K>,
@@ -353,6 +359,7 @@ where
 /// Returns horizontal correlations between an image and a 1d kernel.
 /// Pads by continuity. Intermediate calculations are performed at
 /// type K.
+#[must_use = "the function does not modify the original image"]
 pub fn horizontal_filter<P, K>(image: &Image<P>, kernel: &[K]) -> Image<P>
 where
     P: Pixel + 'static,
@@ -448,6 +455,7 @@ where
 
 /// Returns horizontal correlations between an image and a 1d kernel.
 /// Pads by continuity.
+#[must_use = "the function does not modify the original image"]
 pub fn vertical_filter<P, K>(image: &Image<P>, kernel: &[K]) -> Image<P>
 where
     P: Pixel + 'static,

--- a/src/filter/sharpen.rs
+++ b/src/filter/sharpen.rs
@@ -6,6 +6,7 @@ use crate::{
 use image::{GrayImage, Luma};
 
 /// Sharpens a grayscale image by applying a 3x3 approximation to the Laplacian.
+#[must_use = "the function does not modify the original image"]
 pub fn sharpen3x3(image: &GrayImage) -> GrayImage {
     let identity_minus_laplacian = [0, -1, 0, -1, 5, -1, 0, -1, 0];
     filter3x3(image, &identity_minus_laplacian)
@@ -16,6 +17,7 @@ pub fn sharpen3x3(image: &GrayImage) -> GrayImage {
 /// * `sigma` is the standard deviation of the Gaussian filter used.
 /// * `amount` controls the level of sharpening. `output = input + amount * edges`.
 // TODO: remove unnecessary allocations, support colour images
+#[must_use = "the function does not modify the original image"]
 pub fn sharpen_gaussian(image: &GrayImage, sigma: f32, amount: f32) -> GrayImage {
     let image = map_subpixels(image, |x| x as f32);
     let smooth: Image<Luma<f32>> = gaussian_blur_f32(&image, sigma);


### PR DESCRIPTION
This annotates functions that do not modify the original image.