### PR TITLE
Optimize interpolate_nearest

### DIFF
--- a/src/geometric_transformations.rs
+++ b/src/geometric_transformations.rs
@@ -710,14 +710,18 @@ where
 
 #[inline(always)]
 fn interpolate_nearest<P: Pixel>(image: &Image<P>, x: f32, y: f32, default: P) -> P {
-    let rx = (x + if x.is_sign_positive() { 0.5 } else { -0.5 }) as i32;
-    let ry = (y + if y.is_sign_positive() { 0.5 } else { -0.5 }) as i32;
-
     let (width, height) = image.dimensions();
-    if rx < 0 || ry < 0 || rx as u32 >= width || ry as u32 >= height {
+    if x < -0.5 || y < -0.5 {
+        return default;
+    }
+
+    let rx = (x + 0.5) as u32;
+    let ry = (y + 0.5) as u32;
+
+    if rx >= width || ry >= height {
         default
     } else {
-        unsafe { image.unsafe_get_pixel(rx as u32, ry as u32) }
+        unsafe { image.unsafe_get_pixel(rx, ry) }
     }
 }
 

--- a/src/geometric_transformations.rs
+++ b/src/geometric_transformations.rs
@@ -710,8 +710,8 @@ where
 
 #[inline(always)]
 fn interpolate_nearest<P: Pixel>(image: &Image<P>, x: f32, y: f32, default: P) -> P {
-    let rx = (x + if x > 0.0 { 0.5 } else { -0.5 }) as i32;
-    let ry = (y + if y > 0.0 { 0.5 } else { -0.5 }) as i32;
+    let rx = (x + if x.is_sign_positive() { 0.5 } else { -0.5 }) as i32;
+    let ry = (y + if y.is_sign_positive() { 0.5 } else { -0.5 }) as i32;
 
     let (width, height) = image.dimensions();
     if rx < 0 || rx >= width as i32 || ry < 0 || ry >= height as i32 {

--- a/src/geometric_transformations.rs
+++ b/src/geometric_transformations.rs
@@ -710,11 +710,11 @@ where
 
 #[inline(always)]
 fn interpolate_nearest<P: Pixel>(image: &Image<P>, x: f32, y: f32, default: P) -> P {
-    let rx = x.round();
-    let ry = y.round();
+    let rx = (x + if x > 0.0 { 0.5 } else { -0.5 }) as i32;
+    let ry = (y + if y > 0.0 { 0.5 } else { -0.5 }) as i32;
 
     let (width, height) = image.dimensions();
-    if rx < 0f32 || rx >= width as f32 || ry < 0f32 || ry >= height as f32 {
+    if rx < 0 || rx >= width as i32 || ry < 0 || ry >= height as i32 {
         default
     } else {
         unsafe { image.unsafe_get_pixel(rx as u32, ry as u32) }

--- a/src/geometric_transformations.rs
+++ b/src/geometric_transformations.rs
@@ -710,10 +710,11 @@ where
 
 #[inline(always)]
 fn interpolate_nearest<P: Pixel>(image: &Image<P>, x: f32, y: f32, default: P) -> P {
-    let (width, height) = image.dimensions();
     if x < -0.5 || y < -0.5 {
         return default;
     }
+
+    let (width, height) = image.dimensions();
 
     let rx = (x + 0.5) as u32;
     let ry = (y + 0.5) as u32;

--- a/src/geometric_transformations.rs
+++ b/src/geometric_transformations.rs
@@ -714,7 +714,7 @@ fn interpolate_nearest<P: Pixel>(image: &Image<P>, x: f32, y: f32, default: P) -
     let ry = (y + if y.is_sign_positive() { 0.5 } else { -0.5 }) as i32;
 
     let (width, height) = image.dimensions();
-    if rx < 0 || rx >= width as i32 || ry < 0 || ry >= height as i32 {
+    if rx < 0 || ry < 0 || rx as u32 >= width || ry as u32 >= height {
         default
     } else {
         unsafe { image.unsafe_get_pixel(rx as u32, ry as u32) }


### PR DESCRIPTION
Right now interpolate_nearest does .round() to get the positions, but adding 0.5 and casting is faster. I didn't benchmark interpolate_nearest specifically, but my program that makes heavy use of it became around 3 times faster with this change.
