### PR TITLE
Refactor Gradients [Discussion]

### DIFF
--- a/src/edges.rs
+++ b/src/edges.rs
@@ -2,7 +2,7 @@
 
 use crate::definitions::{HasBlack, HasWhite};
 use crate::filter::gaussian_blur_f32;
-use crate::gradients::{horizontal_sobel, vertical_sobel};
+use crate::gradients::{GradientKernel::Sobel};
 use image::{GenericImageView, GrayImage, ImageBuffer, Luma};
 use std::f32;
 
@@ -35,8 +35,8 @@ pub fn canny(image: &GrayImage, low_threshold: f32, high_threshold: f32) -> Gray
     let blurred = gaussian_blur_f32(image, SIGMA);
 
     // 2. Intensity of gradients.
-    let gx = horizontal_sobel(&blurred);
-    let gy = vertical_sobel(&blurred);
+    let gx = Sobel.horizontal_gradient(&blurred);
+    let gy = Sobel.vertical_gradient(&blurred);
     let g: Vec<f32> = gx
         .iter()
         .zip(gy.iter())

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -215,9 +215,9 @@ pub fn box_filter(image: &GrayImage, x_radius: u32, y_radius: u32) -> Image<Luma
 
 /// A 2D kernel, used to filter images via convolution.
 pub struct Kernel<'a, K> {
-    data: &'a [K],
-    width: u32,
-    height: u32,
+    pub(crate) data: &'a [K],
+    pub(crate) width: u32,
+    pub(crate) height: u32,
 }
 
 impl<'a, K: Num + Copy + 'a> Kernel<'a, K> {

--- a/src/hog.rs
+++ b/src/hog.rs
@@ -2,7 +2,7 @@
 //! and helpers for visualizing them.
 
 use crate::definitions::{Clamp, Image};
-use crate::gradients::{horizontal_sobel, vertical_sobel};
+use crate::gradients::{GradientKernel::Sobel};
 use crate::math::l2_norm;
 use image::{GenericImage, GrayImage, ImageBuffer, Luma};
 use num::Zero;
@@ -257,8 +257,8 @@ pub fn cell_histograms(image: &GrayImage, spec: HogSpec) -> Array3d<f32> {
     let mut grid = Array3d::new(spec.cell_grid_lengths());
     let cell_area = spec.cell_area() as f32;
     let cell_side = spec.options.cell_side as f32;
-    let horizontal = horizontal_sobel(image);
-    let vertical = vertical_sobel(image);
+    let horizontal = Sobel.horizontal_gradient(image);
+    let vertical = Sobel.vertical_gradient(image);
     let interval = orientation_bin_width(spec.options);
     let range = direction_range(spec.options);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //! a standard image processing function in this crate.
 //!
 //! [image]: https://github.com/image-rs/image
-#![deny(missing_docs)]
+// #![deny(missing_docs)]
 #![cfg_attr(test, feature(test))]
 #![allow(
     clippy::cast_lossless,

--- a/src/seam_carving.rs
+++ b/src/seam_carving.rs
@@ -4,7 +4,7 @@
 //! [seam carving]: https://en.wikipedia.org/wiki/Seam_carving
 
 use crate::definitions::{HasBlack, Image};
-use crate::gradients::sobel_gradient_map;
+use crate::gradients::GradientKernel::Sobel;
 use crate::map::{map_colors, WithChannel};
 use image::{GrayImage, Luma, Pixel, Rgb};
 use std::cmp::min;
@@ -54,7 +54,7 @@ where
         "Cannot find seams if image width is < 2"
     );
 
-    let mut gradients = sobel_gradient_map(image, |p| {
+    let mut gradients = Sobel.gradient_map(image, |p| {
         let gradient_sum: u16 = p.channels().iter().sum();
         let gradient_mean: u16 = gradient_sum / P::CHANNEL_COUNT as u16;
         Luma([gradient_mean as u32])


### PR DESCRIPTION
This PR is intended to facilitate discussion about a proposed refactor. It isn't a complete PR—probably won't even compile.

I suggest the gradient filter module & API be refactored to achieve the following: 

 * unify the API with respect to the choice of kernel
 * increase orthogonality
 * allow for the addition of the [Roberts cross](https://en.wikipedia.org/wiki/Roberts_cross) kernel, which is a $2\times 2$ kernel, not a $3\times 3$ kernel and so isn't compatible with present-day code
 * reduce code duplication (DRY)

# A summary of the suggested design

1. Have a `GradientKernel` (alt. named `GradientMethod`) enum with variants `Sobel`, `Scharr`, etc.
2. Change the `pub static HORIZONTAL_*` and `pub static VERTICAL_*` kernels to be actual `Kernel<i32>` struct instances rather than `[i32; 9]` arrays.
3. Member functions of `GradientKernel` return references to the appropriate `pub static` `Kernel<i32>` instance.
4. Move the filtering functions into member functions of `GradientKernel`. Optionally have free function aliases that take the `GradientKernel` variant as a parameter. (The Sobel kernel would no longer be distinguished.)
5. Change the function and purpose of `gradient_map` so that it applies a function to the gradient vector of each point to produce a single pixel result. Consequently, the member functions `gradient_L1_norm`, `gradient_angle`, `gradient_L2_norm` (with alias `gradient_magnitude`) trivially reduce to calls to `gradient_map`.
6. Gradient operations only work on single channel images. Do away with the functionality currently being provided by `gradient_map`. (Justified by replacing multichannel functionality with better, more general `imageproc `feature.)

# More Details

The suggestion is to have a `GradientKernel` (alt. name could be `GradientMethod`) enum:

```rust
pub enum GradientKernel {
    Sobel,
    Scharr,
    Prewitt,
    Roberts
}
```

## 4. Move the filtering functions into member functions of `GradientKernel`.

The free functions in `gradients.rs` would be brought into `GradientKernel` member functions:

```rust
impl GradientKernel {
    pub fn horizontal_gradient(&self, image: &GrayImage) -> Image<Luma<i16>> {…}
    pub fn vertical_gradient(&self, image: &GrayImage) -> Image<Luma<i16>> {…}
    pub fn gradient_map<P, F, Q>(&self, image: &GrayImage, f: F) -> Image<Q> where … {…}
    pub fn gradient_magnitude(&self, image: &GrayImage) -> Image<Luma<i16>> {…}
    ⋮
}
```

## 5. Change the function and purpose of `gradient_map`

I'll argue for the existence of a new function in this section. I will argue for the deletion of the current version of `gradient_map` in the next section, as these are two distinct questions.

I want a function called `gradient_map`, but I do not want it to do what the current definition of `gradient_map` does. Instead, it makes sense to me to have a `gradient_map` function that maps a function over the gradient vector at each point to produce an output image. This would literally map a function onto the gradient, which strikes me as linguistically more accurate. Such a function would be useful to client code and would reduce the computations of `gradient_angle` and `gradient_magnitude` to the composition of `gradient_map` with the appropriate function of the gradient vector, which is satisfyingly orthogonal.

## 6. Gradient operations only work on single channel images

The current version of `gradient_map` enables an arbitrary function of an n-channel pixel to produce an m-channel pixel for the output. I speculate that this function exists because gradient computations are often needed to produce a "magnitude of rate of change at a point" from a color source image, and since kernel convolution in a single channel operation, there needed to be a way to go from three channels to one. But if magnitude of perceptual rate of change is what is of interest, then the color source image should be converted to luminance before a gradient operation is ever applied. (Note also that any linear function of channels commutes with a channel-wise gradient operation.) In my view, this functionality doesn't belong in the `gradients` module at all, and in any case it isn't well-described by the function name `gradient_map`. 

This refactor is agnostic to whether and to where the existing functionality to move. But I'll say a few words about that anyway. Producing an image via a function of another image's channels can be done by the client code. If it is useful functionality and/or is cumbersome for client code to implement, the functionality should be implemented in a generic way in some other module, or in its own module. In fact, I would like to draft a second feature proposal independent of this one that implements fast generic high-level elementwise mathematical operations on images: add two images, multiply two images, find the max of two images. But this is a digression.

A gradient operation is fundamentally a single channel operation. Splitting and combining channels and images is a distinct collection of operations from gradient operations.