### PR TITLE
Implementing Laplacian and LaplacianEdgeDetector Builders for Laplacian Edge Detection

### DIFF
--- a/src/edges.rs
+++ b/src/edges.rs
@@ -1,7 +1,8 @@
 //! Functions for detecting edges in images.
 
+use crate::contrast;
 use crate::definitions::{HasBlack, HasWhite};
-use crate::filter::gaussian_blur_f32;
+use crate::filter::{gaussian_blur_f32, Laplacian};
 use crate::gradients::{horizontal_sobel, vertical_sobel};
 use image::{GenericImageView, GrayImage, ImageBuffer, Luma};
 use std::f32;
@@ -155,6 +156,80 @@ fn hysteresis(
         }
     }
     out
+}
+
+/// A builder for the Laplacian edge detection algorithm.
+/// This LaplacianEdgeDetector builder provides a flexible and convenient way to perform edge detection
+/// on grayscale images using the Laplacian filter. It supports optional parameters such as custom
+/// Gaussian blur sigma, diagonal adjustment for the Laplacian kernel, and a custom threshold for edge
+/// detection. The builder pattern makes it easy to configure and apply the edge detection algorithm
+/// with a fluent and readable syntax.
+pub struct LaplacianEdgeDetector<'a> {
+    image: &'a GrayImage,
+    sigma: Option<f32>,
+    diagonal_adjustment: bool,
+    threshold: Option<u8>,
+}
+
+impl<'a> LaplacianEdgeDetector<'a> {
+    /// Creates a new LaplacianEdgeDetector with the specified grayscale image.
+    ///
+    /// # Arguments
+    /// * image - A reference to the grayscale image on which edge detection will be performed.
+    pub fn new(image: &'a GrayImage) -> Self {
+        Self {
+            image,
+            sigma: None,
+            diagonal_adjustment: false,
+            threshold: None,
+        }
+    }
+
+    /// Sets the standard deviation (sigma) of the Gaussian blur applied before edge detection.
+    ///
+    /// # Arguments
+    /// * sigma - The standard deviation of the Gaussian blur.
+    pub fn sigma(mut self, sigma: f32) -> Self {
+        self.sigma = Some(sigma);
+        self
+    }
+
+    /// Enables diagonal adjustment for the Laplacian kernel.
+    pub fn diagonal_adjustment(mut self) -> Self {
+        self.diagonal_adjustment = true;
+        self
+    }
+
+    /// Sets a custom threshold for edge detection.
+    ///
+    /// # Arguments
+    /// * threshold - The custom threshold value.
+    pub fn threshold(mut self, threshold: u8) -> Self {
+        self.threshold = Some(threshold);
+        self
+    }
+
+    /// Applies the Laplacian edge detection algorithm and returns the resulting image.
+    ///
+    /// # Returns
+    /// * An ImageBuffer containing the result of the edge detection.
+    pub fn apply(self) -> ImageBuffer<Luma<u8>, Vec<u8>> {
+        let sigma = self.sigma.unwrap_or(1.4);
+        let blurred_img = gaussian_blur_f32(self.image, sigma);
+
+        let laplacian_img = if self.diagonal_adjustment {
+            Laplacian::new(&blurred_img).diagonal_adjustment().apply()
+        } else {
+            Laplacian::new(&blurred_img).apply()
+        };
+
+        if let Some(threshold) = self.threshold {
+            contrast::threshold(&laplacian_img, threshold)
+        } else {
+            let otsu_threshold = contrast::otsu_level(&laplacian_img);
+            contrast::threshold(&laplacian_img, otsu_threshold)
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -574,6 +574,7 @@ where
 pub struct Laplacian<'a> {
     image: &'a GrayImage,
     mask: [i32; 9],
+    _marker: std::marker::PhantomData<&'a ()>,
 }
 
 impl<'a> Laplacian<'a> {
@@ -588,6 +589,7 @@ impl<'a> Laplacian<'a> {
         Self {
             image,
             mask: [1, 1, 1, 1, -8, 1, 1, 1, 1],
+            _marker: std::marker::PhantomData,
         }
     }
 

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -564,6 +564,51 @@ where
     }
 }
 
+// Laplacian filter with basic mask and diagonal adjustment mask
+
+/// This implementation of the Laplacian algorithm provides a builder pattern for easy customization.
+/// The default Laplacian mask can be used, or an optional diagonal adjustment mask can be selected.
+/// The chosen mask is convolved with the input image to produce an output image with the edges highlighted.
+
+/// A builder for applying Laplacian filter to a grayscale image.
+pub struct Laplacian<'a> {
+    image: &'a GrayImage,
+    mask: [i32; 9],
+}
+
+impl<'a> Laplacian<'a> {
+    /// Creates a new Laplacian with the default mask.
+    ///
+    /// # Arguments
+    /// * image - A reference to the grayscale image to which the Laplacian filter will be applied.
+    ///
+    /// # Returns
+    /// A new Laplacian instance.
+    pub fn new(image: &'a GrayImage) -> Self {
+        Self {
+            image,
+            mask: [1, 1, 1, 1, -8, 1, 1, 1, 1],
+        }
+    }
+
+    /// Sets the mask to the diagonal adjustment mask.
+    ///
+    /// # Returns
+    /// The modified Laplacian instance.
+    pub fn diagonal_adjustment(mut self) -> Self {
+        self.mask = [0, 1, 0, 1, -4, 1, 0, 1, 0];
+        self
+    }
+
+    /// Applies the Laplacian filter with the selected mask to the image.
+    ///
+    /// # Returns
+    /// An ImageBuffer containing the filtered image.
+    pub fn apply(self) -> ImageBuffer<Luma<u8>, Vec<u8>> {
+        filter3x3(self.image, &self.mask)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -574,7 +574,6 @@ where
 pub struct Laplacian<'a> {
     image: &'a GrayImage,
     mask: [i32; 9],
-    _marker: std::marker::PhantomData<&'a ()>,
 }
 
 impl<'a> Laplacian<'a> {
@@ -589,7 +588,6 @@ impl<'a> Laplacian<'a> {
         Self {
             image,
             mask: [1, 1, 1, 1, -8, 1, 1, 1, 1],
-            _marker: std::marker::PhantomData,
         }
     }
 

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -564,7 +564,9 @@ where
     }
 }
 
-fn laplacian_filter(image: &GrayImage) -> ImageBuffer<Luma<u8>, Vec<u8>> {
+/// Apply a Laplacian filter to an image.
+#[must_use = "the function does not modify the original image"]
+pub fn laplacian_filter(image: &GrayImage) -> ImageBuffer<Luma<u8>, Vec<u8>> {
     filter3x3(image, &[1, 1, 1, 1, -8, 1, 1, 1, 1])
 }
 

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -564,49 +564,8 @@ where
     }
 }
 
-// Laplacian filter with basic mask and diagonal adjustment mask
-
-/// This implementation of the Laplacian algorithm provides a builder pattern for easy customization.
-/// The default Laplacian mask can be used, or an optional diagonal adjustment mask can be selected.
-/// The chosen mask is convolved with the input image to produce an output image with the edges highlighted.
-
-/// A builder for applying Laplacian filter to a grayscale image.
-pub struct Laplacian<'a> {
-    image: &'a GrayImage,
-    mask: [i32; 9],
-}
-
-impl<'a> Laplacian<'a> {
-    /// Creates a new Laplacian with the default mask.
-    ///
-    /// # Arguments
-    /// * image - A reference to the grayscale image to which the Laplacian filter will be applied.
-    ///
-    /// # Returns
-    /// A new Laplacian instance.
-    pub fn new(image: &'a GrayImage) -> Self {
-        Self {
-            image,
-            mask: [1, 1, 1, 1, -8, 1, 1, 1, 1],
-        }
-    }
-
-    /// Sets the mask to the diagonal adjustment mask.
-    ///
-    /// # Returns
-    /// The modified Laplacian instance.
-    pub fn diagonal_adjustment(mut self) -> Self {
-        self.mask = [0, 1, 0, 1, -4, 1, 0, 1, 0];
-        self
-    }
-
-    /// Applies the Laplacian filter with the selected mask to the image.
-    ///
-    /// # Returns
-    /// An ImageBuffer containing the filtered image.
-    pub fn apply(self) -> ImageBuffer<Luma<u8>, Vec<u8>> {
-        filter3x3(self.image, &self.mask)
-    }
+fn laplacian_filter(image: &GrayImage) -> ImageBuffer<Luma<u8>, Vec<u8>> {
+    filter3x3(image, &[1, 1, 1, 1, -8, 1, 1, 1, 1])
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This pull request adds two new builder structures, Laplacian and LaplacianEdgeDetector, to address the request in Issue #505 titled "Laplacian edge detection". These builders are designed to make it easy and flexible for users to perform Laplacian edge detection on grayscale images.

The Laplacian builder allows users to apply a Laplacian filter to a grayscale image. It provides the option to use the default Laplacian kernel or to apply a diagonal adjustment to the kernel. This diagonal adjustment changes the kernel to emphasize diagonal edges in the image. To maximize compatibility and maintainability, the Laplacian builder utilizes existing project functions, such as the filter3x3 function, for filtering the image.

The LaplacianEdgeDetector builder builds on the Laplacian builder and provides a complete edge detection solution. Users can customize the edge detection process by setting parameters such as the Gaussian blur sigma value and the edge threshold value. If these parameters are not provided, the builder will use default values (sigma = 1.4 for Gaussian blur and Otsu's method for edge threshold). The LaplacianEdgeDetector builder also offers an option for diagonal adjustment, similar to the Laplacian builder.

These new builders make it easy for users to perform Laplacian edge detection on grayscale images with just a few lines of code. The flexibility of the builders allows for customization of the edge detection process according to the user's needs. By leveraging existing functions within the project, these additions ensure seamless integration and improved maintainability. I believe these enhancements will be a valuable addition to the project and help users achieve better edge detection results.