### PR TITLE
Make `Contour` clonable.

### DIFF
--- a/src/contours.rs
+++ b/src/contours.rs
@@ -17,7 +17,7 @@ pub enum BorderType {
 }
 
 /// A border of an 8-connected foreground region.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Contour<T> {
     /// The points in the border.
     pub points: Vec<Point<T>>,


### PR DESCRIPTION
I want to clone some custom structs that contain contours. And I don't see any reason why `Contour` should not implement `Clone` :)