### PR TITLE
Fix Gaussian blur loosing value by normalizing the finite Gaussian kernel.

### DIFF
--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -295,6 +295,8 @@ fn gaussian_kernel_f32(sigma: f32) -> Vec<f32> {
         kernel_data[kernel_radius + i] = value;
         kernel_data[kernel_radius - i] = value;
     }
+    let sum: f32 = kernel_data.iter().sum();
+    kernel_data.iter_mut().for_each(|x| *x /= sum);
     kernel_data
 }
 

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -355,6 +355,20 @@ fn test_gaussian_blur_stdev_10() {
 }
 
 #[test]
+fn test_gaussian_on_u8_white_idempotent() {
+    let image = ImageBuffer::<Luma<u8>, Vec<u8>>::from_pixel(64, 64, Luma([255]));
+    let image2 = gaussian_blur_f32(&image, 10f32);
+    assert_pixels_eq_within!(image2, image, 0);
+}
+
+#[test]
+fn test_gaussian_on_f32_white_idempotent() {
+    let image = ImageBuffer::<Luma<f32>, Vec<f32>>::from_pixel(64, 64, Luma([1.0]));
+    let image2 = gaussian_blur_f32(&image, 10f32);
+    assert_pixels_eq_within!(image2, image, 1e-6);
+}
+
+#[test]
 fn test_adaptive_threshold() {
     use imageproc::contrast::adaptive_threshold;
     compare_to_truth("zebra.png", "zebra_adaptive_threshold.png", |image| {


### PR DESCRIPTION
This corrects issue #529 by re-normalizing the Gaussian kernel. This breaks regression tests based on existing images, obviously. 