### PR TITLE
chore: update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,22 +18,22 @@ display-window = ["sdl2"]
 [dependencies]
 approx = "0.5"
 conv = "0.3.3"
-image = { version = "0.24.6", default-features = false }
-itertools = "0.10"
+image = { version = "0.24.7", default-features = false }
+itertools = "0.11"
 nalgebra = { version = "0.32", default-features = false, features = ["std"] }
 num = "0.4"
+quickcheck = { version = "1.0.3", optional = true }
 rand = "0.8.5"
 rand_distr = "0.4.3"
+rayon = { version = "1.8.0", optional = true }
 rusttype = "0.9.3"
-rayon = { version = "1.7.0", optional = true }
-quickcheck = { version = "1.0.3", optional = true }
 sdl2 = { version = "0.35", optional = true, default-features = false, features = ["bundled"] }
 
 [dev-dependencies]
 assert_approx_eq = "1.1.0"
-image = "0.24.6"
+image = "0.24.7"
 quickcheck = "1.0.3"
-wasm-bindgen-test = "0.3.35"
+wasm-bindgen-test = "0.3.37"
 
 [package.metadata.docs.rs]
 # See https://github.com/image-rs/imageproc/issues/358


### PR DESCRIPTION
More dependency updates.

The switch from `rusttype`, which is unmaintained, to `ab_glyph` seems non-trivial.