### PR TITLE
cargo check with minimal versions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,6 +6,8 @@
 # - hack: check combinations of feature flags
 # - msrv: check that the msrv specified in the crate is correct
 # - semver: check API changes for semver violations.
+# - minimal: runs "cargo check" with the minimal versions of the dependencies that satisfy the
+#   requirements of this crate, and its dependencies
 permissions:
   contents: read
 # This configuration allows maintainers of this repo to create a branch and pull request based on
@@ -119,3 +121,44 @@ jobs:
         uses: actions/checkout@v3
       - name: Check semver
         uses: obi1kenobi/cargo-semver-checks-action@v2
+  minimal:
+    # This action chooses the oldest version of the dependencies permitted by Cargo.toml to ensure
+    # that this crate is compatible with the minimal version that this crate and its dependencies
+    # require. This will pickup issues where this create relies on functionality that was introduced
+    # later than the actual version specified (e.g., when we choose just a major version, but a
+    # method was added after this version).
+    #
+    # This particular check can be difficult to get to succeed as often transitive dependencies may
+    # be incorrectly specified (e.g., a dependency specifies 1.0 but really requires 1.1.5). There
+    # is an alternative flag available -Zdirect-minimal-versions that uses the minimal versions for
+    # direct dependencies of this crate, while selecting the maximal versions for the transitive
+    # dependencies. Alternatively, you can add a line in your Cargo.toml to artificially increase
+    # the minimal dependency, which you do with e.g.:
+    # ```toml
+    # # for minimal-versions
+    # [target.'cfg(any())'.dependencies]
+    # openssl = { version = "0.10.55", optional = true } # needed to allow foo to build with -Zminimal-versions
+    # ```
+    # The optional = true is necessary in case that dependency isn't otherwise transitively required
+    # by your library, and the target bit is so that this dependency edge never actually affects
+    # Cargo build order. See also
+    # https://github.com/jonhoo/fantoccini/blob/fde336472b712bc7ebf5b4e772023a7ba71b2262/Cargo.toml#L47-L49.
+    # This action is run on ubuntu with the stable toolchain, as it is not expected to fail
+    runs-on: ubuntu-latest
+    name: ubuntu / stable / minimal-versions
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Install stable
+        uses: dtolnay/rust-toolchain@stable
+      - name: Install nightly for -Zminimal-versions
+        uses: dtolnay/rust-toolchain@nightly
+      - name: rustup default stable
+        run: rustup default stable
+      - name: cargo update -Zminimal-versions
+        run: cargo +nightly update -Zminimal-versions
+      - name: cargo check
+        run: cargo check --locked
+        env:
+          RUSTFLAGS: -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ conv = "0.3.3"
 image = { version = "0.24.7", default-features = false }
 itertools = "0.12"
 nalgebra = { version = "0.32", default-features = false, features = ["std"] }
-num = "0.4"
+num = "0.4.1"
 rand = "0.8.5"
 rand_distr = "0.4.3"
 rayon = { version = "1.8.0", optional = true }


### PR DESCRIPTION
cargo check with `num` = `"0.4.0"` failed locally: `cargo +nightly update -Zminimal-versions && cargo check`.
update `num` to `"0.4.1"`