### PR TITLE
Update MSRV and replace "minimal-versions" check with "direct-minimal-versions" test

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -98,7 +98,7 @@ jobs:
     # https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability
     strategy:
       matrix:
-        msrv: ["1.63.0"] # 2021 edition requires 1.56
+        msrv: ["1.65.0"] # 2021 edition requires 1.56
     name: ubuntu / ${{ matrix.msrv }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,8 +6,6 @@
 # - hack: check combinations of feature flags
 # - msrv: check that the msrv specified in the crate is correct
 # - semver: check API changes for semver violations.
-# - minimal: runs "cargo check" with the minimal versions of the dependencies that satisfy the
-#   requirements of this crate, and its dependencies
 permissions:
   contents: read
 # This configuration allows maintainers of this repo to create a branch and pull request based on
@@ -111,7 +109,7 @@ jobs:
         with:
           toolchain: ${{ matrix.msrv }}
       - name: cargo +${{ matrix.msrv }} check
-        run: cargo check
+        run: cargo check --all-features
         env:
           RUSTFLAGS: -D warnings
   semver:
@@ -121,44 +119,3 @@ jobs:
         uses: actions/checkout@v3
       - name: Check semver
         uses: obi1kenobi/cargo-semver-checks-action@v2
-  minimal:
-    # This action chooses the oldest version of the dependencies permitted by Cargo.toml to ensure
-    # that this crate is compatible with the minimal version that this crate and its dependencies
-    # require. This will pickup issues where this create relies on functionality that was introduced
-    # later than the actual version specified (e.g., when we choose just a major version, but a
-    # method was added after this version).
-    #
-    # This particular check can be difficult to get to succeed as often transitive dependencies may
-    # be incorrectly specified (e.g., a dependency specifies 1.0 but really requires 1.1.5). There
-    # is an alternative flag available -Zdirect-minimal-versions that uses the minimal versions for
-    # direct dependencies of this crate, while selecting the maximal versions for the transitive
-    # dependencies. Alternatively, you can add a line in your Cargo.toml to artificially increase
-    # the minimal dependency, which you do with e.g.:
-    # ```toml
-    # # for minimal-versions
-    # [target.'cfg(any())'.dependencies]
-    # openssl = { version = "0.10.55", optional = true } # needed to allow foo to build with -Zminimal-versions
-    # ```
-    # The optional = true is necessary in case that dependency isn't otherwise transitively required
-    # by your library, and the target bit is so that this dependency edge never actually affects
-    # Cargo build order. See also
-    # https://github.com/jonhoo/fantoccini/blob/fde336472b712bc7ebf5b4e772023a7ba71b2262/Cargo.toml#L47-L49.
-    # This action is run on ubuntu with the stable toolchain, as it is not expected to fail
-    runs-on: ubuntu-latest
-    name: ubuntu / stable / minimal-versions
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: true
-      - name: Install stable
-        uses: dtolnay/rust-toolchain@stable
-      - name: Install nightly for -Zminimal-versions
-        uses: dtolnay/rust-toolchain@nightly
-      - name: rustup default stable
-        run: rustup default stable
-      - name: cargo update -Zminimal-versions
-        run: cargo +nightly update -Zminimal-versions
-      - name: cargo check
-        run: cargo check --locked
-        env:
-          RUSTFLAGS: -D warnings

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,8 @@
 # This is the main CI workflow that runs the test suite on all pushes to main and all pull requests.
 # It runs the following jobs:
 # - required: runs the test suite on ubuntu with the specified rust toolchains
+# - direct-minimal: runs the test suite with the minimal versions of the dependencies that satisfy the
+#   requirements of this crate
 # - os-check: runs the test suite on mac and windows
 # See check.yml for information about how the concurrency cancellation and workflow triggering works
 permissions:
@@ -38,6 +40,19 @@ jobs:
       # https://github.com/rust-lang/cargo/issues/6669
       - name: cargo test --doc
         run: cargo test --locked --all-features --doc
+  direct-minimal:
+    runs-on: ubuntu-latest
+    name: ubuntu / nightly / direct-minimal-versions
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Install nightly
+        uses: dtolnay/rust-toolchain@nightly
+      - name: cargo update -Zdirect-minimal-versions
+        run: cargo update -Zdirect-minimal-versions
+      - name: cargo test
+        run: cargo test --locked --all-features --all-targets
   os-check:
     # run cargo test on mac and windows
     runs-on: ${{ matrix.os }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "imageproc"
 version = "0.24.0"
 authors = ["theotherphil"]
-rust-version = "1.63.0"
+rust-version = "1.65.0"
 edition = "2021"
 license = "MIT"
 description = "Image processing operations"


### PR DESCRIPTION
`-Zminimal-versions` + `cargo check` will validate only default features without `dev-dependencies`.
But `-Zminimal-versions` + `cargo +nightly test --all-targets --all-features` is completely broken due to indirect dependencies.
We can try to update with `-Zdirect-minimal-versions` instead and then test.

MSRV updated from `1.63` to `1.65` for `property-testing` feature. Added `--all-features` to the `msrv` workflow (note: additional `--all-targets` flag will not work due to `nightly` tests).