### PR TITLE
Re-export `image`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,3 +67,5 @@ pub mod template_matching;
 pub mod union_find;
 #[cfg(feature = "display-window")]
 pub mod window;
+
+pub use image;


### PR DESCRIPTION
The problem is described [here](https://www.lurklurk.org/effective-rust/re-export.html).

This gives the user the ability to not depend on `image`, so the code will always compile.
Once this version of `imageproc` is published on `crates.io`, we can add `use imageproc::image` to the beginning of all `examples`.