### PR TITLE
add `image/default` as default feature

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -98,7 +98,7 @@ jobs:
     # https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability
     strategy:
       matrix:
-        msrv: ["1.67.1"] # 2021 edition requires 1.56
+        msrv: ["1.70.0"] # 2021 edition requires 1.56
     name: ubuntu / ${{ matrix.msrv }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -109,7 +109,7 @@ jobs:
         with:
           toolchain: ${{ matrix.msrv }}
       - name: cargo +${{ matrix.msrv }} check
-        run: cargo check --all-features
+        run: cargo check
         env:
           RUSTFLAGS: -D warnings
   semver:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,8 @@
 name = "imageproc"
 version = "0.24.0"
 authors = ["theotherphil"]
-rust-version = "1.67.1"
+# note: when changed, also update `msrv` in `.github/workflows/check.yml`
+rust-version = "1.70.0"
 edition = "2021"
 license = "MIT"
 description = "Image processing operations"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ homepage = "https://github.com/image-rs/imageproc"
 exclude = ["examples/*.ttf"]
 
 [features]
-default = [ "rayon" ]
+default = [ "rayon", "image/default" ]
 property-testing = [ "quickcheck" ]
 display-window = ["sdl2"]
 
@@ -35,7 +35,6 @@ getrandom = { version = "0.2", features = ["js"] }
 
 [dev-dependencies]
 assert_approx_eq = "1.1.0"
-image = "0.25.0"
 quickcheck = "1.0.3"
 wasm-bindgen-test = "0.3.38"
 


### PR DESCRIPTION
Continuing our discussion about the re-export of the `image` https://github.com/image-rs/imageproc/pull/557.

`image/default` should allow to run examples using `imageproc::image`, otherwise a panic/error may occur (png/jpeg decode, etc).
It seems to me that users will expect this from our re-export.
If they don't need the default `image` features, then they will do `imageproc = { ..., default-features = false }` which will lead to `image = { ..., default-features = false } ` internally.

The `msrv` is increased, see https://github.com/image-rs/image/issues/2168