### PR TITLE
Drop conv dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ display-window = ["sdl2"]
 [dependencies]
 ab_glyph = "0.2.23"
 approx = "0.5"
-conv = "0.3.3"
 image = { version = "0.25.0", default-features = false }
 itertools = "0.12"
 nalgebra = { version = "0.32", default-features = false, features = ["std"] }

--- a/src/drawing/text.rs
+++ b/src/drawing/text.rs
@@ -1,4 +1,3 @@
-use conv::ValueInto;
 use image::{GenericImage, ImageBuffer, Pixel};
 use std::f32;
 
@@ -59,7 +58,7 @@ pub fn draw_text_mut<C>(
     text: &str,
 ) where
     C: Canvas,
-    <C::Pixel as Pixel>::Subpixel: ValueInto<f32> + Clamp<f32>,
+    <C::Pixel as Pixel>::Subpixel: Into<f32> + Clamp<f32>,
 {
     let image_width = canvas.width() as i32;
     let image_height = canvas.height() as i32;
@@ -97,7 +96,7 @@ pub fn draw_text<I>(
 ) -> Image<I::Pixel>
 where
     I: GenericImage,
-    <I::Pixel as Pixel>::Subpixel: ValueInto<f32> + Clamp<f32>,
+    <I::Pixel as Pixel>::Subpixel: Into<f32> + Clamp<f32>,
 {
     let mut out = ImageBuffer::new(image.width(), image.height());
     out.copy_from(image, 0, 0).unwrap();

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -13,8 +13,6 @@ use crate::integral_image::{column_running_sum, row_running_sum};
 use crate::map::{ChannelMap, WithChannel};
 use num::{abs, pow, Num};
 
-use crate::math::cast;
-use conv::ValueInto;
 use std::cmp::{max, min};
 use std::f32;
 
@@ -237,7 +235,7 @@ impl<'a, K: Num + Copy + 'a> Kernel<'a, K> {
     pub fn filter<P, F, Q>(&self, image: &Image<P>, mut f: F) -> Image<Q>
     where
         P: Pixel,
-        <P as Pixel>::Subpixel: ValueInto<K>,
+        <P as Pixel>::Subpixel: Into<K>,
         Q: Pixel,
         F: FnMut(&mut Q::Subpixel, K),
     {
@@ -304,7 +302,7 @@ fn gaussian_kernel_f32(sigma: f32) -> Vec<f32> {
 pub fn gaussian_blur_f32<P>(image: &Image<P>, sigma: f32) -> Image<P>
 where
     P: Pixel,
-    <P as Pixel>::Subpixel: ValueInto<f32> + Clamp<f32>,
+    <P as Pixel>::Subpixel: Into<f32> + Clamp<f32>,
 {
     assert!(sigma > 0.0, "sigma must be > 0.0");
     let kernel = gaussian_kernel_f32(sigma);
@@ -317,7 +315,7 @@ where
 pub fn separable_filter<P, K>(image: &Image<P>, h_kernel: &[K], v_kernel: &[K]) -> Image<P>
 where
     P: Pixel,
-    <P as Pixel>::Subpixel: ValueInto<K> + Clamp<K>,
+    <P as Pixel>::Subpixel: Into<K> + Clamp<K>,
     K: Num + Copy,
 {
     let h = horizontal_filter(image, h_kernel);
@@ -330,7 +328,7 @@ where
 pub fn separable_filter_equal<P, K>(image: &Image<P>, kernel: &[K]) -> Image<P>
 where
     P: Pixel,
-    <P as Pixel>::Subpixel: ValueInto<K> + Clamp<K>,
+    <P as Pixel>::Subpixel: Into<K> + Clamp<K>,
     K: Num + Copy,
 {
     separable_filter(image, kernel, kernel)
@@ -341,7 +339,7 @@ where
 #[must_use = "the function does not modify the original image"]
 pub fn filter3x3<P, K, S>(image: &Image<P>, kernel: &[K]) -> Image<ChannelMap<P, S>>
 where
-    P::Subpixel: ValueInto<K>,
+    P::Subpixel: Into<K>,
     S: Clamp<K> + Primitive,
     P: WithChannel<S>,
     K: Num + Copy,
@@ -357,7 +355,7 @@ where
 pub fn horizontal_filter<P, K>(image: &Image<P>, kernel: &[K]) -> Image<P>
 where
     P: Pixel,
-    <P as Pixel>::Subpixel: ValueInto<K> + Clamp<K>,
+    <P as Pixel>::Subpixel: Into<K> + Clamp<K>,
     K: Num + Copy,
 {
     // Don't replace this with a call to Kernel::filter without
@@ -453,7 +451,7 @@ where
 pub fn vertical_filter<P, K>(image: &Image<P>, kernel: &[K]) -> Image<P>
 where
     P: Pixel,
-    <P as Pixel>::Subpixel: ValueInto<K> + Clamp<K>,
+    <P as Pixel>::Subpixel: Into<K> + Clamp<K>,
     K: Num + Copy,
 {
     // Don't replace this with a call to Kernel::filter without
@@ -550,11 +548,11 @@ where
 fn accumulate<P, K>(acc: &mut [K], pixel: &P, weight: K)
 where
     P: Pixel,
-    <P as Pixel>::Subpixel: ValueInto<K>,
+    <P as Pixel>::Subpixel: Into<K>,
     K: Num + Copy,
 {
     for i in 0..(P::CHANNEL_COUNT as usize) {
-        acc[i] = acc[i] + cast(pixel.channels()[i]) * weight;
+        acc[i] = acc[i] + pixel.channels()[i].into() * weight;
     }
 }
 

--- a/src/math.rs
+++ b/src/math.rs
@@ -1,7 +1,5 @@
 //! Assorted mathematical helper functions.
 
-use conv::ValueInto;
-
 /// L1 norm of a vector.
 pub fn l1_norm(xs: &[f32]) -> f32 {
     xs.iter().fold(0f32, |acc, x| acc + x.abs())
@@ -10,15 +8,4 @@ pub fn l1_norm(xs: &[f32]) -> f32 {
 /// L2 norm of a vector.
 pub fn l2_norm(xs: &[f32]) -> f32 {
     xs.iter().fold(0f32, |acc, x| acc + x * x).sqrt()
-}
-
-/// Helper for a conversion that we know can't fail.
-pub fn cast<T, U>(x: T) -> U
-where
-    T: ValueInto<U>,
-{
-    match x.value_into() {
-        Ok(y) => y,
-        Err(_) => panic!("Failed to convert"),
-    }
 }

--- a/src/noise.rs
+++ b/src/noise.rs
@@ -1,8 +1,6 @@
 //! Functions for adding synthetic noise to images.
 
 use crate::definitions::{Clamp, HasBlack, HasWhite, Image};
-use crate::math::cast;
-use conv::ValueInto;
 use image::Pixel;
 use rand::{rngs::StdRng, SeedableRng};
 use rand_distr::{Distribution, Normal, Uniform};
@@ -12,7 +10,7 @@ use rand_distr::{Distribution, Normal, Uniform};
 pub fn gaussian_noise<P>(image: &Image<P>, mean: f64, stddev: f64, seed: u64) -> Image<P>
 where
     P: Pixel,
-    P::Subpixel: ValueInto<f64> + Clamp<f64>,
+    P::Subpixel: Into<f64> + Clamp<f64>,
 {
     let mut out = image.clone();
     gaussian_noise_mut(&mut out, mean, stddev, seed);
@@ -24,7 +22,7 @@ where
 pub fn gaussian_noise_mut<P>(image: &mut Image<P>, mean: f64, stddev: f64, seed: u64)
 where
     P: Pixel,
-    P::Subpixel: ValueInto<f64> + Clamp<f64>,
+    P::Subpixel: Into<f64> + Clamp<f64>,
 {
     let mut rng: StdRng = SeedableRng::seed_from_u64(seed);
     let normal = Normal::new(mean, stddev).unwrap();
@@ -32,7 +30,7 @@ where
     for p in image.pixels_mut() {
         for c in p.channels_mut() {
             let noise = normal.sample(&mut rng);
-            *c = P::Subpixel::clamp(cast(*c) + noise);
+            *c = P::Subpixel::clamp((*c).into() + noise);
         }
     }
 }

--- a/src/pixelops.rs
+++ b/src/pixelops.rs
@@ -1,8 +1,6 @@
 //! Pixel manipulations.
 
 use crate::definitions::Clamp;
-use crate::math::cast;
-use conv::ValueInto;
 use image::Pixel;
 
 /// Adds pixels with the given weights. Results are clamped to prevent arithmetical overflows.
@@ -24,7 +22,7 @@ use image::Pixel;
 /// ```
 pub fn weighted_sum<P: Pixel>(left: P, right: P, left_weight: f32, right_weight: f32) -> P
 where
-    P::Subpixel: ValueInto<f32> + Clamp<f32>,
+    P::Subpixel: Into<f32> + Clamp<f32>,
 {
     left.map2(&right, |p, q| {
         weighted_channel_sum(p, q, left_weight, right_weight)
@@ -50,7 +48,7 @@ where
 /// ```
 pub fn interpolate<P: Pixel>(left: P, right: P, left_weight: f32) -> P
 where
-    P::Subpixel: ValueInto<f32> + Clamp<f32>,
+    P::Subpixel: Into<f32> + Clamp<f32>,
 {
     weighted_sum(left, right, left_weight, 1.0 - left_weight)
 }
@@ -58,9 +56,9 @@ where
 #[inline(always)]
 fn weighted_channel_sum<C>(left: C, right: C, left_weight: f32, right_weight: f32) -> C
 where
-    C: ValueInto<f32> + Clamp<f32>,
+    C: Into<f32> + Clamp<f32>,
 {
-    Clamp::clamp(cast(left) * left_weight + cast(right) * right_weight)
+    Clamp::clamp(left.into() * left_weight + right.into() * right_weight)
 }
 
 #[cfg(test)]

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,8 +1,6 @@
 //! Statistical properties of images.
 
 use crate::definitions::Image;
-use crate::math::cast;
-use conv::ValueInto;
 use image::{GenericImageView, GrayImage, Pixel, Primitive};
 use num::Bounded;
 
@@ -110,7 +108,7 @@ where
     I: GenericImageView<Pixel = P>,
     J: GenericImageView<Pixel = P>,
     P: Pixel,
-    P::Subpixel: ValueInto<f64>,
+    P::Subpixel: Into<f64>,
 {
     mean_squared_error(left, right).sqrt()
 }
@@ -124,9 +122,9 @@ where
     I: GenericImageView<Pixel = P>,
     J: GenericImageView<Pixel = P>,
     P: Pixel,
-    P::Subpixel: ValueInto<f64> + Primitive,
+    P::Subpixel: Into<f64> + Primitive,
 {
-    let max: f64 = cast(<P::Subpixel as Bounded>::max_value());
+    let max: f64 = <P::Subpixel as Bounded>::max_value().into();
     let mse = mean_squared_error(original, noisy);
     20f64 * max.log(10f64) - 10f64 * mse.log(10f64)
 }
@@ -136,14 +134,14 @@ where
     I: GenericImageView<Pixel = P>,
     J: GenericImageView<Pixel = P>,
     P: Pixel,
-    P::Subpixel: ValueInto<f64>,
+    P::Subpixel: Into<f64>,
 {
     assert_dimensions_match!(left, right);
     let mut sum_squared_diffs = 0f64;
     for (p, q) in left.pixels().zip(right.pixels()) {
         for (c, d) in p.2.channels().iter().zip(q.2.channels().iter()) {
-            let fc: f64 = cast(*c);
-            let fd: f64 = cast(*d);
+            let fc: f64 = (*c).into();
+            let fd: f64 = (*d).into();
             let diff = fc - fd;
             sum_squared_diffs += diff * diff;
         }


### PR DESCRIPTION
Drops the ancient `conv` dependency, which isn't necessary anymore these days.

Unfortunately this is a breaking change as the `ValueInto` trait appears in many places in the API https://docs.rs/imageproc/0.24.0/imageproc/index.html?search=ValueInto