### PR TITLE
clamp coverage value in text.rs between 0.0 and 1.0;

### DIFF
--- a/src/drawing/text.rs
+++ b/src/drawing/text.rs
@@ -67,6 +67,7 @@ pub fn draw_text_mut<C>(
         g.draw(|gx, gy, gv| {
             let image_x = gx as i32 + x + bb.min.x.round() as i32;
             let image_y = gy as i32 + y + bb.min.y.round() as i32;
+            let gv = gv.clamp(0.0, 1.0);
 
             if (0..image_width).contains(&image_x) && (0..image_height).contains(&image_y) {
                 let image_x = image_x as u32;


### PR DESCRIPTION
Very minimal change. I had copied the code from this crate to use in my own projects, and found out that sometimes `ab_glyph` gives a higher coverage value than `1.0` when there are overlapping glyphs (like in Arabic.) The same change worked in my code. You can find the relevant issue here: https://github.com/alexheretic/ab-glyph/issues/101 