### PR TITLE
Template matching with an alpha channel

### DIFF
--- a/src/template_matching.rs
+++ b/src/template_matching.rs
@@ -336,13 +336,17 @@ mod tests {
             3, 4
         );
 
-        let actual = match_template(&image, &template, MatchTemplateMethod::SumOfSquaredErrors);
         let expected = gray_image!(type: f32,
             14.0, 14.0;
             3.0, 1.0
         );
 
+        let actual = match_template(&image, &template, MatchTemplateMethod::SumOfSquaredErrors);
         assert_pixels_eq!(actual, expected);
+
+        let actual_parallel =
+            match_template_parallel(&image, &template, MatchTemplateMethod::SumOfSquaredErrors);
+        assert_pixels_eq!(actual_parallel, expected);
     }
 
     #[test]
@@ -357,18 +361,25 @@ mod tests {
             3, 4
         );
 
-        let actual = match_template(
-            &image,
-            &template,
-            MatchTemplateMethod::SumOfSquaredErrorsNormalized,
-        );
         let tss = 30f32;
         let expected = gray_image!(type: f32,
             14.0 / (22.0 * tss).sqrt(), 14.0 / (30.0 * tss).sqrt();
             3.0 / (23.0 * tss).sqrt(), 1.0 / (35.0 * tss).sqrt()
         );
 
+        let actual = match_template(
+            &image,
+            &template,
+            MatchTemplateMethod::SumOfSquaredErrorsNormalized,
+        );
         assert_pixels_eq!(actual, expected);
+
+        let actual_parallel = match_template_parallel(
+            &image,
+            &template,
+            MatchTemplateMethod::SumOfSquaredErrorsNormalized,
+        );
+        assert_pixels_eq!(actual_parallel, expected);
     }
 
     #[test]
@@ -383,13 +394,17 @@ mod tests {
             3, 4
         );
 
-        let actual = match_template(&image, &template, MatchTemplateMethod::CrossCorrelation);
         let expected = gray_image!(type: f32,
             19.0, 23.0;
             25.0, 32.0
         );
 
+        let actual = match_template(&image, &template, MatchTemplateMethod::CrossCorrelation);
         assert_pixels_eq!(actual, expected);
+
+        let actual_parallel =
+            match_template_parallel(&image, &template, MatchTemplateMethod::CrossCorrelation);
+        assert_pixels_eq!(actual_parallel, expected);
     }
 
     #[test]
@@ -404,18 +419,25 @@ mod tests {
             3, 4
         );
 
-        let actual = match_template(
-            &image,
-            &template,
-            MatchTemplateMethod::CrossCorrelationNormalized,
-        );
         let tss = 30f32;
         let expected = gray_image!(type: f32,
             19.0 / (22.0 * tss).sqrt(), 23.0 / (30.0 * tss).sqrt();
             25.0 / (23.0 * tss).sqrt(), 32.0 / (35.0 * tss).sqrt()
         );
 
+        let actual = match_template(
+            &image,
+            &template,
+            MatchTemplateMethod::CrossCorrelationNormalized,
+        );
         assert_pixels_eq!(actual, expected);
+
+        let actual_parallel = match_template_parallel(
+            &image,
+            &template,
+            MatchTemplateMethod::CrossCorrelationNormalized,
+        );
+        assert_pixels_eq!(actual_parallel, expected);
     }
 
     macro_rules! bench_match_template {


### PR DESCRIPTION
This MR is adding the `match_template_with_alpha` (and its `match_template_parallel_with_alpha` counterpart).
This make this crate support "masked" templates (or "non rectangular" templates or templates "with an alpha channel", name it as you'd like :D )

A few notes:
* In order not to change the public API, I _added_ new functions, instead of making the same function accept more data types (which would boil down to exposing the `_inner` function).
* I'm not sure I am normalizing the right way (in `sum_squares`) in the case of an image with alpha. I'd be happy to have a review on this part (it's late and my brain is unable to get the meaning of the math behind this normalization, especially as the normalization term depending on the location of the image)

Neat side effects:
* This implementations de-duplicates (a bit) the code between `match_template` and `match_template_parallel`
* I'm making sure the `_parallel` functions are tested in CI
* I'm adding the `gray_alpha_image!` macro