### PR TITLE
Add `assert!` for image dims in `bilateral_filter`

### DIFF
--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -39,6 +39,10 @@ use std::f32;
 ///        Images." IEEE International Conference on Computer Vision (1998)
 ///        839-846. DOI: 10.1109/ICCV.1998.710815
 ///
+/// # Panics
+///
+/// Panics if `image.width() > i32::MAX as u32` or `image.height() > i32::MAX as u32`.
+///
 /// # Examples
 ///
 /// ```

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -98,6 +98,9 @@ pub fn bilateral_filter(
     let window_extent = (window_size - 1) / 2;
 
     let (width, height) = image.dimensions();
+    assert!(width <= i32::MAX as u32);
+    assert!(height <= i32::MAX as u32);
+
     Image::from_fn(width, height, |col, row| {
         let mut total_val = 0f32;
         let mut total_weight = 0f32;


### PR DESCRIPTION
Someone can create an image with `dim > i32::MAX as u32` and `dim as i32` will be negative.