### PR TITLE
Implement L2 Norm for morphology transforms

### DIFF
--- a/src/distance_transform.rs
+++ b/src/distance_transform.rs
@@ -114,8 +114,8 @@ pub(crate) enum DistanceFrom {
 
 pub(crate) fn distance_transform_impl(image: &mut GrayImage, norm: Norm, from: DistanceFrom) {
     match norm {
-        Norm::LInf => distance_transform_impl_linf(image, from),
-        Norm::L1 => distance_transform_impl_l1(image, from),
+        Norm::LInf => distance_transform_impl_linf_or_l1::<true>(image, from),
+        Norm::L1 => distance_transform_impl_linf_or_l1::<false>(image, from),
         Norm::L2 => {
             match from {
                 DistanceFrom::Foreground => (),
@@ -131,21 +131,6 @@ pub(crate) fn distance_transform_impl(image: &mut GrayImage, norm: Norm, from: D
                 .for_each(|(u, v)| *u = v.sqrt().clamp(0.0, 255.0).ceil() as u8);
         }
     }
-}
-
-#[inline(always)]
-fn distance_transform_impl_linf(image: &mut GrayImage, from: DistanceFrom) {
-    // the boolean generic parameter "IS_LINF" allows
-    // for there to be one compiled fuction per norm,
-    // reducing the number of if statements evaluated at runtime
-    distance_transform_impl_linf_or_l1::<true>(image, from)
-}
-#[inline(always)]
-fn distance_transform_impl_l1(image: &mut GrayImage, from: DistanceFrom) {
-    // the boolean generic parameter "IS_LINF" allows
-    // for there to be one compiled fuction per norm,
-    // reducing the number of if statements evaluated at runtime
-    distance_transform_impl_linf_or_l1::<false>(image, from)
 }
 
 fn distance_transform_impl_linf_or_l1<const IS_LINF: bool>(
@@ -184,7 +169,6 @@ fn distance_transform_impl_linf_or_l1<const IS_LINF: bool>(
                     check(image, x, y, x, y - 1);
 
                     if IS_LINF {
-                        // this 'if' statement will be compiled away because IS_LINF is a const
                         if x > 0 {
                             check(image, x, y, x - 1, y - 1);
                         }
@@ -207,7 +191,6 @@ fn distance_transform_impl_linf_or_l1<const IS_LINF: bool>(
                     check(image, x, y, x, y + 1);
 
                     if IS_LINF {
-                        // this 'if' statement will be compiled away because IS_LINF is a const
                         if x < image.width() - 1 {
                             check(image, x, y, x + 1, y + 1);
                         }

--- a/src/distance_transform.rs
+++ b/src/distance_transform.rs
@@ -24,7 +24,7 @@ pub enum Norm {
     L1,
     /// Defines d((x1, y1), (x2, y2)) to be sqrt((x1 - x2)^2 + (y1 - y2)^2).
     /// Also known as the euclidian norm.
-    /// when working in integer distances, we take the smallest 
+    /// when working with integer distances, we take the smallest
     /// greater integer value, also know as 'ceiling'
     /// example : d((0,0),(1,2)) = ceil(sqrt(1+2^2)) = ceil(2.236...) = 3
     L2,
@@ -65,7 +65,7 @@ pub enum Norm {
 /// );
 ///
 /// assert_pixels_eq!(distance_transform(&image, Norm::L1), l1_distances);
-/// 
+///
 /// // L2 norm
 /// let l2_distances = gray_image!(
 ///     3,   3,   2,   3,   3;
@@ -87,7 +87,7 @@ pub enum Norm {
 /// );
 ///
 /// assert_pixels_eq!(distance_transform(&image, Norm::LInf), linf_distances);
-/// 
+///
 /// # }
 /// ```
 pub fn distance_transform(image: &GrayImage, norm: Norm) -> GrayImage {
@@ -119,37 +119,45 @@ pub(crate) fn distance_transform_impl(image: &mut GrayImage, norm: Norm, from: D
         Norm::L2 => {
             match from {
                 DistanceFrom::Foreground => (),
-                DistanceFrom::Background => image.iter_mut().for_each(|p| *p = if *p == 0 {1} else {0})
+                DistanceFrom::Background => image
+                    .iter_mut()
+                    .for_each(|p| *p = if *p == 0 { 1 } else { 0 }),
             }
-            let float_dist: ImageBuffer<Luma<f64>, Vec<f64>> = euclidean_squared_distance_transform(image);
-            image.iter_mut().zip(float_dist.iter())
-                .for_each(|(u,v)| { *u = v.sqrt().clamp(0.0, 255.0).ceil() as u8 });
+            let float_dist: ImageBuffer<Luma<f64>, Vec<f64>> =
+                euclidean_squared_distance_transform(image);
+            image
+                .iter_mut()
+                .zip(float_dist.iter())
+                .for_each(|(u, v)| *u = v.sqrt().clamp(0.0, 255.0).ceil() as u8);
         }
     }
 }
 
 #[inline(always)]
 fn distance_transform_impl_linf(image: &mut GrayImage, from: DistanceFrom) {
-    // the boolean generic parameter "IS_LINF" allows 
-    // for there to be one compiled fuction per norm, 
+    // the boolean generic parameter "IS_LINF" allows
+    // for there to be one compiled fuction per norm,
     // reducing the number of if statements evaluated at runtime
     distance_transform_impl_linf_or_l1::<true>(image, from)
 }
 #[inline(always)]
 fn distance_transform_impl_l1(image: &mut GrayImage, from: DistanceFrom) {
-    // the boolean generic parameter "IS_LINF" allows 
-    // for there to be one compiled fuction per norm, 
+    // the boolean generic parameter "IS_LINF" allows
+    // for there to be one compiled fuction per norm,
     // reducing the number of if statements evaluated at runtime
     distance_transform_impl_linf_or_l1::<false>(image, from)
 }
 
-fn distance_transform_impl_linf_or_l1<const IS_LINF : bool>(image: &mut GrayImage, from: DistanceFrom) {
+fn distance_transform_impl_linf_or_l1<const IS_LINF: bool>(
+    image: &mut GrayImage,
+    from: DistanceFrom,
+) {
     let max_distance = Luma([min(image.width() + image.height(), 255u32) as u8]);
 
     // We use an unsafe code block for optimisation purposes here
-    // We use the 'unsafe_get_pixel' and 'check' unsafe functions, 
+    // We use the 'unsafe_get_pixel' and 'check' unsafe functions,
     // which are faster than safe functions,
-    // and we garantee that they are used safely 
+    // and we garantee that they are used safely
     // by making sure we are always within the bounds of the image
 
     unsafe {
@@ -175,7 +183,8 @@ fn distance_transform_impl_linf_or_l1<const IS_LINF : bool>(image: &mut GrayImag
                 if y > 0 {
                     check(image, x, y, x, y - 1);
 
-                    if IS_LINF { // this 'if' statement will be compiled away because IS_LINF is a const
+                    if IS_LINF {
+                        // this 'if' statement will be compiled away because IS_LINF is a const
                         if x > 0 {
                             check(image, x, y, x - 1, y - 1);
                         }
@@ -197,7 +206,8 @@ fn distance_transform_impl_linf_or_l1<const IS_LINF : bool>(image: &mut GrayImag
                 if y < image.height() - 1 {
                     check(image, x, y, x, y + 1);
 
-                    if IS_LINF { // this 'if' statement will be compiled away because IS_LINF is a const
+                    if IS_LINF {
+                        // this 'if' statement will be compiled away because IS_LINF is a const
                         if x < image.width() - 1 {
                             check(image, x, y, x + 1, y + 1);
                         }

--- a/src/distance_transform.rs
+++ b/src/distance_transform.rs
@@ -23,7 +23,7 @@ pub enum Norm {
     /// Also known as the Manhattan or city block norm.
     L1,
     /// Defines d((x1, y1), (x2, y2)) to be sqrt((x1 - x2)^2 + (y1 - y2)^2).
-    /// Also known as the euclidian norm.
+    /// Also known as the Euclidean norm.
     /// when working with integer distances, we take the smallest
     /// greater integer value, also know as 'ceiling'
     /// example : d((0,0),(1,2)) = ceil(sqrt(1+2^2)) = ceil(2.236...) = 3

--- a/src/distance_transform.rs
+++ b/src/distance_transform.rs
@@ -131,14 +131,14 @@ pub(crate) fn distance_transform_impl(image: &mut GrayImage, norm: Norm, from: D
 #[inline(always)]
 fn distance_transform_impl_linf(image: &mut GrayImage, from: DistanceFrom) {
     // the boolean generic parameter "IS_LINF" allows 
-    // for there two be one compiled fuction per norm, 
+    // for there to be one compiled fuction per norm, 
     // reducing the number of if statements evaluated at runtime
     distance_transform_impl_linf_or_l1::<true>(image, from)
 }
 #[inline(always)]
 fn distance_transform_impl_l1(image: &mut GrayImage, from: DistanceFrom) {
     // the boolean generic parameter "IS_LINF" allows 
-    // for there two be one compiled fuction per norm, 
+    // for there to be one compiled fuction per norm, 
     // reducing the number of if statements evaluated at runtime
     distance_transform_impl_linf_or_l1::<false>(image, from)
 }

--- a/src/distance_transform.rs
+++ b/src/distance_transform.rs
@@ -670,6 +670,9 @@ mod tests {
     bench_distance_transform!(bench_distance_transform_l1_10, Norm::L1, side: 10);
     bench_distance_transform!(bench_distance_transform_l1_100, Norm::L1, side: 100);
     bench_distance_transform!(bench_distance_transform_l1_200, Norm::L1, side: 200);
+    bench_distance_transform!(bench_distance_transform_l2_10, Norm::L2, side: 10);
+    bench_distance_transform!(bench_distance_transform_l2_100, Norm::L2, side: 100);
+    bench_distance_transform!(bench_distance_transform_l2_200, Norm::L2, side: 200);
     bench_distance_transform!(bench_distance_transform_linf_10, Norm::LInf, side: 10);
     bench_distance_transform!(bench_distance_transform_linf_100, Norm::LInf, side: 100);
     bench_distance_transform!(bench_distance_transform_linf_200, Norm::LInf, side: 200);

--- a/src/morphology.rs
+++ b/src/morphology.rs
@@ -40,6 +40,18 @@ use image::GrayImage;
 ///
 /// assert_pixels_eq!(dilate(&image, Norm::L1, 1), l1_dilated);
 ///
+/// // L2 norm
+/// // (note that L2 behaves identically to L1 for distances of 2 or less)
+/// let l2_dilated = gray_image!(
+///    0,   0,   0,   0,   0;
+///    0,   0, 255,   0,   0;
+///    0, 255, 255, 255,   0;
+///    0,   0, 255,   0,   0;
+///    0,   0,   0,   0,   0
+/// );
+///
+/// assert_pixels_eq!(dilate(&image, Norm::L2, 1), l2_dilated);
+///
 /// // LInf norm
 /// let linf_dilated = gray_image!(
 ///    0,   0,   0,   0,   0;
@@ -112,6 +124,23 @@ pub fn dilate_mut(image: &mut GrayImage, norm: Norm, k: u8) {
 /// );
 ///
 /// assert_pixels_eq!(erode(&image, Norm::L1, 1), l1_eroded);
+///
+/// // L2 norm - all foreground pixels within a distance of n or less
+/// // of a background pixel are eroded.
+/// // (note that L2 behaves identically to L1 for distances of 2 or less)
+/// let l2_eroded = gray_image!(
+///     0,   0,   0,   0,   0,   0,   0,   0,  0;
+///     0,   0,   0,   0,   0,   0,   0,   0,  0;
+///     0,   0, 255, 255, 255, 255, 255,   0,  0;
+///     0,   0, 255, 255,   0, 255, 255,   0,  0;
+///     0,   0, 255,   0,   0,   0, 255,   0,  0;
+///     0,   0, 255, 255,   0, 255, 255,   0,  0;
+///     0,   0, 255, 255, 255, 255, 255,   0,  0;
+///     0,   0,   0,   0,   0,   0,   0,   0,  0;
+///     0,   0,   0,   0,   0,   0,   0,   0,  0
+/// );
+///
+/// assert_pixels_eq!(erode(&image, Norm::L2, 1), l2_eroded);
 ///
 /// // LInf norm - all pixels eroded using the L1 norm are eroded,
 /// // as well as the pixels diagonally adjacent to the centre pixel.
@@ -328,6 +357,22 @@ mod tests {
     use std::cmp::{max, min};
 
     #[test]
+    fn test_dilate_point_l1_0() {
+        let image = gray_image!(
+              0,   0,   0,   0,   0;
+              0,   0,   0,   0,   0;
+              0,   0, 255,   0,   0;
+              0,   0,   0,   0,   0;
+              0,   0,   0,   0,   0
+        );
+        let dilated = dilate(&image, Norm::L1, 0);
+
+        let expected = image;
+
+        assert_pixels_eq!(dilated, expected);
+    }
+
+    #[test]
     fn test_dilate_point_l1_1() {
         let image = gray_image!(
               0,   0,   0,   0,   0;
@@ -367,6 +412,142 @@ mod tests {
               0, 255, 255, 255,   0;
               0,   0, 255,   0,   0
         );
+
+        assert_pixels_eq!(dilated, expected);
+    }
+
+    #[test]
+    fn test_dilate_point_l1_4() {
+        let image = gray_image!(
+              0,   0,   0,   0,   0,   0,   0,   0,   0;
+              0,   0,   0,   0,   0,   0,   0,   0,   0;
+              0,   0,   0,   0,   0,   0,   0,   0,   0;
+              0,   0,   0,   0,   0,   0,   0,   0,   0;
+              0,   0,   0,   0, 255,   0,   0,   0,   0;
+              0,   0,   0,   0,   0,   0,   0,   0,   0;
+              0,   0,   0,   0,   0,   0,   0,   0,   0;
+              0,   0,   0,   0,   0,   0,   0,   0,   0;
+              0,   0,   0,   0,   0,   0,   0,   0,   0
+        );
+        let dilated = dilate(&image, Norm::L1, 4);
+
+        let expected = gray_image!(
+              0,   0,   0,   0, 255,   0,   0,   0,   0;
+              0,   0,   0, 255, 255, 255,   0,   0,   0;
+              0,   0, 255, 255, 255, 255, 255,   0,   0;
+              0, 255, 255, 255, 255, 255, 255, 255,   0;
+            255, 255, 255, 255, 255, 255, 255, 255, 255;
+              0, 255, 255, 255, 255, 255, 255, 255,   0;
+              0,   0, 255, 255, 255, 255, 255,   0,   0;
+              0,   0,   0, 255, 255, 255,   0,   0,   0;
+              0,   0,   0,   0, 255,   0,   0,   0,   0
+        );
+
+        assert_pixels_eq!(dilated, expected);
+    }
+
+    #[test]
+    fn test_dilate_point_l2_0() {
+        let image = gray_image!(
+              0,   0,   0,   0,   0;
+              0,   0,   0,   0,   0;
+              0,   0, 255,   0,   0;
+              0,   0,   0,   0,   0;
+              0,   0,   0,   0,   0
+        );
+        let dilated = dilate(&image, Norm::L2, 0);
+
+        let expected = image;
+
+        assert_pixels_eq!(dilated, expected);
+    }
+
+    #[test]
+    fn test_dilate_point_l2_1() {
+        let image = gray_image!(
+              0,   0,   0,   0,   0;
+              0,   0,   0,   0,   0;
+              0,   0, 255,   0,   0;
+              0,   0,   0,   0,   0;
+              0,   0,   0,   0,   0
+        );
+        let dilated = dilate(&image, Norm::L2, 1);
+
+        let expected = gray_image!(
+              0,   0,   0,   0,   0;
+              0,   0, 255,   0,   0;
+              0, 255, 255, 255,   0;
+              0,   0, 255,   0,   0;
+              0,   0,   0,   0,   0
+        );
+
+        assert_pixels_eq!(dilated, expected);
+    }
+
+    #[test]
+    fn test_dilate_point_l2_2() {
+        let image = gray_image!(
+              0,   0,   0,   0,   0;
+              0,   0,   0,   0,   0;
+              0,   0, 255,   0,   0;
+              0,   0,   0,   0,   0;
+              0,   0,   0,   0,   0
+        );
+        let dilated = dilate(&image, Norm::L2, 2);
+
+        let expected = gray_image!(
+              0,   0, 255,   0,   0;
+              0, 255, 255, 255,   0;
+            255, 255, 255, 255, 255;
+              0, 255, 255, 255,   0;
+              0,   0, 255,   0,   0
+        );
+
+        assert_pixels_eq!(dilated, expected);
+    }
+
+    #[test]
+    fn test_dilate_point_l2_4() {
+        let image = gray_image!(
+            0,   0,   0,   0,   0,   0,   0,   0,   0;
+            0,   0,   0,   0,   0,   0,   0,   0,   0;
+            0,   0,   0,   0,   0,   0,   0,   0,   0;
+            0,   0,   0,   0,   0,   0,   0,   0,   0;
+            0,   0,   0,   0, 255,   0,   0,   0,   0;
+            0,   0,   0,   0,   0,   0,   0,   0,   0;
+            0,   0,   0,   0,   0,   0,   0,   0,   0;
+            0,   0,   0,   0,   0,   0,   0,   0,   0;
+            0,   0,   0,   0,   0,   0,   0,   0,   0
+        );
+        let dilated = dilate(&image, Norm::L2, 4);
+
+        let expected = gray_image!(
+              0,   0,   0,   0, 255,   0,   0,   0,   0;
+              0,   0, 255, 255, 255, 255, 255,   0,   0;
+              0, 255, 255, 255, 255, 255, 255, 255,   0;
+              0, 255, 255, 255, 255, 255, 255, 255,   0;
+            255, 255, 255, 255, 255, 255, 255, 255, 255;
+              0, 255, 255, 255, 255, 255, 255, 255,   0;
+              0, 255, 255, 255, 255, 255, 255, 255,   0;
+              0,   0, 255, 255, 255, 255, 255,   0,   0;
+              0,   0,   0,   0, 255,   0,   0,   0,   0
+        );
+
+        assert_pixels_eq!(dilated, expected);
+    }
+
+    #[test]
+    fn test_dilate_point_linf_0() {
+        let image = gray_image!(
+              0,   0,   0,   0,   0;
+              0,   0,   0,   0,   0;
+              0,   0, 255,   0,   0;
+              0,   0,   0,   0,   0;
+              0,   0,   0,   0,   0
+        );
+        let dilated = dilate(&image, Norm::LInf, 0);
+
+        let expected = image;
 
         assert_pixels_eq!(dilated, expected);
     }
@@ -416,6 +597,52 @@ mod tests {
     }
 
     #[test]
+    fn test_dilate_point_linf_4() {
+        let image = gray_image!(
+            0,   0,   0,   0,   0,   0,   0,   0,   0;
+            0,   0,   0,   0,   0,   0,   0,   0,   0;
+            0,   0,   0,   0,   0,   0,   0,   0,   0;
+            0,   0,   0,   0,   0,   0,   0,   0,   0;
+            0,   0,   0,   0, 255,   0,   0,   0,   0;
+            0,   0,   0,   0,   0,   0,   0,   0,   0;
+            0,   0,   0,   0,   0,   0,   0,   0,   0;
+            0,   0,   0,   0,   0,   0,   0,   0,   0;
+            0,   0,   0,   0,   0,   0,   0,   0,   0
+        );
+        let dilated = dilate(&image, Norm::LInf, 4);
+
+        let expected = gray_image!(
+            255, 255, 255, 255, 255, 255, 255, 255, 255;
+            255, 255, 255, 255, 255, 255, 255, 255, 255;
+            255, 255, 255, 255, 255, 255, 255, 255, 255;
+            255, 255, 255, 255, 255, 255, 255, 255, 255;
+            255, 255, 255, 255, 255, 255, 255, 255, 255;
+            255, 255, 255, 255, 255, 255, 255, 255, 255;
+            255, 255, 255, 255, 255, 255, 255, 255, 255;
+            255, 255, 255, 255, 255, 255, 255, 255, 255;
+            255, 255, 255, 255, 255, 255, 255, 255, 255
+        );
+
+        assert_pixels_eq!(dilated, expected);
+    }
+
+    #[test]
+    fn test_erode_point_l1_0() {
+        let image = gray_image!(
+              0,   0,   0,   0,   0;
+              0,   0,   0,   0,   0;
+              0,   0, 255,   0,   0;
+              0,   0,   0,   0,   0;
+              0,   0,   0,   0,   0
+        );
+        let eroded = erode(&image, Norm::L1, 0);
+
+        let expected = image;
+
+        assert_pixels_eq!(eroded, expected);
+    }
+
+    #[test]
     fn test_erode_point_l1_1() {
         let image = gray_image!(
               0,   0,   0,   0,   0;
@@ -433,6 +660,120 @@ mod tests {
               0,   0,   0,   0,   0;
               0,   0,   0,   0,   0
         );
+
+        assert_pixels_eq!(eroded, expected);
+    }
+
+    #[test]
+    fn test_erode_dented_wall_l1_4() {
+        let image = gray_image!(
+            255, 255, 255, 255, 255, 255, 255, 255,   0;
+            255, 255, 255, 255, 255, 255, 255, 255,   0;
+            255, 255, 255, 255, 255, 255, 255, 255,   0;
+            255, 255, 255, 255, 255, 255, 255, 255,   0;
+            255, 255, 255, 255, 255, 255,   0,   0,   0;
+            255, 255, 255, 255, 255, 255, 255, 255,   0;
+            255, 255, 255, 255, 255, 255, 255, 255,   0;
+            255, 255, 255, 255, 255, 255, 255, 255,   0;
+            255, 255, 255, 255, 255, 255, 255, 255,   0
+        );
+        let dilated = erode(&image, Norm::L1, 4);
+
+        let expected = gray_image!(
+            255, 255, 255, 255,   0,   0,   0,   0,   0;
+            255, 255, 255, 255,   0,   0,   0,   0,   0;
+            255, 255, 255, 255,   0,   0,   0,   0,   0;
+            255, 255, 255,   0,   0,   0,   0,   0,   0;
+            255, 255,   0,   0,   0,   0,   0,   0,   0;
+            255, 255, 255,   0,   0,   0,   0,   0,   0;
+            255, 255, 255, 255,   0,   0,   0,   0,   0;
+            255, 255, 255, 255,   0,   0,   0,   0,   0;
+            255, 255, 255, 255,   0,   0,   0,   0,   0
+        );
+
+        assert_pixels_eq!(dilated, expected);
+    }
+
+    #[test]
+    fn test_erode_point_l2_0() {
+        let image = gray_image!(
+              0,   0,   0,   0,   0;
+              0,   0,   0,   0,   0;
+              0,   0, 255,   0,   0;
+              0,   0,   0,   0,   0;
+              0,   0,   0,   0,   0
+        );
+        let eroded = erode(&image, Norm::L2, 0);
+
+        let expected = image;
+
+        assert_pixels_eq!(eroded, expected);
+    }
+
+    #[test]
+    fn test_erode_point_l2_1() {
+        let image = gray_image!(
+              0,   0,   0,   0,   0;
+              0,   0,   0,   0,   0;
+              0,   0, 255,   0,   0;
+              0,   0,   0,   0,   0;
+              0,   0,   0,   0,   0
+        );
+        let eroded = erode(&image, Norm::L2, 1);
+
+        let expected = gray_image!(
+              0,   0,   0,   0,   0;
+              0,   0,   0,   0,   0;
+              0,   0,   0,   0,   0;
+              0,   0,   0,   0,   0;
+              0,   0,   0,   0,   0
+        );
+
+        assert_pixels_eq!(eroded, expected);
+    }
+
+    #[test]
+    fn test_erode_dented_wall_l2_4() {
+        let image = gray_image!(
+            255, 255, 255, 255, 255, 255, 255, 255,   0;
+            255, 255, 255, 255, 255, 255, 255, 255,   0;
+            255, 255, 255, 255, 255, 255, 255, 255,   0;
+            255, 255, 255, 255, 255, 255, 255, 255,   0;
+            255, 255, 255, 255, 255, 255,   0,   0,   0;
+            255, 255, 255, 255, 255, 255, 255, 255,   0;
+            255, 255, 255, 255, 255, 255, 255, 255,   0;
+            255, 255, 255, 255, 255, 255, 255, 255,   0;
+            255, 255, 255, 255, 255, 255, 255, 255,   0
+        );
+        let dilated = erode(&image, Norm::L2, 4);
+
+        let expected = gray_image!(
+            255, 255, 255, 255,   0,   0,   0,   0,   0;
+            255, 255, 255, 255,   0,   0,   0,   0,   0;
+            255, 255, 255,   0,   0,   0,   0,   0,   0;
+            255, 255, 255,   0,   0,   0,   0,   0,   0;
+            255, 255,   0,   0,   0,   0,   0,   0,   0;
+            255, 255, 255,   0,   0,   0,   0,   0,   0;
+            255, 255, 255,   0,   0,   0,   0,   0,   0;
+            255, 255, 255, 255,   0,   0,   0,   0,   0;
+            255, 255, 255, 255,   0,   0,   0,   0,   0
+        );
+
+        assert_pixels_eq!(dilated, expected);
+    }
+
+    #[test]
+    fn test_erode_point_linf_0() {
+        let image = gray_image!(
+              0,   0,   0,   0,   0;
+              0,   0,   0,   0,   0;
+              0,   0, 255,   0,   0;
+              0,   0,   0,   0,   0;
+              0,   0,   0,   0,   0
+        );
+        let eroded = erode(&image, Norm::LInf, 0);
+
+        let expected = image;
 
         assert_pixels_eq!(eroded, expected);
     }
@@ -459,6 +800,36 @@ mod tests {
         assert_pixels_eq!(eroded, expected);
     }
 
+    #[test]
+    fn test_erode_dented_wall_linf_4() {
+        let image = gray_image!(
+            255, 255, 255, 255, 255, 255, 255, 255,   0;
+            255, 255, 255, 255, 255, 255, 255, 255,   0;
+            255, 255, 255, 255, 255, 255, 255, 255,   0;
+            255, 255, 255, 255, 255, 255, 255, 255,   0;
+            255, 255, 255, 255, 255, 255,   0,   0,   0;
+            255, 255, 255, 255, 255, 255, 255, 255,   0;
+            255, 255, 255, 255, 255, 255, 255, 255,   0;
+            255, 255, 255, 255, 255, 255, 255, 255,   0;
+            255, 255, 255, 255, 255, 255, 255, 255,   0
+        );
+        let dilated = erode(&image, Norm::LInf, 4);
+
+        let expected = gray_image!(
+            255, 255,   0,   0,   0,   0,   0,   0,   0;
+            255, 255,   0,   0,   0,   0,   0,   0,   0;
+            255, 255,   0,   0,   0,   0,   0,   0,   0;
+            255, 255,   0,   0,   0,   0,   0,   0,   0;
+            255, 255,   0,   0,   0,   0,   0,   0,   0;
+            255, 255,   0,   0,   0,   0,   0,   0,   0;
+            255, 255,   0,   0,   0,   0,   0,   0,   0;
+            255, 255,   0,   0,   0,   0,   0,   0,   0;
+            255, 255,   0,   0,   0,   0,   0,   0,   0
+        );
+
+        assert_pixels_eq!(dilated, expected);
+    }
+
     fn square() -> GrayImage {
         GrayImage::from_fn(500, 500, |x, y| {
             if min(x, y) > 100 && max(x, y) < 300 {
@@ -474,6 +845,15 @@ mod tests {
         let image = square();
         b.iter(|| {
             let dilated = dilate(&image, Norm::L1, 5);
+            black_box(dilated);
+        })
+    }
+
+    #[bench]
+    fn bench_dilate_l2_5(b: &mut Bencher) {
+        let image = square();
+        b.iter(|| {
+            let dilated = dilate(&image, Norm::L2, 5);
             black_box(dilated);
         })
     }


### PR DESCRIPTION
this PR has been made following the issue #314 : **Implement L2 Norm for morphology transforms**

this PR seeks to integrate the L2 Norm for morphology operation, by expanding the [`Norm`](https://docs.rs/imageproc/0.17.0/imageproc/distance_transform/enum.Norm.html) Enum to include L2, and updating all the functions which use this Enum to support the change.
before :
```rust
pub enum Norm {
    /// Defines d((x1, y1), (x2, y2)) to be abs(x1 - x2) + abs(y1 - y2).
    /// Also known as the Manhattan or city block norm.
    L1,
    /// Defines d((x1, y1), (x2, y2)) to be max(abs(x1 - x2), abs(y1 - y2)).
    /// Also known as the chessboard norm.
    LInf,
}
```
after:
```rust
pub enum Norm {
    /// Defines d((x1, y1), (x2, y2)) to be abs(x1 - x2) + abs(y1 - y2).
    /// Also known as the Manhattan or city block norm.
    L1,
    /// Defines d((x1, y1), (x2, y2)) to be sqrt((x1 - x2)^2 + (y1 - y2)^2).
    /// Also known as the euclidian norm.
    /// when working in integer distances, we take the smallest 
    /// greater integer value, also know as 'ceiling'
    /// example : d((0,0),(1,2)) = ceil(sqrt(1+2^2)) = ceil(2.236...) = 3
    L2,
    /// Defines d((x1, y1), (x2, y2)) to be max(abs(x1 - x2), abs(y1 - y2)).
    /// Also known as the chessboard norm.
    LInf,
}
```
on top of adding tests for the new norm, this PR also adds a couple tests for the other norms, in particular when [`erode`](https://docs.rs/imageproc/0.17.0/imageproc/morphology/fn.erode.html) and [`dilate`](https://docs.rs/imageproc/0.17.0/imageproc/morphology/fn.dilate.html) are called with a distance `k` of 0.
