### PR TITLE
Implemented thresholding with different types for binarization in the…

### DIFF
--- a/src/contrast.rs
+++ b/src/contrast.rs
@@ -100,7 +100,8 @@ pub fn otsu_level(image: &GrayImage) -> u8 {
 }
 
 /// type of the threshold operation, corresponding to opencv threshold type
-/// https://docs.opencv.org/4.x/d7/d1b/group__imgproc__misc.html#gaa9e58d2860d4afa658ef70a9b1115576
+///
+/// `<https://docs.opencv.org/4.x/d7/d1b/group__imgproc__misc.html#gaa9e58d2860d4afa658ef70a9b1115576>`
 pub enum ThresholdType {
     /// `dst(x,y) = maxval if src(x,y) > thresh else 0`
     ThreshBinary,
@@ -254,9 +255,9 @@ pub fn equalize_histogram_mut(image: &mut GrayImage) {
     let total = hist[255] as f32;
 
     #[cfg(feature = "rayon")]
-        let iter = image.par_iter_mut();
+    let iter = image.par_iter_mut();
     #[cfg(not(feature = "rayon"))]
-        let iter = image.iter_mut();
+    let iter = image.iter_mut();
 
     iter.for_each(|p| {
         // JUSTIFICATION
@@ -579,7 +580,11 @@ mod tests {
     #[test]
     fn test_threshold_threshold_255_image_255() {
         let expected = 0u8;
-        let actual = threshold(&constant_image(10, 10, 255), 255, ThresholdType::ThreshBinary);
+        let actual = threshold(
+            &constant_image(10, 10, 255),
+            255,
+            ThresholdType::ThreshBinary,
+        );
         assert_pixels_eq!(actual, constant_image(10, 10, expected));
     }
 

--- a/src/region_labelling.rs
+++ b/src/region_labelling.rs
@@ -1,10 +1,11 @@
 //! Functions for finding and labelling connected components of an image.
 
+use std::cmp;
+
 use image::{GenericImage, GenericImageView, ImageBuffer, Luma};
 
 use crate::definitions::Image;
 use crate::union_find::DisjointSetForest;
-use std::cmp;
 
 /// Determines which neighbors of a pixel we consider
 /// to be connected to it.
@@ -105,7 +106,7 @@ pub enum Connectivity {
 /// use imageproc::contrast::{threshold, ThresholdType};
 ///
 /// // Pixels equal to the threshold are treated as background.
-/// let thresholded = threshold(&image, 0,ThresholdType::ThreshBinary);
+/// let thresholded = threshold(&image, 0,ThresholdType::Binary);
 ///
 /// let thresholded_components_four = gray_image!(type: u32,
 ///     1, 0, 2, 2;
@@ -246,13 +247,16 @@ where
 mod tests {
     extern crate wasm_bindgen_test;
 
-    use super::connected_components;
-    use super::Connectivity::{Eight, Four};
-    use crate::definitions::{HasBlack, HasWhite};
     use ::test;
+
     use image::{GrayImage, ImageBuffer, Luma};
     #[cfg(target_arch = "wasm32")]
     use wasm_bindgen_test::*;
+
+    use crate::definitions::{HasBlack, HasWhite};
+
+    use super::connected_components;
+    use super::Connectivity::{Eight, Four};
 
     #[cfg_attr(not(target_arch = "wasm32"), test)]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]

--- a/src/region_labelling.rs
+++ b/src/region_labelling.rs
@@ -102,10 +102,10 @@ pub enum Connectivity {
 ///
 /// // If this behaviour is not what you want then you can first
 /// // threshold the input image.
-/// use imageproc::contrast::threshold;
+/// use imageproc::contrast::{threshold, ThresholdType};
 ///
 /// // Pixels equal to the threshold are treated as background.
-/// let thresholded = threshold(&image, 0);
+/// let thresholded = threshold(&image, 0,ThresholdType::ThreshBinary);
 ///
 /// let thresholded_components_four = gray_image!(type: u32,
 ///     1, 0, 2, 2;

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -13,10 +13,13 @@
 #[macro_use]
 extern crate imageproc;
 
+use std::{env, f32, path::Path};
+
 use image::{
     DynamicImage, GrayImage, ImageBuffer, Luma, Pixel, PixelWithColorType, Rgb, RgbImage, Rgba,
     RgbaImage,
 };
+
 use imageproc::contrast::ThresholdType;
 use imageproc::{
     definitions::{Clamp, HasBlack, HasWhite},
@@ -26,7 +29,6 @@ use imageproc::{
     gradients,
     utils::load_image_or_panic,
 };
-use std::{env, f32, path::Path};
 
 /// The directory containing the input images used in regression tests.
 const INPUT_DIR: &str = "./tests/data";
@@ -239,11 +241,10 @@ fn test_affine_nearest_rgb() {
         let root_two_inv = 1f32 / 2f32.sqrt() * 2.0;
         #[rustfmt::skip]
             let hom = Projection::from_matrix([
-            root_two_inv, -root_two_inv, 50.0,
-            root_two_inv, root_two_inv, -70.0,
-            0.0, 0.0, 1.0,
-        ])
-            .unwrap();
+            root_two_inv, -root_two_inv,  50.0,
+            root_two_inv,  root_two_inv, -70.0,
+                     0.0,           0.0,   1.0,
+        ]).unwrap();
         warp(image, &hom, Interpolation::Nearest, Rgb::black())
     }
     compare_to_truth(
@@ -367,7 +368,7 @@ fn test_otsu_threshold() {
     use imageproc::contrast::{otsu_level, threshold};
     fn otsu_threshold(image: &GrayImage) -> GrayImage {
         let level = otsu_level(image);
-        threshold(image, level, ThresholdType::ThreshBinary)
+        threshold(image, level, ThresholdType::Binary)
     }
     compare_to_truth("zebra.png", "zebra_otsu.png", otsu_threshold);
 }

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -26,6 +26,7 @@ use imageproc::{
     utils::load_image_or_panic,
 };
 use std::{env, f32, path::Path};
+use imageproc::contrast::ThresholdType;
 
 /// The directory containing the input images used in regression tests.
 const INPUT_DIR: &str = "./tests/data";
@@ -63,10 +64,10 @@ impl FromDynamic for RgbaImage {
 
 /// Loads an input image, applies a function to it and checks that the result matches a 'truth' image.
 fn compare_to_truth<P, F>(input_file_name: &str, truth_file_name: &str, op: F)
-where
-    P: Pixel<Subpixel = u8> + PixelWithColorType,
-    ImageBuffer<P, Vec<u8>>: FromDynamic,
-    F: Fn(&ImageBuffer<P, Vec<u8>>) -> ImageBuffer<P, Vec<u8>>,
+    where
+        P: Pixel<Subpixel=u8> + PixelWithColorType,
+        ImageBuffer<P, Vec<u8>>: FromDynamic,
+        F: Fn(&ImageBuffer<P, Vec<u8>>) -> ImageBuffer<P, Vec<u8>>,
 {
     compare_to_truth_with_tolerance(input_file_name, truth_file_name, op, 0u8);
 }
@@ -79,7 +80,7 @@ fn compare_to_truth_with_tolerance<P, F>(
     op: F,
     tol: u8,
 ) where
-    P: Pixel<Subpixel = u8> + PixelWithColorType,
+    P: Pixel<Subpixel=u8> + PixelWithColorType,
     ImageBuffer<P, Vec<u8>>: FromDynamic,
     F: Fn(&ImageBuffer<P, Vec<u8>>) -> ImageBuffer<P, Vec<u8>>,
 {
@@ -92,9 +93,9 @@ fn compare_to_truth_with_tolerance<P, F>(
 
 /// Checks that an image matches a 'truth' image.
 fn compare_to_truth_image<P>(actual: &ImageBuffer<P, Vec<u8>>, truth_file_name: &str)
-where
-    P: Pixel<Subpixel = u8> + PixelWithColorType,
-    ImageBuffer<P, Vec<u8>>: FromDynamic,
+    where
+        P: Pixel<Subpixel=u8> + PixelWithColorType,
+        ImageBuffer<P, Vec<u8>>: FromDynamic,
 {
     compare_to_truth_image_with_tolerance(actual, truth_file_name, 0u8);
 }
@@ -105,7 +106,7 @@ fn compare_to_truth_image_with_tolerance<P>(
     truth_file_name: &str,
     tol: u8,
 ) where
-    P: Pixel<Subpixel = u8> + PixelWithColorType,
+    P: Pixel<Subpixel=u8> + PixelWithColorType,
     ImageBuffer<P, Vec<u8>>: FromDynamic,
 {
     if should_regenerate() {
@@ -237,12 +238,12 @@ fn test_affine_nearest_rgb() {
     fn affine_nearest(image: &RgbImage) -> RgbImage {
         let root_two_inv = 1f32 / 2f32.sqrt() * 2.0;
         #[rustfmt::skip]
-        let hom = Projection::from_matrix([
-            root_two_inv, -root_two_inv,  50.0,
-            root_two_inv,  root_two_inv, -70.0,
-                     0.0,           0.0,   1.0,
+            let hom = Projection::from_matrix([
+            root_two_inv, -root_two_inv, 50.0,
+            root_two_inv, root_two_inv, -70.0,
+            0.0, 0.0, 1.0,
         ])
-        .unwrap();
+            .unwrap();
         warp(image, &hom, Interpolation::Nearest, Rgb::black())
     }
     compare_to_truth(
@@ -257,12 +258,12 @@ fn test_affine_bilinear_rgb() {
     fn affine_bilinear(image: &RgbImage) -> RgbImage {
         let root_two_inv = 1f32 / 2f32.sqrt() * 2.0;
         #[rustfmt::skip]
-        let hom = Projection::from_matrix([
-            root_two_inv, -root_two_inv,  50.0,
-            root_two_inv,  root_two_inv, -70.0,
-                     0.0,           0.0,   1.0,
+            let hom = Projection::from_matrix([
+            root_two_inv, -root_two_inv, 50.0,
+            root_two_inv, root_two_inv, -70.0,
+            0.0, 0.0, 1.0,
         ])
-        .unwrap();
+            .unwrap();
 
         warp(image, &hom, Interpolation::Bilinear, Rgb::black())
     }
@@ -279,10 +280,10 @@ fn test_affine_bicubic_rgb() {
     fn affine_bilinear(image: &RgbImage) -> RgbImage {
         let root_two_inv = 1f32 / 2f32.sqrt() * 2.0;
         #[rustfmt::skip]
-        let hom = Projection::from_matrix([
-            root_two_inv, -root_two_inv,  50.0,
-            root_two_inv,  root_two_inv, -70.0,
-            0.0         , 0.0          , 1.0,
+            let hom = Projection::from_matrix([
+            root_two_inv, -root_two_inv, 50.0,
+            root_two_inv, root_two_inv, -70.0,
+            0.0, 0.0, 1.0,
         ]).unwrap();
 
         warp(image, &hom, Interpolation::Bicubic, Rgb::black())
@@ -366,7 +367,7 @@ fn test_otsu_threshold() {
     use imageproc::contrast::{otsu_level, threshold};
     fn otsu_threshold(image: &GrayImage) -> GrayImage {
         let level = otsu_level(image);
-        threshold(image, level)
+        threshold(image, level, ThresholdType::ThreshBinary)
     }
     compare_to_truth("zebra.png", "zebra_otsu.png", otsu_threshold);
 }

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -17,6 +17,7 @@ use image::{
     DynamicImage, GrayImage, ImageBuffer, Luma, Pixel, PixelWithColorType, Rgb, RgbImage, Rgba,
     RgbaImage,
 };
+use imageproc::contrast::ThresholdType;
 use imageproc::{
     definitions::{Clamp, HasBlack, HasWhite},
     edges::canny,
@@ -26,7 +27,6 @@ use imageproc::{
     utils::load_image_or_panic,
 };
 use std::{env, f32, path::Path};
-use imageproc::contrast::ThresholdType;
 
 /// The directory containing the input images used in regression tests.
 const INPUT_DIR: &str = "./tests/data";
@@ -64,10 +64,10 @@ impl FromDynamic for RgbaImage {
 
 /// Loads an input image, applies a function to it and checks that the result matches a 'truth' image.
 fn compare_to_truth<P, F>(input_file_name: &str, truth_file_name: &str, op: F)
-    where
-        P: Pixel<Subpixel=u8> + PixelWithColorType,
-        ImageBuffer<P, Vec<u8>>: FromDynamic,
-        F: Fn(&ImageBuffer<P, Vec<u8>>) -> ImageBuffer<P, Vec<u8>>,
+where
+    P: Pixel<Subpixel = u8> + PixelWithColorType,
+    ImageBuffer<P, Vec<u8>>: FromDynamic,
+    F: Fn(&ImageBuffer<P, Vec<u8>>) -> ImageBuffer<P, Vec<u8>>,
 {
     compare_to_truth_with_tolerance(input_file_name, truth_file_name, op, 0u8);
 }
@@ -80,7 +80,7 @@ fn compare_to_truth_with_tolerance<P, F>(
     op: F,
     tol: u8,
 ) where
-    P: Pixel<Subpixel=u8> + PixelWithColorType,
+    P: Pixel<Subpixel = u8> + PixelWithColorType,
     ImageBuffer<P, Vec<u8>>: FromDynamic,
     F: Fn(&ImageBuffer<P, Vec<u8>>) -> ImageBuffer<P, Vec<u8>>,
 {
@@ -93,9 +93,9 @@ fn compare_to_truth_with_tolerance<P, F>(
 
 /// Checks that an image matches a 'truth' image.
 fn compare_to_truth_image<P>(actual: &ImageBuffer<P, Vec<u8>>, truth_file_name: &str)
-    where
-        P: Pixel<Subpixel=u8> + PixelWithColorType,
-        ImageBuffer<P, Vec<u8>>: FromDynamic,
+where
+    P: Pixel<Subpixel = u8> + PixelWithColorType,
+    ImageBuffer<P, Vec<u8>>: FromDynamic,
 {
     compare_to_truth_image_with_tolerance(actual, truth_file_name, 0u8);
 }
@@ -106,7 +106,7 @@ fn compare_to_truth_image_with_tolerance<P>(
     truth_file_name: &str,
     tol: u8,
 ) where
-    P: Pixel<Subpixel=u8> + PixelWithColorType,
+    P: Pixel<Subpixel = u8> + PixelWithColorType,
     ImageBuffer<P, Vec<u8>>: FromDynamic,
 {
     if should_regenerate() {


### PR DESCRIPTION
… imageproc library. Added enum `ThresholdType` to represent the threshold operation corresponding to OpenCV threshold types. Updated functions `threshold` and `threshold_mut` to take `ThresholdType` as a parameter for specifying the type of thresholding operation. Added tests and benchmarks for the new functionality. #574 