### PR TITLE
Match template with alpha

### DIFF
--- a/src/template_matching.rs
+++ b/src/template_matching.rs
@@ -1,5 +1,5 @@
 //! Functions for performing template matching.
-use crate::definitions::Image;
+use crate::{definitions::Image, drawing::Canvas};
 use image::{GenericImageView, GrayImage, Luma, Primitive};
 
 /// Method used to compute the matching score between a template and an image region.
@@ -392,6 +392,8 @@ impl<'a> ImageTemplate<'a> {
     }
     unsafe fn slide_window_at(&self, (x, y): (u32, u32), mut for_each: impl FnMut(f32, f32)) {
         let (image, template) = (self.image, self.template);
+        debug_assert!(x + template.width() - 1 < image.width());
+        debug_assert!(y + template.height() - 1 < image.height());
 
         for dy in 0..template.height() {
             for dx in 0..template.width() {
@@ -427,6 +429,8 @@ impl<'a> ImageTemplateMask<'a> {
     unsafe fn slide_window_at(&self, (x, y): (u32, u32), mut for_each: impl FnMut(f32, f32, f32)) {
         let Self { mask, inner } = self;
         let (image, template) = (inner.image, inner.template);
+        debug_assert!(x + template.width() - 1 < image.width());
+        debug_assert!(y + template.height() - 1 < image.height());
 
         for dy in 0..template.height() {
             for dx in 0..template.width() {

--- a/src/template_matching.rs
+++ b/src/template_matching.rs
@@ -497,7 +497,6 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use image::GrayImage;
 
     #[test]
     #[should_panic]

--- a/src/template_matching.rs
+++ b/src/template_matching.rs
@@ -1,5 +1,5 @@
 //! Functions for performing template matching.
-use crate::{definitions::Image, drawing::Canvas};
+use crate::definitions::Image;
 use image::{GenericImageView, GrayImage, Luma, Primitive};
 
 /// Method used to compute the matching score between a template and an image region.


### PR DESCRIPTION
Very quick-and-dirty proposal for `match_template_with_alpha`, a variant of `match_template_with_mask` that accepts a `GrayImage` (i.e. a template "blended" with its mask) rather than a separate mask.

That's useful because it is a turnkey function that one can call after `image::open`ing a PNG template file.
However, this requires copying the template, then calling `slide_window_at` on separate buffers. I'm not sure how much more efficient it would be to re-implement a `slide_window_at` specifically for this case... Do you think that would be overkill?

**Depends on https://github.com/image-rs/imageproc/pull/568 being merged first**