### PR TITLE
Rebased and Refactored #471 + `range()` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 Changes:
 - `contrast::stretch_contrast{_mut}` had been extended and renamed to `contrast::scale_linear{_mut}`
 
+Added:
+- Added a new `min_max()` function and `MinMax` return struct for finding the
+  minimum and maximum value pixel in an image
+
 ## [0.24.0] - 2024-03-16
 
 New features:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Unreleased
+
+Changes:
+- `contrast::stretch_contrast{_mut}` had been extended and renamed to `contrast::scale_linear{_mut}`
+
 ## [0.24.0] - 2024-03-16
 
 New features:

--- a/examples/color_effects.rs
+++ b/examples/color_effects.rs
@@ -1,6 +1,6 @@
 //! Demonstrates adding a color tint and applying a color gradient to a grayscale image.
 
-use image::{open, Luma, Rgb};
+use image::{GrayImage, Luma, Rgb, open};
 use imageproc::map::map_colors;
 use imageproc::pixelops::weighted_sum;
 use std::env;
@@ -53,4 +53,7 @@ fn main() {
     let yellow = Rgb([255u8, 255u8, 0u8]);
     let gradient = map_colors(&image, |pix| color_gradient(pix, black, red, yellow));
     gradient.save(path.with_file_name("gradient.png")).unwrap();
+
+    let c = GrayImage::from_pixel(100, 100, Luma([50]));
+
 }

--- a/examples/color_effects.rs
+++ b/examples/color_effects.rs
@@ -1,6 +1,6 @@
 //! Demonstrates adding a color tint and applying a color gradient to a grayscale image.
 
-use image::{GrayImage, Luma, Rgb, open};
+use image::{open, Luma, Rgb};
 use imageproc::map::map_colors;
 use imageproc::pixelops::weighted_sum;
 use std::env;
@@ -53,7 +53,4 @@ fn main() {
     let yellow = Rgb([255u8, 255u8, 0u8]);
     let gradient = map_colors(&image, |pix| color_gradient(pix, black, red, yellow));
     gradient.save(path.with_file_name("gradient.png")).unwrap();
-
-    let c = GrayImage::from_pixel(100, 100, Luma([50]));
-
 }

--- a/src/contrast.rs
+++ b/src/contrast.rs
@@ -266,6 +266,59 @@ pub fn equalize_histogram(image: &GrayImage) -> GrayImage {
     out
 }
 
+/// Normalizes contrast of image such that pixel brightness (Min,Max) maps to (new_Min,new_Max)
+/// if (Min,Max) of current image is (0,255) image is unchanged
+pub fn normalize_linear(image: &mut GrayImage, new_min:u8, new_max:u8) {
+    let mut min = u8::MAX;
+    let mut max = u8::MIN;
+    for y in 0..image.height(){
+        for x in 0..image.width(){
+            let current_pixel = image.get_pixel(x, y);
+            let brightness= current_pixel.0[0];
+            if brightness < min{
+                min = brightness;
+            }
+            if brightness > max {
+                max = brightness;
+            }
+        }
+    }
+    if min == u8::MIN && max == u8::MAX {
+        return ;
+    }
+    let fraction = (new_max-new_min)/(max-min);
+
+    for y in 0..image.height(){
+        for x in 0..image.width(){
+            let current_pixel = image.get_pixel_mut(x, y);
+            current_pixel.0[0]= ((current_pixel.0[0] - min ) * fraction) + new_min;
+        }
+    }
+}
+
+/// Normalizes contrast of original such that pixel brightness (Min,Max) maps to (new_Min,new_Max)
+/// Where alpha (α) defines the width of the input intensity range, and beta (β) defines the intensity around which the range is centered
+pub fn normalize_non_linear(image: &mut GrayImage, new_min:u8, new_max:u8, alpha: u8, beta:u8) {
+    let mut min = u8::MAX;
+    let mut max = u8::MIN;
+    for y in 0..image.height(){
+        for x in 0..image.width(){
+            let current_pixel = image.get_pixel(x, y);
+            let brightness= current_pixel.0[0];
+            if brightness < min{
+                min = brightness;
+            }
+            if brightness > max {
+                max = brightness;
+            }
+        }
+    }
+
+    todo!("implement function ")
+}
+
+
+
 /// Adjusts contrast of an 8bpp grayscale image in place so that its
 /// histogram is as close as possible to that of the target image.
 pub fn match_histogram_mut(image: &mut GrayImage, target: &GrayImage) {

--- a/src/contrast.rs
+++ b/src/contrast.rs
@@ -271,15 +271,15 @@ pub fn equalize_histogram(image: &GrayImage) -> GrayImage {
 /// pair to the output_min and output_max pair.
 ///
 /// # Example
-/// (50, 100) -> (0, 255) would make 8 -> 0 since it saturates outside the `u8` range.
-/// 200 -> 255 since it also saturates outside the `u8` range.
+/// (50, 100) -> (0, 255) would make 8 -> 0 since it saturates outside the input range as 8 < 50.
+/// 200 -> 255 since it also saturates outside the input range as 200 > 100.
 /// 50 -> 0, and 100 -> 255 by definition of the scaling pairs.
 /// All values between 50 and 100 are then linearly interpolated into the output range.
 /// Such as 75 -> 128
 ///
 ///
 /// # Panic
-/// This function panics if `input_min` > `input_max` or `output_min` > `output_max`.
+/// This function panics if `input_min` >= `input_max` or `output_min` > `output_max`.
 pub fn scale_linear(
     image: &GrayImage,
     input_min: u8,
@@ -296,8 +296,8 @@ pub fn scale_linear(
 /// pair to the output_min and output_max pair.
 ///
 /// # Example
-/// (50, 100) -> (0, 255) would make 8 -> 0 since it saturates outside the `u8` range.
-/// 200 -> 255 since it also saturates outside the `u8` range.
+/// (50, 100) -> (0, 255) would make 8 -> 0 since it saturates outside the input range as 8 < 50.
+/// 200 -> 255 since it also saturates outside the input range as 200 > 100.
 /// 50 -> 0, and 100 -> 255 by definition of the scaling pairs.
 /// All values between 50 and 100 are then linearly interpolated into the output range.
 /// Such as 75 -> 128

--- a/src/contrast.rs
+++ b/src/contrast.rs
@@ -266,25 +266,28 @@ pub fn equalize_histogram(image: &GrayImage) -> GrayImage {
     out
 }
 
-
-
-/// Normalizes contrast of image in place, such that pixel brightness (Min,Max) maps to (new_Min,new_Max)
+/// Normalizes contrast of a Grayscale image image in place such that pixel brightness (Min,Max) maps to (new_Min,new_Max)
 /// See also  [Normalizes Equalization (wikipedia)] https://en.wikipedia.org/wiki/Normalization_(image_processing)
-pub fn normalize_linear(image: GrayImage, new_min:u8, new_max:u8) -> GrayImage {
+pub fn normalize_linear(image: GrayImage, new_min: u8, new_max: u8) -> GrayImage {
     let mut out = image.clone();
-    normalize_linear_mut(&mut out,new_min, new_max);
+    normalize_linear_mut(&mut out, new_min, new_max);
     out
 }
-/// Normalizes contrast of image such that pixel brightness (Min,Max) maps to (new_Min,new_Max)
-pub fn normalize_linear_mut(image: &mut GrayImage, new_min:u8, new_max:u8) {
-    assert!(new_max > new_min, "new_max must be strictly greater than new_min");
+
+/// Normalizes contrast of a Grayscale image such that pixel brightness (Min,Max) maps to (new_Min,new_Max)
+/// See also  [Normalizes Equalization (wikipedia)] https://en.wikipedia.org/wiki/Normalization_(image_processing)
+pub fn normalize_linear_mut(image: &mut GrayImage, new_min: u8, new_max: u8) {
+    assert!(
+        new_max > new_min,
+        "new_max must be strictly greater than new_min"
+    );
     let mut min = u8::MAX;
     let mut max = u8::MIN;
-    for y in 0..image.height(){
-        for x in 0..image.width(){
+    for y in 0..image.height() {
+        for x in 0..image.width() {
             let current_pixel = image.get_pixel(x, y);
-            let brightness= current_pixel.0[0];
-            if brightness < min{
+            let brightness = current_pixel.0[0];
+            if brightness < min {
                 min = brightness;
             }
             if brightness > max {
@@ -292,34 +295,55 @@ pub fn normalize_linear_mut(image: &mut GrayImage, new_min:u8, new_max:u8) {
             }
         }
     }
-    let fraction = (new_max-new_min) as f64/(max-min) as f64;
-    for y in 0..image.height(){
-        for x in 0..image.width(){
+    let fraction = (new_max - new_min) as f64 / (max - min) as f64;
+    for y in 0..image.height() {
+        for x in 0..image.width() {
             let current_pixel = image.get_pixel_mut(x, y);
-            let new_value =  ((current_pixel.0[0] - min ) as f64 * fraction) + new_min as f64;
+            let new_value = ((current_pixel.0[0] - min) as f64 * fraction) + new_min as f64;
             current_pixel.0[0] = new_value as u8;
         }
     }
 }
 
-
-/// Normalizes contrast of original such that pixel brightness (Min,Max) maps to (new_Min,new_Max)
+/// Normalizes contrast of grayscale image such that pixel brightness (Min,Max) maps to (new_Min,new_Max)
 /// Where alpha (α) defines the width of the input intensity range, and beta (β) defines the intensity around which the range is centered
-pub fn normalize_non_linear(image: &mut GrayImage, new_min:u8, new_max:u8, alpha: f64, beta:f64) {
+/// See also  [Normalizes Equalization (wikipedia)] https://en.wikipedia.org/wiki/Normalization_(image_processing)
+pub fn normalize_non_linear(
+    image: &GrayImage,
+    new_min: u8,
+    new_max: u8,
+    alpha: f64,
+    beta: f64,
+) -> GrayImage {
+    let mut out = image.clone();
+    normalize_non_linear_mut(&mut out, new_min, new_max, alpha, beta);
+    out
+}
+
+/// Normalizes contrast of grayscale image in place such that pixel brightness (Min,Max) maps to (new_Min,new_Max)
+/// Where alpha (α) defines the width of the input intensity range, and beta (β) defines the intensity around which the range is centered
+/// See also  [Normalizes Equalization (wikipedia)] https://en.wikipedia.org/wiki/Normalization_(image_processing)
+pub fn normalize_non_linear_mut(
+    image: &mut GrayImage,
+    new_min: u8,
+    new_max: u8,
+    alpha: f64,
+    beta: f64,
+) {
+    let new_min = new_min as f64;
+    let new_max = new_max as f64;
     use std::f64::consts::E;
-    for y in 0..image.height(){
-        for x in 0..image.width(){
+    for y in 0..image.height() {
+        for x in 0..image.width() {
             let current_pixel = image.get_pixel_mut(x, y);
             let px = current_pixel.0[0] as f64;
-            let exp = -(px-beta)/alpha;
-            let denom = 1f64+E.powf(exp);
-            let i_x= (new_max -new_min )*((1f64/denom) as u8)+new_min;
-            current_pixel.0[0] = i_x;
+            let exp = -(px - beta) / alpha;
+            let denom = 1f64 + E.powf(exp);
+            let i_x = (new_max - new_min) * (1f64 / denom) + new_min;
+            current_pixel.0[0] = i_x as u8;
         }
     }
 }
-
-
 
 /// Adjusts contrast of an 8bpp grayscale image in place so that its
 /// histogram is as close as possible to that of the target image.
@@ -439,6 +463,8 @@ mod tests {
     use crate::definitions::{HasBlack, HasWhite};
     use crate::utils::gray_bench_image;
     use image::{GrayImage, Luma};
+    use itertools::Itertools;
+    use test::{black_box, Bencher};
 
     #[test]
     fn adaptive_threshold_constant() {
@@ -641,13 +667,29 @@ mod benches {
 
     #[test]
     fn test_normalize() {
-        let mut const_min = gray_bench_image(4,4);
-        let buf= vec![10, 28, 46, 65, 28, 46, 65, 83, 46, 65, 83, 101, 65, 83, 101, 120];
+        let mut const_min = gray_bench_image(4, 4);
+        let buf = vec![
+            10, 28, 46, 65, 28, 46, 65, 83, 46, 65, 83, 101, 65, 83, 101, 120,
+        ];
         normalize_linear_mut(&mut const_min, 10, 120);
         let const_min_expected = GrayImage::from_vec(4, 4, buf).unwrap();
-        assert_eq!(const_min,const_min_expected);
-        // assert_eq!(,);
-        // assert_eq!(,);
+        assert_eq!(const_min, const_min_expected);
+    }
+
+    #[test]
+    fn test_normalize_non_linear() {
+        let input = (70..134).collect_vec();
+        let mut const_min = GrayImage::from_vec(8, 8, input).unwrap();
+        normalize_non_linear_mut(&mut const_min, 20, 130, 13.0, 100.0);
+
+        let buf = vec![
+            29, 30, 31, 32, 33, 34, 34, 36, 37, 38, 39, 40, 42, 43, 44, 46, 47, 49, 51, 53, 54, 56,
+            58, 60, 62, 64, 66, 68, 70, 72, 75, 77, 79, 81, 83, 85, 87, 89, 91, 93, 95, 96, 98,
+            100, 102, 103, 105, 106, 107, 109, 110, 111, 112, 113, 115, 115, 116, 117, 118, 119,
+            120, 120, 121, 121,
+        ];
+        let const_min_expected = GrayImage::from_vec(8, 8, buf).unwrap();
+        assert_eq!(const_min, const_min_expected);
     }
 
     #[bench]

--- a/src/edges.rs
+++ b/src/edges.rs
@@ -1,8 +1,7 @@
 //! Functions for detecting edges in images.
 
-use crate::contrast;
 use crate::definitions::{HasBlack, HasWhite};
-use crate::filter::{gaussian_blur_f32, laplacian_filter};
+use crate::filter::gaussian_blur_f32;
 use crate::gradients::{horizontal_sobel, vertical_sobel};
 use image::{GenericImageView, GrayImage, ImageBuffer, Luma};
 use std::f32;

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -4,7 +4,7 @@ use crate::definitions::Image;
 use image::{GenericImageView, GrayImage, Pixel, Primitive};
 use num::Bounded;
 
-/// A minimum and maximum value returned by [`minmax()`]
+/// A minimum and maximum value returned by [`min_max()`]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MinMax<T> {
     /// The minimum value
@@ -14,7 +14,7 @@ pub struct MinMax<T> {
 }
 
 /// Returns the minimum and maximum values per channel in an image.
-pub fn minmax<P, T>(image: &Image<P>) -> Vec<MinMax<T>>
+pub fn min_max<P, T>(image: &Image<P>) -> Vec<MinMax<T>>
 where
     P: Pixel<Subpixel = T>,
     T: Ord + Copy,
@@ -209,7 +209,7 @@ mod tests {
         );
 
         assert_eq!(
-            minmax(&image),
+            min_max(&image),
             vec![
                 MinMax { min: 1, max: 3 },
                 MinMax { min: 10, max: 30 },

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -5,15 +5,17 @@ use image::{GenericImageView, GrayImage, Pixel, Primitive};
 use itertools::Itertools;
 use num::Bounded;
 
-/// A range returned by [`range()`]
+/// A minimum and maximum value returned by [`minmax()`]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct Range<T> {
-    min: T,
-    max: T,
+pub struct MinMax<T> {
+    /// The minimum value
+    pub min: T,
+    /// The maximum value
+    pub max: T,
 }
 
-/// Returns the maxixum and minimum values per channel in an image.
-pub fn range<P, T>(image: &Image<P>) -> Vec<Range<T>>
+/// Returns the minimum and maximum values per channel in an image.
+pub fn minmax<P, T>(image: &Image<P>) -> Vec<MinMax<T>>
 where
     P: Pixel<Subpixel = T>,
     T: Ord + Copy,
@@ -39,7 +41,7 @@ where
 
     ranges
         .into_iter()
-        .map(|(min, max)| Range {
+        .map(|(min, max)| MinMax {
             min: *min.unwrap(),
             max: *max.unwrap(),
         })
@@ -208,11 +210,11 @@ mod tests {
         );
 
         assert_eq!(
-            range(&image),
+            minmax(&image),
             vec![
-                Range { min: 1, max: 3 },
-                Range { min: 10, max: 30 },
-                Range { min: 0, max: 255 }
+                MinMax { min: 1, max: 3 },
+                MinMax { min: 10, max: 30 },
+                MinMax { min: 0, max: 255 }
             ]
         )
     }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -2,7 +2,6 @@
 
 use crate::definitions::Image;
 use image::{GenericImageView, GrayImage, Pixel, Primitive};
-use itertools::Itertools;
 use num::Bounded;
 
 /// A minimum and maximum value returned by [`minmax()`]


### PR DESCRIPTION
I'm working through testing/reviewing all the PRs currently.

This PR is a rebase+refactor of #471. #471 seems like a fairly standard and objective image processing function. I've refactored it to use `map()` as well as adding a `range()` function to the `stats.rs` module which is used in `normalize_linear()`.

I also refactored the tests and added benches for the new normalize functions.

Merging this would close #471 and #470.