### PR TITLE
Gradients, Filter and Kernel Refactor

### DIFF
--- a/examples/gradients.rs
+++ b/examples/gradients.rs
@@ -4,29 +4,29 @@
 //!
 //! `cargo run --example gradients ./examples/empire-state-building.jpg ./tmp`
 
-use image::{open, GrayImage, Luma};
-use imageproc::{
-    definitions::Image,
-    gradients::{
-        horizontal_prewitt, horizontal_scharr, horizontal_sobel, vertical_prewitt, vertical_scharr,
-        vertical_sobel,
-    },
-    map::map_pixels,
-};
+use image::{open, GrayImage};
+use imageproc::{filter::filter3x3, gradients::GradientKernel, map::map_subpixels};
 use std::{env, fs, path::Path};
 
-fn compute_gradients<F>(
+fn save_gradients(
     input: &GrayImage,
-    gradient_func: F,
+    gradient_kernel: &GradientKernel,
     output_dir: &Path,
-    file_name: &str,
+    name: &str,
     scale: i16,
-) where
-    F: Fn(&GrayImage) -> Image<Luma<i16>>,
-{
-    let gradient = gradient_func(input);
-    let gradient = map_pixels(&gradient, |_, _, p| Luma([(p[0].abs() / scale) as u8]));
-    gradient.save(&output_dir.join(file_name)).unwrap();
+) {
+    let horizontal_gradients = filter3x3(input, &gradient_kernel.as_horizontal_kernel::<i16>());
+    let vertical_gradients = filter3x3(input, &gradient_kernel.as_vertical_kernel::<i16>());
+
+    let horizontal_scaled = map_subpixels(&horizontal_gradients, |p: i16| (p.abs() / scale) as u8);
+    let vertical_scaled = map_subpixels(&vertical_gradients, |p: i16| (p.abs() / scale) as u8);
+
+    horizontal_scaled
+        .save(&output_dir.join(format!("{name}_horizontal.png")))
+        .unwrap();
+    vertical_scaled
+        .save(&output_dir.join(format!("{name}_horizontal.png")))
+        .unwrap();
 }
 
 fn main() {
@@ -57,46 +57,20 @@ fn main() {
     let gray_path = output_dir.join("grey.png");
     input_image.save(&gray_path).unwrap();
 
-    compute_gradients(
-        &input_image,
-        horizontal_scharr,
-        output_dir,
-        "horizontal_scharr.png",
-        32,
-    );
-    compute_gradients(
-        &input_image,
-        vertical_scharr,
-        output_dir,
-        "vertical_scharr.png",
-        32,
-    );
-    compute_gradients(
-        &input_image,
-        horizontal_sobel,
-        output_dir,
-        "horizontal_sobel.png",
-        8,
-    );
-    compute_gradients(
-        &input_image,
-        vertical_sobel,
-        output_dir,
-        "vertical_sobel.png",
-        8,
-    );
-    compute_gradients(
-        &input_image,
-        horizontal_prewitt,
-        output_dir,
-        "horizontal_prewitt.png",
-        6,
-    );
-    compute_gradients(
-        &input_image,
-        vertical_prewitt,
-        output_dir,
-        "vertical_prewitt.png",
-        6,
-    );
+    for gradient_kernel in GradientKernel::ALL {
+        let scale = match gradient_kernel {
+            GradientKernel::Sobel => 32,
+            GradientKernel::Scharr => 8,
+            GradientKernel::Prewitt => 6,
+            GradientKernel::Roberts => 4,
+        };
+
+        save_gradients(
+            &input_image,
+            &gradient_kernel,
+            output_dir,
+            &format!("{gradient_kernel:?}"),
+            scale,
+        );
+    }
 }

--- a/examples/gradients.rs
+++ b/examples/gradients.rs
@@ -25,7 +25,7 @@ fn save_gradients(
         .save(&output_dir.join(format!("{name}_horizontal.png")))
         .unwrap();
     vertical_scaled
-        .save(&output_dir.join(format!("{name}_horizontal.png")))
+        .save(&output_dir.join(format!("{name}_vertical.png")))
         .unwrap();
 }
 

--- a/examples/seam_carving.rs
+++ b/examples/seam_carving.rs
@@ -1,6 +1,7 @@
 use image::{open, GrayImage, Luma, Pixel};
 use imageproc::definitions::Clamp;
-use imageproc::gradients::sobel_gradient_map;
+use imageproc::gradients::gradients;
+use imageproc::gradients::GradientKernel;
 use imageproc::map::map_colors;
 use imageproc::seam_carving::*;
 use std::env;
@@ -59,10 +60,16 @@ fn main() {
     annotated.save(&annotated_path).unwrap();
 
     // Draw the seams on the gradient magnitude image.
-    let gradients = sobel_gradient_map(&input_image, |p| {
-        let mean = (p[0] + p[1] + p[2]) / 3;
-        Luma([mean as u32])
-    });
+    let gradient_kernel = GradientKernel::Sobel;
+    let gradients = gradients(
+        &input_image,
+        &gradient_kernel.as_horizontal_kernel(),
+        &gradient_kernel.as_vertical_kernel(),
+        |p| {
+            let mean = (p[0] + p[1] + p[2]) / 3;
+            Luma([mean as u32])
+        },
+    );
     let clamped_gradients: GrayImage = map_colors(&gradients, |p| Luma([Clamp::clamp(p[0])]));
     let annotated_gradients = draw_vertical_seams(&clamped_gradients, &seams);
     let gradients_path = output_dir.join("gradients.png");

--- a/examples/seam_carving.rs
+++ b/examples/seam_carving.rs
@@ -60,16 +60,10 @@ fn main() {
     annotated.save(&annotated_path).unwrap();
 
     // Draw the seams on the gradient magnitude image.
-    let gradient_kernel = GradientKernel::Sobel;
-    let gradients = gradients(
-        &input_image,
-        &gradient_kernel.as_horizontal_kernel(),
-        &gradient_kernel.as_vertical_kernel(),
-        |p| {
-            let mean = (p[0] + p[1] + p[2]) / 3;
-            Luma([mean as u32])
-        },
-    );
+    let gradients = gradients(&input_image, GradientKernel::Sobel, |p| {
+        let mean = (p[0] + p[1] + p[2]) / 3;
+        Luma([mean as u32])
+    });
     let clamped_gradients: GrayImage = map_colors(&gradients, |p| Luma([Clamp::clamp(p[0])]));
     let annotated_gradients = draw_vertical_seams(&clamped_gradients, &seams);
     let gradients_path = output_dir.join("gradients.png");

--- a/src/edges.rs
+++ b/src/edges.rs
@@ -2,8 +2,10 @@
 
 use crate::contrast;
 use crate::definitions::{HasBlack, HasWhite};
-use crate::filter::{gaussian_blur_f32, laplacian_filter};
-use crate::gradients::{horizontal_sobel, vertical_sobel};
+use crate::filter::{
+    filter3x3, gaussian_blur_f32, horizontal_filter, laplacian_filter, vertical_filter,
+};
+use crate::gradients::GradientKernel;
 use image::{GenericImageView, GrayImage, ImageBuffer, Luma};
 use std::f32;
 
@@ -36,8 +38,9 @@ pub fn canny(image: &GrayImage, low_threshold: f32, high_threshold: f32) -> Gray
     let blurred = gaussian_blur_f32(image, SIGMA);
 
     // 2. Intensity of gradients.
-    let gx = horizontal_sobel(&blurred);
-    let gy = vertical_sobel(&blurred);
+    let gradient_kernel = GradientKernel::Sobel;
+    let gx = filter3x3(&blurred, &gradient_kernel.as_horizontal_kernel::<i16>());
+    let gy = filter3x3(&blurred, &gradient_kernel.as_vertical_kernel::<i16>());
     let g: Vec<f32> = gx
         .iter()
         .zip(gy.iter())

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -242,12 +242,29 @@ where
 }
 
 /// A 2D kernel, used to filter images via convolution.
+#[derive(Debug, Clone)]
+pub struct SeparableKernel<K> {
+    pub(crate) horizontal_kernel: Kernel<K>,
+    pub(crate) vertical_kernel: Kernel<K>,
+}
+impl<K> SeparableKernel<K> {
+    /// Maps the separable kernel from type `K` to `Q` via the closure `f`.
+    pub fn map<Q>(self, f: &impl Fn(K) -> Q) -> SeparableKernel<Q> {
+        SeparableKernel {
+            horizontal_kernel: self.horizontal_kernel.map(f),
+            vertical_kernel: self.vertical_kernel.map(f),
+        }
+    }
+}
+
+/// A 2D kernel, used to filter images via convolution.
+#[derive(Debug, Clone)]
 pub struct Kernel<K> {
     pub(crate) data: Vec<K>,
     width: u32,
     height: u32,
 }
-impl<K: Num + Copy> Kernel<K> {
+impl<K> Kernel<K> {
     /// Construct a kernel from a slice and its dimensions. The input slice is
     /// in row-major form.
     pub fn new(data: Vec<K>, width: u32, height: u32) -> Kernel<K> {
@@ -264,11 +281,8 @@ impl<K: Num + Copy> Kernel<K> {
             height,
         }
     }
-    /// Maps the kernel from type `K` to `Q` via the closure `F`.
-    pub fn map<F, Q>(self, f: F) -> Kernel<Q>
-    where
-        F: Fn(K) -> Q,
-    {
+    /// Maps the kernel from type `K` to `Q` via the closure `f`.
+    pub fn map<Q>(self, f: &impl Fn(K) -> Q) -> Kernel<Q> {
         Kernel {
             data: self.data.into_iter().map(f).collect(),
             width: self.width,

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -199,17 +199,58 @@ pub fn box_filter(image: &GrayImage, x_radius: u32, y_radius: u32) -> Image<Luma
     out
 }
 
+/// Returns 2d correlation of an image. Intermediate calculations are performed
+/// at type K, and the results converted to pixel Q via f. Pads by continuity.
+pub fn filter<P, K, F, Q>(image: &Image<P>, kernel: &Kernel<K>, mut f: F) -> Image<Q>
+where
+    P: Pixel,
+    <P as Pixel>::Subpixel: Into<K>,
+    Q: Pixel,
+    F: FnMut(&mut Q::Subpixel, K),
+    K: num::Num + Copy,
+{
+    let (width, height) = image.dimensions();
+    let mut out = Image::<Q>::new(width, height);
+    let num_channels = P::CHANNEL_COUNT as usize;
+    let zero = K::zero();
+    let mut acc = vec![zero; num_channels];
+    let (k_width, k_height) = (kernel.width as i64, kernel.height as i64);
+    let (width, height) = (width as i64, height as i64);
+
+    for y in 0..height {
+        for x in 0..width {
+            for k_y in 0..k_height {
+                let y_p = min(height - 1, max(0, y + k_y - k_height / 2)) as u32;
+                for k_x in 0..k_width {
+                    let x_p = min(width - 1, max(0, x + k_x - k_width / 2)) as u32;
+                    accumulate(
+                        &mut acc,
+                        unsafe { &image.unsafe_get_pixel(x_p, y_p) },
+                        unsafe { *kernel.data.get_unchecked((k_y * k_width + k_x) as usize) },
+                    );
+                }
+            }
+            let out_channels = out.get_pixel_mut(x as u32, y as u32).channels_mut();
+            for (a, c) in acc.iter_mut().zip(out_channels.iter_mut()) {
+                f(c, *a);
+                *a = zero;
+            }
+        }
+    }
+
+    out
+}
+
 /// A 2D kernel, used to filter images via convolution.
-pub struct Kernel<'a, K> {
-    data: &'a [K],
+pub struct Kernel<K> {
+    pub(crate) data: Vec<K>,
     width: u32,
     height: u32,
 }
-
-impl<'a, K: Num + Copy + 'a> Kernel<'a, K> {
+impl<K: Num + Copy> Kernel<K> {
     /// Construct a kernel from a slice and its dimensions. The input slice is
     /// in row-major form.
-    pub fn new(data: &'a [K], width: u32, height: u32) -> Kernel<'a, K> {
+    pub fn new(data: Vec<K>, width: u32, height: u32) -> Kernel<K> {
         assert!(width > 0 && height > 0, "width and height must be non-zero");
         assert!(
             width * height == data.len() as u32,
@@ -223,46 +264,16 @@ impl<'a, K: Num + Copy + 'a> Kernel<'a, K> {
             height,
         }
     }
-
-    /// Returns 2d correlation of an image. Intermediate calculations are performed
-    /// at type K, and the results converted to pixel Q via f. Pads by continuity.
-    pub fn filter<P, F, Q>(&self, image: &Image<P>, mut f: F) -> Image<Q>
+    /// Maps the kernel from type `K` to `Q` via the closure `F`.
+    pub fn map<F, Q>(self, f: F) -> Kernel<Q>
     where
-        P: Pixel,
-        <P as Pixel>::Subpixel: Into<K>,
-        Q: Pixel,
-        F: FnMut(&mut Q::Subpixel, K),
+        F: Fn(K) -> Q,
     {
-        let (width, height) = image.dimensions();
-        let mut out = Image::<Q>::new(width, height);
-        let num_channels = P::CHANNEL_COUNT as usize;
-        let zero = K::zero();
-        let mut acc = vec![zero; num_channels];
-        let (k_width, k_height) = (self.width as i64, self.height as i64);
-        let (width, height) = (width as i64, height as i64);
-
-        for y in 0..height {
-            for x in 0..width {
-                for k_y in 0..k_height {
-                    let y_p = min(height - 1, max(0, y + k_y - k_height / 2)) as u32;
-                    for k_x in 0..k_width {
-                        let x_p = min(width - 1, max(0, x + k_x - k_width / 2)) as u32;
-                        accumulate(
-                            &mut acc,
-                            unsafe { &image.unsafe_get_pixel(x_p, y_p) },
-                            unsafe { *self.data.get_unchecked((k_y * k_width + k_x) as usize) },
-                        );
-                    }
-                }
-                let out_channels = out.get_pixel_mut(x as u32, y as u32).channels_mut();
-                for (a, c) in acc.iter_mut().zip(out_channels.iter_mut()) {
-                    f(c, *a);
-                    *a = zero;
-                }
-            }
+        Kernel {
+            data: self.data.into_iter().map(f).collect(),
+            width: self.width,
+            height: self.height,
         }
-
-        out
     }
 }
 
@@ -273,7 +284,7 @@ fn gaussian(x: f32, r: f32) -> f32 {
 
 /// Construct a one dimensional float-valued kernel for performing a Gaussian blur
 /// with standard deviation sigma.
-fn gaussian_kernel_f32(sigma: f32) -> Vec<f32> {
+fn gaussian_kernel_f32(sigma: f32) -> Kernel<f32> {
     let kernel_radius = (2.0 * sigma).ceil() as usize;
     let mut kernel_data = vec![0.0; 2 * kernel_radius + 1];
     for i in 0..kernel_radius + 1 {
@@ -283,7 +294,12 @@ fn gaussian_kernel_f32(sigma: f32) -> Vec<f32> {
     }
     let sum: f32 = kernel_data.iter().sum();
     kernel_data.iter_mut().for_each(|x| *x /= sum);
-    kernel_data
+
+    Kernel {
+        width: kernel_data.len() as u32,
+        height: 1,
+        data: kernel_data,
+    }
 }
 
 /// Blurs an image using a Gaussian of standard deviation sigma.
@@ -308,7 +324,11 @@ where
 /// Returns 2d correlation of view with the outer product of the 1d
 /// kernels `h_kernel` and `v_kernel`.
 #[must_use = "the function does not modify the original image"]
-pub fn separable_filter<P, K>(image: &Image<P>, h_kernel: &[K], v_kernel: &[K]) -> Image<P>
+pub fn separable_filter<P, K>(
+    image: &Image<P>,
+    h_kernel: &Kernel<K>,
+    v_kernel: &Kernel<K>,
+) -> Image<P>
 where
     P: Pixel,
     <P as Pixel>::Subpixel: Into<K> + Clamp<K>,
@@ -321,39 +341,57 @@ where
 /// Returns 2d correlation of an image with the outer product of the 1d
 /// kernel filter with itself.
 #[must_use = "the function does not modify the original image"]
-pub fn separable_filter_equal<P, K>(image: &Image<P>, kernel: &[K]) -> Image<P>
+pub fn separable_filter_equal<P, K>(image: &Image<P>, kernel: &Kernel<K>) -> Image<P>
 where
     P: Pixel,
     <P as Pixel>::Subpixel: Into<K> + Clamp<K>,
     K: Num + Copy,
 {
+    assert_eq!(
+        kernel.height, 1,
+        "separable_filter only works with 1 dimensional kernels"
+    );
+
     separable_filter(image, kernel, kernel)
 }
 
 /// Returns 2d correlation of an image with a 3x3 row-major kernel. Intermediate calculations are
 /// performed at type K, and the results clamped to subpixel type S. Pads by continuity.
 #[must_use = "the function does not modify the original image"]
-pub fn filter3x3<P, K, S>(image: &Image<P>, kernel: &[K]) -> Image<ChannelMap<P, S>>
+pub fn filter3x3<P, K, S>(image: &Image<P>, kernel: &Kernel<K>) -> Image<ChannelMap<P, S>>
 where
     P::Subpixel: Into<K>,
     S: Clamp<K> + Primitive,
     P: WithChannel<S>,
     K: Num + Copy,
 {
-    let kernel = Kernel::new(kernel, 3, 3);
-    kernel.filter(image, |channel, acc| *channel = S::clamp(acc))
+    assert_eq!(
+        kernel.width, 3,
+        "kernel width must equal 3 to use filter3x3"
+    );
+    assert_eq!(
+        kernel.height, 3,
+        "kernel height must equal 3 to use filter3x3"
+    );
+
+    filter(image, kernel, |channel, acc| *channel = S::clamp(acc))
 }
 
 /// Returns horizontal correlations between an image and a 1d kernel.
 /// Pads by continuity. Intermediate calculations are performed at
 /// type K.
 #[must_use = "the function does not modify the original image"]
-pub fn horizontal_filter<P, K>(image: &Image<P>, kernel: &[K]) -> Image<P>
+pub fn horizontal_filter<P, K>(image: &Image<P>, kernel: &Kernel<K>) -> Image<P>
 where
     P: Pixel,
     <P as Pixel>::Subpixel: Into<K> + Clamp<K>,
     K: Num + Copy,
 {
+    assert_eq!(
+        kernel.height, 1,
+        "horizontal_filter only works with 1 dimensional kernels"
+    );
+
     // Don't replace this with a call to Kernel::filter without
     // checking the benchmark results. At the time of writing this
     // specialised implementation is faster.
@@ -361,14 +399,14 @@ where
     let mut out = Image::<P>::new(width, height);
     let zero = K::zero();
     let mut acc = vec![zero; P::CHANNEL_COUNT as usize];
-    let k_width = kernel.len() as i32;
+    let k_width = kernel.data.len() as i32;
 
     // Typically the image side will be much larger than the kernel length.
     // In that case we can remove a lot of bounds checks for most pixels.
     if k_width >= width as i32 {
         for y in 0..height {
             for x in 0..width {
-                for (i, k) in kernel.iter().enumerate() {
+                for (i, k) in kernel.data.iter().enumerate() {
                     let x_unchecked = (x as i32) + i as i32 - k_width / 2;
                     let x_p = max(0, min(x_unchecked, width as i32 - 1)) as u32;
                     let p = unsafe { image.unsafe_get_pixel(x_p, y) };
@@ -391,7 +429,7 @@ where
     for y in 0..height {
         // Left margin - need to check lower bound only
         for x in 0..half_k {
-            for (i, k) in kernel.iter().enumerate() {
+            for (i, k) in kernel.data.iter().enumerate() {
                 let x_unchecked = x + i as i32 - k_width / 2;
                 let x_p = max(0, x_unchecked) as u32;
                 let p = unsafe { image.unsafe_get_pixel(x_p, y) };
@@ -407,7 +445,7 @@ where
 
         // Neither margin - don't need bounds check on either side
         for x in half_k..(width as i32 - half_k) {
-            for (i, k) in kernel.iter().enumerate() {
+            for (i, k) in kernel.data.iter().enumerate() {
                 let x_unchecked = x + i as i32 - k_width / 2;
                 let x_p = x_unchecked as u32;
                 let p = unsafe { image.unsafe_get_pixel(x_p, y) };
@@ -423,7 +461,7 @@ where
 
         // Right margin - need to check upper bound only
         for x in (width as i32 - half_k)..(width as i32) {
-            for (i, k) in kernel.iter().enumerate() {
+            for (i, k) in kernel.data.iter().enumerate() {
                 let x_unchecked = x + i as i32 - k_width / 2;
                 let x_p = min(x_unchecked, width as i32 - 1) as u32;
                 let p = unsafe { image.unsafe_get_pixel(x_p, y) };
@@ -444,12 +482,17 @@ where
 /// Returns horizontal correlations between an image and a 1d kernel.
 /// Pads by continuity.
 #[must_use = "the function does not modify the original image"]
-pub fn vertical_filter<P, K>(image: &Image<P>, kernel: &[K]) -> Image<P>
+pub fn vertical_filter<P, K>(image: &Image<P>, kernel: &Kernel<K>) -> Image<P>
 where
     P: Pixel,
     <P as Pixel>::Subpixel: Into<K> + Clamp<K>,
     K: Num + Copy,
 {
+    assert_eq!(
+        kernel.height, 1,
+        "vertical_filter only works with 1 dimensional kernels"
+    );
+
     // Don't replace this with a call to Kernel::filter without
     // checking the benchmark results. At the time of writing this
     // specialised implementation is faster.
@@ -457,14 +500,14 @@ where
     let mut out = Image::<P>::new(width, height);
     let zero = K::zero();
     let mut acc = vec![zero; P::CHANNEL_COUNT as usize];
-    let k_height = kernel.len() as i32;
+    let k_height = kernel.data.len() as i32;
 
     // Typically the image side will be much larger than the kernel length.
     // In that case we can remove a lot of bounds checks for most pixels.
     if k_height >= height as i32 {
         for y in 0..height {
             for x in 0..width {
-                for (i, k) in kernel.iter().enumerate() {
+                for (i, k) in kernel.data.iter().enumerate() {
                     let y_unchecked = (y as i32) + i as i32 - k_height / 2;
                     let y_p = max(0, min(y_unchecked, height as i32 - 1)) as u32;
                     let p = unsafe { image.unsafe_get_pixel(x, y_p) };
@@ -487,7 +530,7 @@ where
     // Top margin - need to check lower bound only
     for y in 0..half_k {
         for x in 0..width {
-            for (i, k) in kernel.iter().enumerate() {
+            for (i, k) in kernel.data.iter().enumerate() {
                 let y_unchecked = y + i as i32 - k_height / 2;
                 let y_p = max(0, y_unchecked) as u32;
                 let p = unsafe { image.unsafe_get_pixel(x, y_p) };
@@ -505,7 +548,7 @@ where
     // Neither margin - don't need bounds check on either side
     for y in half_k..(height as i32 - half_k) {
         for x in 0..width {
-            for (i, k) in kernel.iter().enumerate() {
+            for (i, k) in kernel.data.iter().enumerate() {
                 let y_unchecked = y + i as i32 - k_height / 2;
                 let y_p = y_unchecked as u32;
                 let p = unsafe { image.unsafe_get_pixel(x, y_p) };
@@ -523,7 +566,7 @@ where
     // Right margin - need to check upper bound only
     for y in (height as i32 - half_k)..(height as i32) {
         for x in 0..width {
-            for (i, k) in kernel.iter().enumerate() {
+            for (i, k) in kernel.data.iter().enumerate() {
                 let y_unchecked = y + i as i32 - k_height / 2;
                 let y_p = min(y_unchecked, height as i32 - 1) as u32;
                 let p = unsafe { image.unsafe_get_pixel(x, y_p) };
@@ -562,7 +605,7 @@ where
 /// ```
 #[must_use = "the function does not modify the original image"]
 pub fn laplacian_filter(image: &GrayImage) -> Image<Luma<i16>> {
-    let kernel: [i16; 9] = [0, 1, 0, 1, -4, 1, 0, 1, 0];
+    let kernel: Kernel<i16> = Kernel::new(vec![0, 1, 0, 1, -4, 1, 0, 1, 0], 3, 3);
     filter3x3(image, &kernel)
 }
 
@@ -628,7 +671,7 @@ mod tests {
             4, 5, 5;
             6, 7, 7);
 
-        let kernel = vec![1f32 / 3f32; 3];
+        let kernel = Kernel::new(vec![1f32 / 3f32; 3], 3, 1);
         let filtered = separable_filter_equal(&image, &kernel);
 
         assert_pixels_eq!(filtered, expected);
@@ -646,7 +689,7 @@ mod tests {
             39, 45, 51;
             57, 63, 69);
 
-        let kernel = vec![1i32; 3];
+        let kernel = Kernel::new(vec![1i32; 3], 3, 1);
         let filtered = separable_filter_equal(&image, &kernel);
 
         assert_pixels_eq!(filtered, expected);
@@ -654,7 +697,12 @@ mod tests {
 
     /// Reference implementation of horizontal_filter. Used to validate
     /// the (presumably faster) actual implementation.
-    fn horizontal_filter_reference(image: &GrayImage, kernel: &[f32]) -> GrayImage {
+    fn horizontal_filter_reference(image: &GrayImage, kernel: &Kernel<f32>) -> GrayImage {
+        assert_eq!(
+            kernel.height, 1,
+            "horizontal_filter_reference only works with 1 dimensional kernels"
+        );
+
         let (width, height) = image.dimensions();
         let mut out = GrayImage::new(width, height);
 
@@ -662,14 +710,14 @@ mod tests {
             for x in 0..width {
                 let mut acc = 0f32;
 
-                for k in 0..kernel.len() {
-                    let mut x_unchecked = x as i32 + k as i32 - (kernel.len() / 2) as i32;
+                for k in 0..kernel.data.len() {
+                    let mut x_unchecked = x as i32 + k as i32 - (kernel.data.len() / 2) as i32;
                     x_unchecked = max(0, x_unchecked);
                     x_unchecked = min(x_unchecked, width as i32 - 1);
 
                     let x_checked = x_unchecked as u32;
                     let color = image.get_pixel(x_checked, y)[0];
-                    let weight = kernel[k];
+                    let weight = kernel.data[k];
 
                     acc += color as f32 * weight;
                 }
@@ -684,7 +732,12 @@ mod tests {
 
     /// Reference implementation of vertical_filter. Used to validate
     /// the (presumably faster) actual implementation.
-    fn vertical_filter_reference(image: &GrayImage, kernel: &[f32]) -> GrayImage {
+    fn vertical_filter_reference(image: &GrayImage, kernel: &Kernel<f32>) -> GrayImage {
+        assert_eq!(
+            kernel.height, 1,
+            "vertical_filter_reference only works with 1 dimensional kernels"
+        );
+
         let (width, height) = image.dimensions();
         let mut out = GrayImage::new(width, height);
 
@@ -692,14 +745,14 @@ mod tests {
             for x in 0..width {
                 let mut acc = 0f32;
 
-                for k in 0..kernel.len() {
-                    let mut y_unchecked = y as i32 + k as i32 - (kernel.len() / 2) as i32;
+                for k in 0..kernel.data.len() {
+                    let mut y_unchecked = y as i32 + k as i32 - (kernel.data.len() / 2) as i32;
                     y_unchecked = max(0, y_unchecked);
                     y_unchecked = min(y_unchecked, height as i32 - 1);
 
                     let y_checked = y_unchecked as u32;
                     let color = image.get_pixel(x, y_checked)[0];
-                    let weight = kernel[k];
+                    let weight = kernel.data[k];
 
                     acc += color as f32 * weight;
                 }
@@ -722,10 +775,13 @@ mod tests {
                 // examples via quickcheck.
                 for height in 0..5 {
                     for width in 0..5 {
-                        for kernel_length in 0..15 {
+                        for kernel_length in 1..15 {
                             let image = gray_bench_image(width, height);
-                            let kernel: Vec<f32> =
-                                (0..kernel_length).map(|i| i as f32 % 1.35).collect();
+                            let kernel: Kernel<f32> = Kernel::new(
+                                (0..kernel_length).map(|i| i as f32 % 1.35).collect(),
+                                kernel_length,
+                                1,
+                            );
 
                             let expected = $reference_impl(&image, &kernel);
                             let actual = $under_test(&image, &kernel);
@@ -762,7 +818,7 @@ mod tests {
             5, 5, 5;
             2, 2, 2);
 
-        let kernel = vec![1f32 / 3f32; 3];
+        let kernel = Kernel::new(vec![1f32 / 3f32; 3], 3, 1);
         let filtered = horizontal_filter(&image, &kernel);
 
         assert_pixels_eq!(filtered, expected);
@@ -775,7 +831,7 @@ mod tests {
             4, 7, 4;
             1, 4, 1);
 
-        let kernel = vec![1f32 / 10f32; 10];
+        let kernel = Kernel::new(vec![1f32 / 10f32; 10], 10, 1);
         black_box(horizontal_filter(&image, &kernel));
     }
     #[test]
@@ -790,7 +846,7 @@ mod tests {
             2, 5, 2;
             2, 5, 2);
 
-        let kernel = vec![1f32 / 3f32; 3];
+        let kernel = Kernel::new(vec![1f32 / 3f32; 3], 3, 1);
         let filtered = vertical_filter(&image, &kernel);
 
         assert_pixels_eq!(filtered, expected);
@@ -803,17 +859,17 @@ mod tests {
             4, 7, 4;
             1, 4, 1);
 
-        let kernel = vec![1f32 / 10f32; 10];
+        let kernel = Kernel::new(vec![1f32 / 10f32; 10], 10, 1);
         black_box(vertical_filter(&image, &kernel));
     }
     #[test]
     fn test_filter3x3_with_results_outside_input_channel_range() {
         #[rustfmt::skip]
-        let kernel: Vec<i32> = vec![
+        let kernel: Kernel<i32> = Kernel::new(vec![
             -1, 0, 1,
             -2, 0, 2,
             -1, 0, 1
-        ];
+        ], 3, 3);
 
         let image = gray_image!(
             3, 2, 1;
@@ -834,7 +890,7 @@ mod tests {
     #[should_panic]
     fn test_kernel_must_be_nonempty() {
         let k: Vec<u8> = Vec::new();
-        let _ = Kernel::new(&k, 0, 0);
+        let _ = Kernel::new(k, 0, 0);
     }
 
     #[test]
@@ -844,8 +900,8 @@ mod tests {
             4, 1);
 
         let k = vec![1u8, 2u8];
-        let kernel = Kernel::new(&k, 2, 1);
-        let filtered = kernel.filter(&image, |c, a| *c = a);
+        let kernel = Kernel::new(k, 2, 1);
+        let filtered = filter(&image, &kernel, |c, a| *c = a);
 
         let expected = gray_image!(
              9,  7;
@@ -859,8 +915,8 @@ mod tests {
         let image = gray_image!();
 
         let k = vec![2u8];
-        let kernel = Kernel::new(&k, 1, 1);
-        let filtered = kernel.filter(&image, |c, a| *c = a);
+        let kernel = Kernel::new(k, 1, 1);
+        let filtered = filter(&image, &kernel, |c, a| *c = a);
 
         let expected = gray_image!();
         assert_pixels_eq!(filtered, expected);
@@ -878,9 +934,9 @@ mod tests {
             0.2, 0.4, 0.2,
             0.1, 0.2, 0.1
         ];
-        let kernel = Kernel::new(&k, 3, 3);
+        let kernel = Kernel::new(k, 3, 3);
         let filtered: Image<Luma<u8>> =
-            kernel.filter(&image, |c, a| *c = <u8 as Clamp<f32>>::clamp(a));
+            filter(&image, &kernel, |c, a| *c = <u8 as Clamp<f32>>::clamp(a));
 
         let expected = gray_image!(
             11,  7;
@@ -957,8 +1013,8 @@ mod benches {
     #[bench]
     fn bench_separable_filter(b: &mut Bencher) {
         let image = gray_bench_image(300, 300);
-        let h_kernel = vec![1f32 / 5f32; 5];
-        let v_kernel = vec![0.1f32, 0.4f32, 0.3f32, 0.1f32, 0.1f32];
+        let h_kernel = Kernel::new(vec![1f32 / 5f32; 5], 5, 1);
+        let v_kernel = Kernel::new(vec![0.1f32, 0.4f32, 0.3f32, 0.1f32, 0.1f32], 5, 1);
         b.iter(|| {
             let filtered = separable_filter(&image, &h_kernel, &v_kernel);
             black_box(filtered);
@@ -968,7 +1024,7 @@ mod benches {
     #[bench]
     fn bench_horizontal_filter(b: &mut Bencher) {
         let image = gray_bench_image(500, 500);
-        let kernel = vec![1f32 / 5f32; 5];
+        let kernel = Kernel::new(vec![1f32 / 5f32; 5], 5, 1);
         b.iter(|| {
             let filtered = horizontal_filter(&image, &kernel);
             black_box(filtered);
@@ -978,7 +1034,7 @@ mod benches {
     #[bench]
     fn bench_vertical_filter(b: &mut Bencher) {
         let image = gray_bench_image(500, 500);
-        let kernel = vec![1f32 / 5f32; 5];
+        let kernel = Kernel::new(vec![1f32 / 5f32; 5], 5, 1);
         b.iter(|| {
             let filtered = vertical_filter(&image, &kernel);
             black_box(filtered);
@@ -989,11 +1045,11 @@ mod benches {
     fn bench_filter3x3_i32_filter(b: &mut Bencher) {
         let image = gray_bench_image(500, 500);
         #[rustfmt::skip]
-        let kernel: Vec<i32> = vec![
+        let kernel: Kernel<i32> = Kernel::new(vec![
             -1, 0, 1,
             -2, 0, 2,
             -1, 0, 1
-        ];
+        ], 3, 3);
 
         b.iter(|| {
             let filtered: ImageBuffer<Luma<i16>, Vec<i16>> =

--- a/src/filter/sharpen.rs
+++ b/src/filter/sharpen.rs
@@ -1,4 +1,4 @@
-use super::{filter3x3, gaussian_blur_f32};
+use super::{filter3x3, gaussian_blur_f32, Kernel};
 use crate::{
     definitions::{Clamp, Image},
     map::{map_colors2, map_subpixels},
@@ -8,7 +8,7 @@ use image::{GrayImage, Luma};
 /// Sharpens a grayscale image by applying a 3x3 approximation to the Laplacian.
 #[must_use = "the function does not modify the original image"]
 pub fn sharpen3x3(image: &GrayImage) -> GrayImage {
-    let identity_minus_laplacian = [0, -1, 0, -1, 5, -1, 0, -1, 0];
+    let identity_minus_laplacian = Kernel::new(vec![0, -1, 0, -1, 5, -1, 0, -1, 0], 3, 3);
     filter3x3(image, &identity_minus_laplacian)
 }
 

--- a/src/gradients.rs
+++ b/src/gradients.rs
@@ -1,7 +1,7 @@
 //! Functions for computing gradients of image intensities.
 
 use crate::definitions::{Clamp, HasBlack, Image};
-use crate::filter::{filter, filter3x3, Kernel};
+use crate::filter::{filter, filter3x3, Kernel, SeparableKernel};
 use crate::map::{ChannelMap, WithChannel};
 use image::{GenericImage, GenericImageView, GrayImage, Luma, Pixel};
 use itertools::multizip;
@@ -20,6 +20,33 @@ pub enum GradientKernel {
     /// See <https://en.wikipedia.org/wiki/Roberts_cross>
     Roberts,
 }
+impl<K> From<GradientKernel> for SeparableKernel<K>
+where
+    K: From<i8> + Copy,
+{
+    fn from(value: GradientKernel) -> Self {
+        let x = match value {
+            GradientKernel::Sobel => SeparableKernel {
+                horizontal_kernel: Kernel::new(vec![-1, 0, 1, -2, 0, 2, -1, 0, 1], 3, 3),
+                vertical_kernel: Kernel::new(vec![-1, -2, -1, 0, 0, 0, 1, 2, 1], 3, 3),
+            },
+            GradientKernel::Scharr => SeparableKernel {
+                horizontal_kernel: Kernel::new(vec![-3, 0, 3, -10, 0, 10, -3, 0, 3], 3, 3),
+                vertical_kernel: Kernel::new(vec![-3, -10, -3, 0, 0, 0, 3, 10, 3], 3, 3),
+            },
+            GradientKernel::Prewitt => SeparableKernel {
+                horizontal_kernel: Kernel::new(vec![-1, 0, 1, -1, 0, 1, -1, 0, 1], 3, 3),
+                vertical_kernel: Kernel::new(vec![-1, -1, -1, 0, 0, 0, 1, 1, 1], 3, 3),
+            },
+            GradientKernel::Roberts => SeparableKernel {
+                horizontal_kernel: Kernel::new(vec![0, 1, -1, -0], 2, 2),
+                vertical_kernel: Kernel::new(vec![1, 0, 0, -1], 2, 2),
+            },
+        };
+
+        x.map(&K::from)
+    }
+}
 impl GradientKernel {
     /// A slice of all the [`GradientKernel`] variants.
     pub const ALL: [GradientKernel; 4] = [
@@ -29,73 +56,19 @@ impl GradientKernel {
         GradientKernel::Roberts,
     ];
 
-    #[rustfmt::skip]
     /// Returns the horizontal separable matrix of the gradient kernel.
     pub fn as_horizontal_kernel<K>(&self) -> Kernel<K>
     where
-        K: From<i8> + num::Num + Copy,
+        K: From<i8> + Copy,
     {
-        let kernel_i8: Kernel<i8> = match self {
-            GradientKernel::Sobel => Kernel::new(
-                vec![-1, 0, 1,
-                     -2, 0, 2,
-                     -1, 0, 1,],
-                3, 3
-            ),
-            GradientKernel::Scharr => Kernel::new(
-                vec![-3,  0, 3,
-                     -10, 0, 10,
-                     -3,  0, 3,],
-                3, 3
-            ),
-            GradientKernel::Prewitt => Kernel::new(
-                vec![-1, 0, 1,
-                     -1, 0, 1,
-                     -1, 0, 1,],
-                3, 3
-            ),
-            GradientKernel::Roberts => Kernel::new(
-                vec![0,   1,
-                    -1, -0,],
-                2, 2
-            ),
-        };
-
-        kernel_i8.map(K::from)
+        SeparableKernel::from(*self).horizontal_kernel
     }
-    #[rustfmt::skip]
     /// Returns the vertical separable matrix of the gradient kernel.
     pub fn as_vertical_kernel<K>(&self) -> Kernel<K>
     where
-        K: From<i8> + num::Num + Copy,
+        K: From<i8> + Copy,
     {
-        let kernel_i8: Kernel<i8> = match self {
-            GradientKernel::Sobel => Kernel::new(
-                vec![-1, -2, -1,
-                      0,  0,  0,
-                      1,  2,  1,],
-                3, 3
-            ),
-            GradientKernel::Scharr => Kernel::new(
-                vec![-3, -10, -3,
-                      0,   0,  0,
-                      3,  10,  3,],
-                3, 3
-            ),
-            GradientKernel::Prewitt => Kernel::new(
-                vec![-1, -1, -1,
-                      0, 0, 0,
-                      1, 1, 1,],
-                3, 3
-            ),
-            GradientKernel::Roberts => Kernel::new(
-                vec![1,  0,
-                     0, -1,],
-                2, 2
-            ),
-        };
-
-        kernel_i8.map(K::from)
+        SeparableKernel::from(*self).vertical_kernel
     }
 }
 
@@ -136,7 +109,7 @@ impl GradientKernel {
 /// let gradient_kernel = GradientKernel::Sobel;
 ///
 /// assert_pixels_eq!(
-///     gradients(&input, &gradient_kernel.as_horizontal_kernel(), &gradient_kernel.as_vertical_kernel(), |p| p),
+///     gradients(&input, gradient_kernel, |p| p),
 ///     channel_gradient
 /// );
 ///
@@ -149,7 +122,7 @@ impl GradientKernel {
 /// );
 ///
 /// assert_pixels_eq!(
-///     gradients(&input, &gradient_kernel.as_horizontal_kernel(), &gradient_kernel.as_vertical_kernel(), |p| {
+///     gradients(&input, gradient_kernel, |p| {
 ///         let mean = (p[0] + p[1] + p[2]) / 3;
 ///         Luma([mean])
 ///     }),
@@ -165,7 +138,7 @@ impl GradientKernel {
 /// );
 ///
 /// assert_pixels_eq!(
-///     gradients(&input, &gradient_kernel.as_horizontal_kernel(), &gradient_kernel.as_vertical_kernel(), |p| {
+///     gradients(&input, gradient_kernel, |p| {
 ///         let max = cmp::max(cmp::max(p[0], p[1]), p[2]);
 ///         Luma([max])
 ///     }),
@@ -174,8 +147,7 @@ impl GradientKernel {
 /// # }
 pub fn gradients<P, F, Q>(
     image: &Image<P>,
-    horizontal_kernel: &Kernel<i32>,
-    vertical_kernel: &Kernel<i32>,
+    separable_kernel: impl Into<SeparableKernel<i32>>,
     f: F,
 ) -> Image<Q>
 where
@@ -184,12 +156,17 @@ where
     ChannelMap<P, u16>: HasBlack,
     F: Fn(ChannelMap<P, u16>) -> Q,
 {
-    let horizontal: Image<ChannelMap<P, i16>> = filter(image, horizontal_kernel, |channel, acc| {
-        *channel = <i16 as Clamp<i32>>::clamp(acc)
-    });
-    let vertical: Image<ChannelMap<P, i16>> = filter(image, vertical_kernel, |channel, acc| {
-        *channel = <i16 as Clamp<i32>>::clamp(acc)
-    });
+    let separable_kernel: SeparableKernel<i32> = separable_kernel.into();
+
+    let horizontal: Image<ChannelMap<P, i16>> = filter(
+        image,
+        &separable_kernel.horizontal_kernel,
+        |channel, acc| *channel = <i16 as Clamp<i32>>::clamp(acc),
+    );
+    let vertical: Image<ChannelMap<P, i16>> =
+        filter(image, &separable_kernel.vertical_kernel, |channel, acc| {
+            *channel = <i16 as Clamp<i32>>::clamp(acc)
+        });
 
     let (width, height) = image.dimensions();
     let mut out = Image::<Q>::new(width, height);
@@ -252,68 +229,28 @@ mod tests {
         let image = ImageBuffer::from_pixel(5, 5, Luma([15u8]));
         let expected = ImageBuffer::from_pixel(5, 5, Luma([0u16]));
 
-        let gradient_kernel = GradientKernel::Sobel;
-
-        assert_pixels_eq!(
-            gradients(
-                &image,
-                &gradient_kernel.as_horizontal_kernel(),
-                &gradient_kernel.as_vertical_kernel(),
-                |p| p
-            ),
-            expected
-        );
+        assert_pixels_eq!(gradients(&image, GradientKernel::Sobel, |p| p), expected);
     }
     #[test]
     fn test_gradients_constant_image_scharr() {
         let image = ImageBuffer::from_pixel(5, 5, Luma([15u8]));
         let expected = ImageBuffer::from_pixel(5, 5, Luma([0u16]));
 
-        let gradient_kernel = GradientKernel::Scharr;
-
-        assert_pixels_eq!(
-            gradients(
-                &image,
-                &gradient_kernel.as_horizontal_kernel(),
-                &gradient_kernel.as_vertical_kernel(),
-                |p| p
-            ),
-            expected
-        );
+        assert_pixels_eq!(gradients(&image, GradientKernel::Scharr, |p| p), expected);
     }
     #[test]
     fn test_gradients_constant_image_prewitt() {
         let image = ImageBuffer::from_pixel(5, 5, Luma([15u8]));
         let expected = ImageBuffer::from_pixel(5, 5, Luma([0u16]));
 
-        let gradient_kernel = GradientKernel::Prewitt;
-
-        assert_pixels_eq!(
-            gradients(
-                &image,
-                &gradient_kernel.as_horizontal_kernel(),
-                &gradient_kernel.as_vertical_kernel(),
-                |p| p
-            ),
-            expected
-        );
+        assert_pixels_eq!(gradients(&image, GradientKernel::Prewitt, |p| p), expected);
     }
     #[test]
     fn test_gradients_constant_image_roberts() {
         let image = ImageBuffer::from_pixel(5, 5, Luma([15u8]));
         let expected = ImageBuffer::from_pixel(5, 5, Luma([0u16]));
 
-        let gradient_kernel = GradientKernel::Roberts;
-
-        assert_pixels_eq!(
-            gradients(
-                &image,
-                &gradient_kernel.as_horizontal_kernel(),
-                &gradient_kernel.as_vertical_kernel(),
-                |p| p
-            ),
-            expected
-        );
+        assert_pixels_eq!(gradients(&image, GradientKernel::Roberts, |p| p), expected);
     }
 
     #[test]
@@ -430,12 +367,7 @@ mod benches {
     fn bench_sobel_gradients(b: &mut Bencher) {
         let image = gray_bench_image(500, 500);
         b.iter(|| {
-            let gradients = gradients(
-                &image,
-                &GradientKernel::Sobel.as_horizontal_kernel(),
-                &GradientKernel::Sobel.as_vertical_kernel(),
-                |p| p,
-            );
+            let gradients = gradients(&image, GradientKernel::Sobel, |p| p);
             black_box(gradients);
         });
     }

--- a/src/gradients.rs
+++ b/src/gradients.rs
@@ -1,107 +1,110 @@
 //! Functions for computing gradients of image intensities.
 
-use crate::definitions::{HasBlack, Image};
-use crate::filter::filter3x3;
+use crate::definitions::{Clamp, HasBlack, Image};
+use crate::filter::{filter, filter3x3, Kernel};
 use crate::map::{ChannelMap, WithChannel};
 use image::{GenericImage, GenericImageView, GrayImage, Luma, Pixel};
 use itertools::multizip;
 
-/// Sobel filter for detecting vertical gradients.
-///
-/// Used by the [`vertical_sobel`](fn.vertical_sobel.html) function.
-#[rustfmt::skip]
-pub static VERTICAL_SOBEL: [i32; 9] = [
-    -1, -2, -1,
-     0,  0,  0,
-     1,  2,  1];
+/// Different kernels for finding detecting gradients in images.
+#[derive(Debug, Copy, Clone)]
+pub enum GradientKernel {
+    /// The 3x3 Sobel kernel
+    /// See <https://en.wikipedia.org/wiki/Sobel_operator>
+    Sobel,
+    /// The 3x3 Scharr kernel
+    Scharr,
+    /// The 3x3 Prewitt kernel
+    Prewitt,
+    /// The 2x2 Roberts kernel
+    /// See <https://en.wikipedia.org/wiki/Roberts_cross>
+    Roberts,
+}
+impl GradientKernel {
+    /// A slice of all the [`GradientKernel`] variants.
+    pub const ALL: [GradientKernel; 4] = [
+        GradientKernel::Sobel,
+        GradientKernel::Scharr,
+        GradientKernel::Prewitt,
+        GradientKernel::Roberts,
+    ];
 
-/// Sobel filter for detecting horizontal gradients.
-///
-/// Used by the [`horizontal_sobel`](fn.horizontal_sobel.html) function.
-#[rustfmt::skip]
-pub static HORIZONTAL_SOBEL: [i32; 9] = [
-    -1, 0, 1,
-    -2, 0, 2,
-    -1, 0, 1];
+    #[rustfmt::skip]
+    /// Returns the horizontal separable matrix of the gradient kernel.
+    pub fn as_horizontal_kernel<K>(&self) -> Kernel<K>
+    where
+        K: From<i8> + num::Num + Copy,
+    {
+        let kernel_i8: Kernel<i8> = match self {
+            GradientKernel::Sobel => Kernel::new(
+                vec![-1, 0, 1,
+                     -2, 0, 2,
+                     -1, 0, 1,],
+                3, 3
+            ),
+            GradientKernel::Scharr => Kernel::new(
+                vec![-3,  0, 3,
+                     -10, 0, 10,
+                     -3,  0, 3,],
+                3, 3
+            ),
+            GradientKernel::Prewitt => Kernel::new(
+                vec![-1, 0, 1,
+                     -1, 0, 1,
+                     -1, 0, 1,],
+                3, 3
+            ),
+            GradientKernel::Roberts => Kernel::new(
+                vec![0,   1,
+                    -1, -0,],
+                2, 2
+            ),
+        };
 
-/// Scharr filter for detecting vertical gradients.
-///
-/// Used by the [`vertical_scharr`](fn.vertical_scharr.html) function.
-#[rustfmt::skip]
-pub static VERTICAL_SCHARR: [i32; 9] = [
-    -3, -10,  -3,
-     0,   0,   0,
-     3,  10,   3];
+        kernel_i8.map(K::from)
+    }
+    #[rustfmt::skip]
+    /// Returns the vertical separable matrix of the gradient kernel.
+    pub fn as_vertical_kernel<K>(&self) -> Kernel<K>
+    where
+        K: From<i8> + num::Num + Copy,
+    {
+        let kernel_i8: Kernel<i8> = match self {
+            GradientKernel::Sobel => Kernel::new(
+                vec![-1, -2, -1,
+                      0,  0,  0,
+                      1,  2,  1,],
+                3, 3
+            ),
+            GradientKernel::Scharr => Kernel::new(
+                vec![-3, -10, -3,
+                      0,   0,  0,
+                      3,  10,  3,],
+                3, 3
+            ),
+            GradientKernel::Prewitt => Kernel::new(
+                vec![-1, -1, -1,
+                      0, 0, 0,
+                      1, 1, 1,],
+                3, 3
+            ),
+            GradientKernel::Roberts => Kernel::new(
+                vec![1,  0,
+                     0, -1,],
+                2, 2
+            ),
+        };
 
-/// Scharr filter for detecting horizontal gradients.
-///
-/// Used by the [`horizontal_scharr`](fn.horizontal_scharr.html) function.
-#[rustfmt::skip]
-pub static HORIZONTAL_SCHARR: [i32; 9] = [
-     -3,  0,   3,
-    -10,  0,  10,
-     -3,  0,   3];
-
-/// Prewitt filter for detecting vertical gradients.
-///
-/// Used by the [`vertical_prewitt`](fn.vertical_prewitt.html) function.
-#[rustfmt::skip]
-pub static VERTICAL_PREWITT: [i32; 9] = [
-    -1, -1, -1,
-     0,  0,  0,
-     1,  1,  1];
-
-/// Prewitt filter for detecting horizontal gradients.
-///
-/// Used by the [`horizontal_prewitt`](fn.horizontal_prewitt.html) function.
-#[rustfmt::skip]
-pub static HORIZONTAL_PREWITT: [i32; 9] = [
-    -1, 0, 1,
-    -1, 0, 1,
-    -1, 0, 1];
-
-/// Convolves an image with the [`HORIZONTAL_SOBEL`](static.HORIZONTAL_SOBEL.html)
-/// kernel to detect horizontal gradients.
-pub fn horizontal_sobel(image: &GrayImage) -> Image<Luma<i16>> {
-    filter3x3(image, &HORIZONTAL_SOBEL)
+        kernel_i8.map(K::from)
+    }
 }
 
-/// Convolves an image with the [`VERTICAL_SOBEL`](static.VERTICAL_SOBEL.html)
-/// kernel to detect vertical gradients.
-pub fn vertical_sobel(image: &GrayImage) -> Image<Luma<i16>> {
-    filter3x3(image, &VERTICAL_SOBEL)
-}
-
-/// Convolves an image with the [`HORIZONTAL_SCHARR`](static.HORIZONTAL_SCHARR.html)
-/// kernel to detect horizontal gradients.
-pub fn horizontal_scharr(image: &GrayImage) -> Image<Luma<i16>> {
-    filter3x3(image, &HORIZONTAL_SCHARR)
-}
-
-/// Convolves an image with the [`VERTICAL_SCHARR`](static.VERTICAL_SCHARR.html)
-/// kernel to detect vertical gradients.
-pub fn vertical_scharr(image: &GrayImage) -> Image<Luma<i16>> {
-    filter3x3(image, &VERTICAL_SCHARR)
-}
-
-/// Convolves an image with the [`HORIZONTAL_PREWITT`](static.HORIZONTAL_PREWITT.html)
-/// kernel to detect horizontal gradients.
-pub fn horizontal_prewitt(image: &GrayImage) -> Image<Luma<i16>> {
-    filter3x3(image, &HORIZONTAL_PREWITT)
-}
-
-/// Convolves an image with the [`VERTICAL_PREWITT`](static.VERTICAL_PREWITT.html)
-/// kernel to detect vertical gradients.
-pub fn vertical_prewitt(image: &GrayImage) -> Image<Luma<i16>> {
-    filter3x3(image, &VERTICAL_PREWITT)
-}
-
-/// Returns the magnitudes of gradients in an image using Sobel filters.
-pub fn sobel_gradients(image: &GrayImage) -> Image<Luma<u16>> {
-    gradients(image, &HORIZONTAL_SOBEL, &VERTICAL_SOBEL, |p| p)
-}
-
-/// Computes per-channel gradients using Sobel filters and calls `f`
+// TODO: Returns directions as well as magnitudes.
+// TODO: Support filtering without allocating a fresh image - filtering functions could
+// TODO: take some kind of pixel-sink. This would allow us to compute gradient magnitudes
+// TODO: and directions without allocating intermediates for vertical and horizontal gradients.
+//
+/// Computes per-channel gradients using the given horizontal and vertical kernels and calls `f`
 /// to compute each output pixel.
 ///
 /// # Examples
@@ -110,7 +113,7 @@ pub fn sobel_gradients(image: &GrayImage) -> Image<Luma<u16>> {
 /// # #[macro_use]
 /// # extern crate imageproc;
 /// # fn main() {
-/// use imageproc::gradients::{sobel_gradient_map};
+/// use imageproc::gradients::{gradients, GradientKernel};
 /// use image::Luma;
 /// use std::cmp;
 ///
@@ -130,8 +133,10 @@ pub fn sobel_gradients(image: &GrayImage) -> Image<Luma<u16>> {
 ///     [ 4,  0,  8], [ 8,  0,  8], [ 4,  0,  8]
 /// );
 ///
+/// let gradient_kernel = GradientKernel::Sobel;
+///
 /// assert_pixels_eq!(
-///     sobel_gradient_map(&input, |p| p),
+///     gradients(&input, &gradient_kernel.as_horizontal_kernel(), &gradient_kernel.as_vertical_kernel(), |p| p),
 ///     channel_gradient
 /// );
 ///
@@ -144,7 +149,7 @@ pub fn sobel_gradients(image: &GrayImage) -> Image<Luma<u16>> {
 /// );
 ///
 /// assert_pixels_eq!(
-///     sobel_gradient_map(&input, |p| {
+///     gradients(&input, &gradient_kernel.as_horizontal_kernel(), &gradient_kernel.as_vertical_kernel(), |p| {
 ///         let mean = (p[0] + p[1] + p[2]) / 3;
 ///         Luma([mean])
 ///     }),
@@ -160,36 +165,17 @@ pub fn sobel_gradients(image: &GrayImage) -> Image<Luma<u16>> {
 /// );
 ///
 /// assert_pixels_eq!(
-///     sobel_gradient_map(&input, |p| {
+///     gradients(&input, &gradient_kernel.as_horizontal_kernel(), &gradient_kernel.as_vertical_kernel(), |p| {
 ///         let max = cmp::max(cmp::max(p[0], p[1]), p[2]);
 ///         Luma([max])
 ///     }),
 ///     max_gradient
 /// );
 /// # }
-pub fn sobel_gradient_map<P, F, Q>(image: &Image<P>, f: F) -> Image<Q>
-where
-    P: Pixel<Subpixel = u8> + WithChannel<u16> + WithChannel<i16>,
-    Q: Pixel,
-    ChannelMap<P, u16>: HasBlack,
-    F: Fn(ChannelMap<P, u16>) -> Q,
-{
-    gradients(image, &HORIZONTAL_SOBEL, &VERTICAL_SOBEL, f)
-}
-
-/// Returns the magnitudes of gradients in an image using Prewitt filters.
-pub fn prewitt_gradients(image: &GrayImage) -> Image<Luma<u16>> {
-    gradients(image, &HORIZONTAL_PREWITT, &VERTICAL_PREWITT, |p| p)
-}
-
-// TODO: Returns directions as well as magnitudes.
-// TODO: Support filtering without allocating a fresh image - filtering functions could
-// TODO: take some kind of pixel-sink. This would allow us to compute gradient magnitudes
-// TODO: and directions without allocating intermediates for vertical and horizontal gradients.
-fn gradients<P, F, Q>(
+pub fn gradients<P, F, Q>(
     image: &Image<P>,
-    horizontal_kernel: &[i32; 9],
-    vertical_kernel: &[i32; 9],
+    horizontal_kernel: &Kernel<i32>,
+    vertical_kernel: &Kernel<i32>,
     f: F,
 ) -> Image<Q>
 where
@@ -198,8 +184,12 @@ where
     ChannelMap<P, u16>: HasBlack,
     F: Fn(ChannelMap<P, u16>) -> Q,
 {
-    let horizontal: Image<ChannelMap<P, i16>> = filter3x3::<_, _, i16>(image, horizontal_kernel);
-    let vertical: Image<ChannelMap<P, i16>> = filter3x3::<_, _, i16>(image, vertical_kernel);
+    let horizontal: Image<ChannelMap<P, i16>> = filter(image, horizontal_kernel, |channel, acc| {
+        *channel = <i16 as Clamp<i32>>::clamp(acc)
+    });
+    let vertical: Image<ChannelMap<P, i16>> = filter(image, vertical_kernel, |channel, acc| {
+        *channel = <i16 as Clamp<i32>>::clamp(acc)
+    });
 
     let (width, height) = image.dimensions();
     let mut out = Image::<Q>::new(width, height);
@@ -209,7 +199,7 @@ where
         for x in 0..width {
             // JUSTIFICATION
             //  Benefit
-            //      Using checked indexing here makes this sobel_gradients 1.1x slower,
+            //      Using checked indexing here makes this gradients 1.1x slower,
             //      as measured by bench_sobel_gradients
             //  Correctness
             //      x and y are in bounds for image by construction,
@@ -251,20 +241,79 @@ fn gradient_magnitude(dx: f32, dy: f32) -> u16 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::utils::gray_bench_image;
+    use crate::{
+        filter::{horizontal_filter, vertical_filter},
+        utils::gray_bench_image,
+    };
     use image::{ImageBuffer, Luma};
 
-    #[rustfmt::skip::macros(gray_image)]
     #[test]
-    fn test_gradients_constant_image() {
+    fn test_gradients_constant_image_sobel() {
         let image = ImageBuffer::from_pixel(5, 5, Luma([15u8]));
-        let expected = ImageBuffer::from_pixel(5, 5, Luma([0i16]));
-        assert_pixels_eq!(horizontal_sobel(&image), expected);
-        assert_pixels_eq!(vertical_sobel(&image), expected);
-        assert_pixels_eq!(horizontal_scharr(&image), expected);
-        assert_pixels_eq!(vertical_scharr(&image), expected);
-        assert_pixels_eq!(horizontal_prewitt(&image), expected);
-        assert_pixels_eq!(vertical_prewitt(&image), expected);
+        let expected = ImageBuffer::from_pixel(5, 5, Luma([0u16]));
+
+        let gradient_kernel = GradientKernel::Sobel;
+
+        assert_pixels_eq!(
+            gradients(
+                &image,
+                &gradient_kernel.as_horizontal_kernel(),
+                &gradient_kernel.as_vertical_kernel(),
+                |p| p
+            ),
+            expected
+        );
+    }
+    #[test]
+    fn test_gradients_constant_image_scharr() {
+        let image = ImageBuffer::from_pixel(5, 5, Luma([15u8]));
+        let expected = ImageBuffer::from_pixel(5, 5, Luma([0u16]));
+
+        let gradient_kernel = GradientKernel::Scharr;
+
+        assert_pixels_eq!(
+            gradients(
+                &image,
+                &gradient_kernel.as_horizontal_kernel(),
+                &gradient_kernel.as_vertical_kernel(),
+                |p| p
+            ),
+            expected
+        );
+    }
+    #[test]
+    fn test_gradients_constant_image_prewitt() {
+        let image = ImageBuffer::from_pixel(5, 5, Luma([15u8]));
+        let expected = ImageBuffer::from_pixel(5, 5, Luma([0u16]));
+
+        let gradient_kernel = GradientKernel::Prewitt;
+
+        assert_pixels_eq!(
+            gradients(
+                &image,
+                &gradient_kernel.as_horizontal_kernel(),
+                &gradient_kernel.as_vertical_kernel(),
+                |p| p
+            ),
+            expected
+        );
+    }
+    #[test]
+    fn test_gradients_constant_image_roberts() {
+        let image = ImageBuffer::from_pixel(5, 5, Luma([15u8]));
+        let expected = ImageBuffer::from_pixel(5, 5, Luma([0u16]));
+
+        let gradient_kernel = GradientKernel::Roberts;
+
+        assert_pixels_eq!(
+            gradients(
+                &image,
+                &gradient_kernel.as_horizontal_kernel(),
+                &gradient_kernel.as_vertical_kernel(),
+                |p| p
+            ),
+            expected
+        );
     }
 
     #[test]
@@ -279,7 +328,7 @@ mod tests {
             -4, -8, -4;
             -4, -8, -4);
 
-        let filtered = horizontal_sobel(&image);
+        let filtered = filter3x3(&image, &GradientKernel::Sobel.as_horizontal_kernel::<i16>());
         assert_pixels_eq!(filtered, expected);
     }
 
@@ -295,7 +344,7 @@ mod tests {
             -8, -8, -8;
             -4, -4, -4);
 
-        let filtered = vertical_sobel(&image);
+        let filtered = filter3x3(&image, &GradientKernel::Sobel.as_vertical_kernel::<i16>());
         assert_pixels_eq!(filtered, expected);
     }
 
@@ -311,7 +360,10 @@ mod tests {
             -16, -32, -16;
             -16, -32, -16);
 
-        let filtered = horizontal_scharr(&image);
+        let filtered = filter3x3(
+            &image,
+            &GradientKernel::Scharr.as_horizontal_kernel::<i16>(),
+        );
         assert_pixels_eq!(filtered, expected);
     }
 
@@ -327,7 +379,7 @@ mod tests {
             -32, -32, -32;
             -16, -16, -16);
 
-        let filtered = vertical_scharr(&image);
+        let filtered = filter3x3(&image, &GradientKernel::Scharr.as_vertical_kernel::<i16>());
         assert_pixels_eq!(filtered, expected);
     }
 
@@ -343,7 +395,10 @@ mod tests {
             -3, -6, -3;
             -3, -6, -3);
 
-        let filtered = horizontal_prewitt(&image);
+        let filtered = filter3x3(
+            &image,
+            &GradientKernel::Prewitt.as_horizontal_kernel::<i16>(),
+        );
         assert_pixels_eq!(filtered, expected);
     }
 
@@ -359,7 +414,7 @@ mod tests {
             -6, -6, -6;
             -3, -3, -3);
 
-        let filtered = vertical_prewitt(&image);
+        let filtered = filter3x3(&image, &GradientKernel::Prewitt.as_vertical_kernel::<i16>());
         assert_pixels_eq!(filtered, expected);
     }
 }
@@ -375,7 +430,12 @@ mod benches {
     fn bench_sobel_gradients(b: &mut Bencher) {
         let image = gray_bench_image(500, 500);
         b.iter(|| {
-            let gradients = sobel_gradients(&image);
+            let gradients = gradients(
+                &image,
+                &GradientKernel::Sobel.as_horizontal_kernel(),
+                &GradientKernel::Sobel.as_vertical_kernel(),
+                |p| p,
+            );
             black_box(gradients);
         });
     }

--- a/src/hog.rs
+++ b/src/hog.rs
@@ -2,7 +2,8 @@
 //! and helpers for visualizing them.
 
 use crate::definitions::{Clamp, Image};
-use crate::gradients::{horizontal_sobel, vertical_sobel};
+use crate::filter::{filter3x3, horizontal_filter, vertical_filter};
+use crate::gradients::GradientKernel;
 use crate::math::l2_norm;
 use image::{GenericImage, GrayImage, ImageBuffer, Luma};
 use num::Zero;
@@ -257,8 +258,10 @@ pub fn cell_histograms(image: &GrayImage, spec: HogSpec) -> Array3d<f32> {
     let mut grid = Array3d::new(spec.cell_grid_lengths());
     let cell_area = spec.cell_area() as f32;
     let cell_side = spec.options.cell_side as f32;
-    let horizontal = horizontal_sobel(image);
-    let vertical = vertical_sobel(image);
+
+    let gradient_kernel = GradientKernel::Sobel;
+    let horizontal = filter3x3::<_, _, i32>(image, &gradient_kernel.as_horizontal_kernel());
+    let vertical = filter3x3::<_, _, i32>(image, &gradient_kernel.as_vertical_kernel());
     let interval = orientation_bin_width(spec.options);
     let range = direction_range(spec.options);
 

--- a/src/seam_carving.rs
+++ b/src/seam_carving.rs
@@ -4,7 +4,7 @@
 //! [seam carving]: https://en.wikipedia.org/wiki/Seam_carving
 
 use crate::definitions::{HasBlack, Image};
-use crate::gradients::sobel_gradient_map;
+use crate::gradients::{gradients, GradientKernel};
 use crate::map::{map_colors, WithChannel};
 use image::{GrayImage, Luma, Pixel, Rgb};
 use std::cmp::min;
@@ -54,11 +54,17 @@ where
         "Cannot find seams if image width is < 2"
     );
 
-    let mut gradients = sobel_gradient_map(image, |p| {
-        let gradient_sum: u16 = p.channels().iter().sum();
-        let gradient_mean: u16 = gradient_sum / P::CHANNEL_COUNT as u16;
-        Luma([gradient_mean as u32])
-    });
+    let gradient_kernel = GradientKernel::Sobel;
+    let mut gradients = gradients(
+        image,
+        &gradient_kernel.as_horizontal_kernel(),
+        &gradient_kernel.as_vertical_kernel(),
+        |p| {
+            let gradient_sum: u16 = p.channels().iter().sum();
+            let gradient_mean: u16 = gradient_sum / P::CHANNEL_COUNT as u16;
+            Luma([gradient_mean as u32])
+        },
+    );
 
     // Find the least energy path through the gradient image.
     for y in 1..height {

--- a/src/seam_carving.rs
+++ b/src/seam_carving.rs
@@ -54,17 +54,11 @@ where
         "Cannot find seams if image width is < 2"
     );
 
-    let gradient_kernel = GradientKernel::Sobel;
-    let mut gradients = gradients(
-        image,
-        &gradient_kernel.as_horizontal_kernel(),
-        &gradient_kernel.as_vertical_kernel(),
-        |p| {
-            let gradient_sum: u16 = p.channels().iter().sum();
-            let gradient_mean: u16 = gradient_sum / P::CHANNEL_COUNT as u16;
-            Luma([gradient_mean as u32])
-        },
-    );
+    let mut gradients = gradients(image, GradientKernel::Sobel, |p| {
+        let gradient_sum: u16 = p.channels().iter().sum();
+        let gradient_mean: u16 = gradient_sum / P::CHANNEL_COUNT as u16;
+        Luma([gradient_mean as u32])
+    });
 
     // Find the least energy path through the gradient image.
     for y in 1..height {

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -23,6 +23,7 @@ use image::{
 };
 
 use imageproc::contrast::ThresholdType;
+use imageproc::gradients::GradientKernel;
 use imageproc::{
     definitions::{Clamp, HasBlack, HasWhite},
     edges::canny,
@@ -303,7 +304,12 @@ fn test_affine_bicubic_rgb() {
 fn test_sobel_gradients() {
     fn sobel_gradients(image: &GrayImage) -> GrayImage {
         imageproc::map::map_subpixels(
-            &gradients::sobel_gradients(image),
+            &gradients::gradients(
+                image,
+                &GradientKernel::Sobel.as_horizontal_kernel(),
+                &GradientKernel::Sobel.as_vertical_kernel(),
+                |p| p,
+            ),
             <u8 as Clamp<u16>>::clamp,
         )
     }

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -304,12 +304,7 @@ fn test_affine_bicubic_rgb() {
 fn test_sobel_gradients() {
     fn sobel_gradients(image: &GrayImage) -> GrayImage {
         imageproc::map::map_subpixels(
-            &gradients::gradients(
-                image,
-                &GradientKernel::Sobel.as_horizontal_kernel(),
-                &GradientKernel::Sobel.as_vertical_kernel(),
-                |p| p,
-            ),
+            &gradients::gradients(image, GradientKernel::Sobel, |p| p),
             <u8 as Clamp<u16>>::clamp,
         )
     }


### PR DESCRIPTION
- Made `Kernel::filter` a free-standing function which is more consistent with the rest of the library
- Made more functions use the `Kernel` type for better dimensionality checking
- Added some asserts for functions that take specific dimension kernels
- Added `GradientKernel` enum for common gradient kernels which replaces all the `pub static HORIZONTAL_SOBEL` and similar (and adds a new `Roberts` kernel)
- Removed `horizontal_*` and `vertical_*` functions since they can all be achieved using filter with `GradientKernel`
- Added a `SeparableKernel` type for use with the `gradient` function to make function parameter passing more concise.