### PR TITLE
optimisation of grayscale morphology operators

### DIFF
--- a/src/distance_transform.rs
+++ b/src/distance_transform.rs
@@ -143,7 +143,7 @@ fn distance_transform_impl_linf_or_l1<const IS_LINF: bool>(
     // We use an unsafe code block for optimisation purposes here
     // We use the 'unsafe_get_pixel' and 'check' unsafe functions,
     // which are faster than safe functions,
-    // and we garantee that they are used safely
+    // and we guarantee that they are used safely
     // by making sure we are always within the bounds of the image
 
     unsafe {

--- a/src/morphology.rs
+++ b/src/morphology.rs
@@ -627,7 +627,7 @@ impl Mask {
     }
 
     /// all the slices are garanteed to be non empty
-    fn lines<'a>(&'a self) -> impl Iterator<Item = &'a [Point<i16>]> {
+    fn lines(&self) -> impl Iterator<Item = &[Point<i16>]> {
         self.elements.chunk_by(|p1, p2| p1.y == p2.y)
     }
 }
@@ -733,7 +733,7 @@ pub fn grayscale_dilate(image: &GrayImage, mask: &Mask) -> GrayImage {
                 .unwrap_or(0);
 
             for i in 0..image.width() {
-                if l_bound > 0 && i64::from(line[l_bound - 1].x) >= i64::from(i){
+                if l_bound > 0 && i64::from(line[l_bound - 1].x) >= i64::from(i) {
                     l_bound -= 1
                 };
                 if r_bound > 0

--- a/src/morphology.rs
+++ b/src/morphology.rs
@@ -370,7 +370,6 @@ pub struct Mask {
 }
 
 impl Mask {
-
     /// creates a mask from a grayscale image
     ///
     /// a pixel is part of the mask if and only if it is non-zero

--- a/src/morphology.rs
+++ b/src/morphology.rs
@@ -466,13 +466,12 @@ impl Mask {
     /// ```
     pub fn square(radius: u8) -> Self {
         let range = -(radius as i16)..=(radius as i16);
-        Self {
-            elements: range
-                .clone()
-                .cartesian_product(range)
-                .map(|(y, x)| Point::new(x, y))
-                .collect(),
-        }
+        let elements = range
+            .clone()
+            .cartesian_product(range)
+            .map(|(y, x)| Point::new(x, y))
+            .collect();
+        Self { elements }
     }
 
     /// creates a diamond-shaped mask
@@ -515,14 +514,12 @@ impl Mask {
     /// # }
     /// ```
     pub fn diamond(radius: u8) -> Self {
-        Self {
-            elements: (-(radius as i16)..=(radius as i16))
-                .flat_map(|y| {
-                    ((y.abs() - radius as i16)..=(radius as i16 - y.abs()))
-                        .map(move |x| Point::new(x, y))
-                })
-                .collect(),
-        }
+        let mut elements = Vec::new();
+        let mut iter = (-(radius as i16)..=(radius as i16)).flat_map(|y| {
+            ((y.abs() - radius as i16)..=(radius as i16 - y.abs())).map(move |x| Point::new(x, y))
+        });
+        elements.resize_with(1 + 2 * (radius as usize) * (radius as usize + 1), || iter.next().expect("the size of iter is exactly equal to 1 + 2 * radius * (radius + 1) (i, Morgane55440, did the math)"));
+        Self { elements }
     }
 
     /// creates a disk-shaped mask
@@ -582,17 +579,18 @@ impl Mask {
     /// ```
     pub fn disk(radius: u8) -> Self {
         let range = -(radius as i16)..=(radius as i16);
-        Self {
-            elements: range
-                .clone()
-                .cartesian_product(range)
-                .filter(|(y, x)| {
-                    (x.unsigned_abs() as u32).pow(2) + (y.unsigned_abs() as u32).pow(2)
-                        <= (radius as u32).pow(2)
-                })
-                .map(|(y, x)| Point::new(x, y))
-                .collect(),
-        }
+        let radius_squared = (radius as u32) * (radius as u32);
+        let elements = range
+            .clone()
+            .cartesian_product(range)
+            .filter(|(y, x)| {
+                (x.unsigned_abs() as u32) * (x.unsigned_abs() as u32)
+                    + (y.unsigned_abs() as u32) * (y.unsigned_abs() as u32)
+                    <= radius_squared
+            })
+            .map(|(y, x)| Point::new(x, y))
+            .collect();
+        Self { elements }
     }
 
     fn apply<'a, 'b: 'a, 'c: 'a>(

--- a/src/morphology.rs
+++ b/src/morphology.rs
@@ -845,7 +845,7 @@ pub fn grayscale_erode(image: &GrayImage, mask: &Mask) -> GrayImage {
 /// use imageproc::morphology::{Mask, grayscale_open};
 ///
 /// // Isolated regions of foreground pixels are removed,
-/// // while isolated zones of background pixels are maintaned
+/// // while isolated zones of background pixels are maintained
 /// let image = gray_image!(
 ///   100,  99,  99,  99, 222,  99;
 ///    99,  99,  99, 222, 222, 222;
@@ -855,7 +855,7 @@ pub fn grayscale_erode(image: &GrayImage, mask: &Mask) -> GrayImage {
 /// );
 ///
 /// // Isolated regions of foreground pixels are removed,
-/// // while isolated zones of background are maintaned
+/// // while isolated zones of background are maintained
 /// let image_opened = gray_image!(
 ///    99,  99,  99,  99,  99,  99;
 ///    99,  99,  99,  99,  99,  99;
@@ -910,7 +910,7 @@ pub fn grayscale_open(image: &GrayImage, mask: &Mask) -> GrayImage {
 /// );
 ///
 /// // Isolated regions of background pixels are removed,
-/// // while isolated zones of foreground pixels are maintaned
+/// // while isolated zones of foreground pixels are maintained
 /// let image_closed = gray_image!(
 ///    99,  99,  99, 222, 222, 222;
 ///    99,  99,  99, 222, 222, 222;

--- a/src/morphology.rs
+++ b/src/morphology.rs
@@ -361,7 +361,7 @@ pub fn close_mut(image: &mut GrayImage, norm: Norm, k: u8) {
 /// The mask can have any size between 0 by 0 to 511 by 511 pixels
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Mask {
-    /// for any optimisation/arithmetic purposes, it is garanteed that :
+    /// for any optimisation/arithmetic purposes, it is guaranteed that:
     ///
     /// - all the integer values will be strictly between -512 and 512
     /// - all tuples will be sorted in reverse lexicographic order, line by line ((-1,-1),(0,-1),(1,-1),(-1,0),(0,0),...)

--- a/src/morphology.rs
+++ b/src/morphology.rs
@@ -622,7 +622,7 @@ impl Mask {
         Self::new(elements)
     }
 
-    /// all the slices are garanteed to be non empty
+    /// all the slices are guaranteed to be non empty
     fn lines<'a>(
         &'a self,
     ) -> GroupBy<i16, Iter<Point<i16>>, impl FnMut(&&'a Point<i16>) -> i16 + '_> {

--- a/src/morphology.rs
+++ b/src/morphology.rs
@@ -370,10 +370,6 @@ pub struct Mask {
 }
 
 impl Mask {
-    fn new(elements: Vec<Point<i16>>) -> Self {
-        assert!(elements.len() <= (511 * 511) as usize);
-        Self { elements }
-    }
 
     /// creates a mask from a grayscale image
     ///
@@ -441,7 +437,7 @@ impl Mask {
             .filter(|(_, _, &p)| p[0] != 0)
             .map(|(x, y, _)| Point::new(x as i16 - center_x, y as i16 - center_y)) // cast to i16 ok because of the size check
             .collect();
-        Self::new(elements)
+        Self { elements }
     }
 
     /// creates a square-shaped mask
@@ -529,7 +525,7 @@ impl Mask {
         elements.extend((-radius..=radius).flat_map(|y| {
             ((y.abs() - radius)..=(radius - y.abs())).map(move |x| Point::new(x, y))
         }));
-        Self::new(elements)
+        Self { elements }
     }
 
     /// creates a disk-shaped mask
@@ -619,7 +615,7 @@ impl Mask {
         elements.extend(half_widths_per_height.flat_map(|(y, half_width)| {
             ((-i16::from(half_width))..=i16::from(half_width)).map(move |x| Point::new(x, y))
         }));
-        Self::new(elements)
+        Self { elements }
     }
 
     /// all the slices are guaranteed to be non empty

--- a/src/morphology.rs
+++ b/src/morphology.rs
@@ -2039,4 +2039,37 @@ mod benches {
     bench_grayscale_mask!(bench_grayscale_square_mask, Mask::square);
     bench_grayscale_mask!(bench_grayscale_diamond_mask, Mask::diamond);
     bench_grayscale_mask!(bench_grayscale_disk_mask, Mask::disk);
+
+    macro_rules! bench_grayscale_operator {
+        ($name:ident, $f:expr, $mask:expr, $img_size:expr) => {
+            #[bench]
+            fn $name(b: &mut Bencher) {
+                let image = GrayImage::from_fn($img_size, $img_size, |x, y| Luma([(x + y % 3) as u8]));
+                let mask = $mask;
+                b.iter(|| {
+                    let processed = $f(&image, &mask);
+                    black_box(processed);
+                })
+            }
+        };
+    }
+
+    bench_grayscale_operator!(bench_grayscale_op_erode_small_image_point, grayscale_erode, Mask::diamond(0), 50);
+    bench_grayscale_operator!(bench_grayscale_op_erode_medium_image_point, grayscale_erode, Mask::diamond(0), 200);
+    bench_grayscale_operator!(bench_grayscale_op_erode_big_image_point, grayscale_erode, Mask::diamond(0), 1000);
+    bench_grayscale_operator!(bench_grayscale_op_erode_small_image_diamond, grayscale_erode, Mask::diamond(5), 50);
+    bench_grayscale_operator!(bench_grayscale_op_erode_medium_image_diamond, grayscale_erode, Mask::diamond(5), 200);
+    bench_grayscale_operator!(bench_grayscale_op_erode_big_image_diamond, grayscale_erode, Mask::diamond(5), 1000);
+    bench_grayscale_operator!(bench_grayscale_op_erode_small_image_large_square, grayscale_erode, Mask::square(25), 50);
+    bench_grayscale_operator!(bench_grayscale_op_erode_medium_image_large_square, grayscale_erode, Mask::square(25), 200);
+    
+
+    bench_grayscale_operator!(bench_grayscale_op_dilate_small_image_point, grayscale_dilate, Mask::diamond(0), 50);
+    bench_grayscale_operator!(bench_grayscale_op_dilate_medium_image_point, grayscale_dilate, Mask::diamond(0), 200);
+    bench_grayscale_operator!(bench_grayscale_op_dilate_big_image_point, grayscale_dilate, Mask::diamond(0), 1000);
+    bench_grayscale_operator!(bench_grayscale_op_dilate_small_image_diamond, grayscale_dilate, Mask::diamond(5), 50);
+    bench_grayscale_operator!(bench_grayscale_op_dilate_medium_image_diamond, grayscale_dilate, Mask::diamond(5), 200);
+    bench_grayscale_operator!(bench_grayscale_op_dilate_big_image_diamond, grayscale_dilate, Mask::diamond(5), 1000);
+    bench_grayscale_operator!(bench_grayscale_op_dilate_small_image_large_square, grayscale_dilate, Mask::square(25), 50);
+    bench_grayscale_operator!(bench_grayscale_op_dilate_medium_image_large_square, grayscale_dilate, Mask::square(25), 200);
 }

--- a/src/morphology.rs
+++ b/src/morphology.rs
@@ -2044,7 +2044,8 @@ mod benches {
         ($name:ident, $f:expr, $mask:expr, $img_size:expr) => {
             #[bench]
             fn $name(b: &mut Bencher) {
-                let image = GrayImage::from_fn($img_size, $img_size, |x, y| Luma([(x + y % 3) as u8]));
+                let image =
+                    GrayImage::from_fn($img_size, $img_size, |x, y| Luma([(x + y % 3) as u8]));
                 let mask = $mask;
                 b.iter(|| {
                     let processed = $f(&image, &mask);
@@ -2054,22 +2055,101 @@ mod benches {
         };
     }
 
-    bench_grayscale_operator!(bench_grayscale_op_erode_small_image_point, grayscale_erode, Mask::diamond(0), 50);
-    bench_grayscale_operator!(bench_grayscale_op_erode_medium_image_point, grayscale_erode, Mask::diamond(0), 200);
-    bench_grayscale_operator!(bench_grayscale_op_erode_big_image_point, grayscale_erode, Mask::diamond(0), 1000);
-    bench_grayscale_operator!(bench_grayscale_op_erode_small_image_diamond, grayscale_erode, Mask::diamond(5), 50);
-    bench_grayscale_operator!(bench_grayscale_op_erode_medium_image_diamond, grayscale_erode, Mask::diamond(5), 200);
-    bench_grayscale_operator!(bench_grayscale_op_erode_big_image_diamond, grayscale_erode, Mask::diamond(5), 1000);
-    bench_grayscale_operator!(bench_grayscale_op_erode_small_image_large_square, grayscale_erode, Mask::square(25), 50);
-    bench_grayscale_operator!(bench_grayscale_op_erode_medium_image_large_square, grayscale_erode, Mask::square(25), 200);
-    
+    bench_grayscale_operator!(
+        bench_grayscale_op_erode_small_image_point,
+        grayscale_erode,
+        Mask::diamond(0),
+        50
+    );
+    bench_grayscale_operator!(
+        bench_grayscale_op_erode_medium_image_point,
+        grayscale_erode,
+        Mask::diamond(0),
+        200
+    );
+    bench_grayscale_operator!(
+        bench_grayscale_op_erode_big_image_point,
+        grayscale_erode,
+        Mask::diamond(0),
+        1000
+    );
+    bench_grayscale_operator!(
+        bench_grayscale_op_erode_small_image_diamond,
+        grayscale_erode,
+        Mask::diamond(5),
+        50
+    );
+    bench_grayscale_operator!(
+        bench_grayscale_op_erode_medium_image_diamond,
+        grayscale_erode,
+        Mask::diamond(5),
+        200
+    );
+    bench_grayscale_operator!(
+        bench_grayscale_op_erode_big_image_diamond,
+        grayscale_erode,
+        Mask::diamond(5),
+        1000
+    );
+    bench_grayscale_operator!(
+        bench_grayscale_op_erode_small_image_large_square,
+        grayscale_erode,
+        Mask::square(25),
+        50
+    );
+    bench_grayscale_operator!(
+        bench_grayscale_op_erode_medium_image_large_square,
+        grayscale_erode,
+        Mask::square(25),
+        200
+    );
 
-    bench_grayscale_operator!(bench_grayscale_op_dilate_small_image_point, grayscale_dilate, Mask::diamond(0), 50);
-    bench_grayscale_operator!(bench_grayscale_op_dilate_medium_image_point, grayscale_dilate, Mask::diamond(0), 200);
-    bench_grayscale_operator!(bench_grayscale_op_dilate_big_image_point, grayscale_dilate, Mask::diamond(0), 1000);
-    bench_grayscale_operator!(bench_grayscale_op_dilate_small_image_diamond, grayscale_dilate, Mask::diamond(5), 50);
-    bench_grayscale_operator!(bench_grayscale_op_dilate_medium_image_diamond, grayscale_dilate, Mask::diamond(5), 200);
-    bench_grayscale_operator!(bench_grayscale_op_dilate_big_image_diamond, grayscale_dilate, Mask::diamond(5), 1000);
-    bench_grayscale_operator!(bench_grayscale_op_dilate_small_image_large_square, grayscale_dilate, Mask::square(25), 50);
-    bench_grayscale_operator!(bench_grayscale_op_dilate_medium_image_large_square, grayscale_dilate, Mask::square(25), 200);
+    bench_grayscale_operator!(
+        bench_grayscale_op_dilate_small_image_point,
+        grayscale_dilate,
+        Mask::diamond(0),
+        50
+    );
+    bench_grayscale_operator!(
+        bench_grayscale_op_dilate_medium_image_point,
+        grayscale_dilate,
+        Mask::diamond(0),
+        200
+    );
+    bench_grayscale_operator!(
+        bench_grayscale_op_dilate_big_image_point,
+        grayscale_dilate,
+        Mask::diamond(0),
+        1000
+    );
+    bench_grayscale_operator!(
+        bench_grayscale_op_dilate_small_image_diamond,
+        grayscale_dilate,
+        Mask::diamond(5),
+        50
+    );
+    bench_grayscale_operator!(
+        bench_grayscale_op_dilate_medium_image_diamond,
+        grayscale_dilate,
+        Mask::diamond(5),
+        200
+    );
+    bench_grayscale_operator!(
+        bench_grayscale_op_dilate_big_image_diamond,
+        grayscale_dilate,
+        Mask::diamond(5),
+        1000
+    );
+    bench_grayscale_operator!(
+        bench_grayscale_op_dilate_small_image_large_square,
+        grayscale_dilate,
+        Mask::square(25),
+        50
+    );
+    bench_grayscale_operator!(
+        bench_grayscale_op_dilate_medium_image_large_square,
+        grayscale_dilate,
+        Mask::square(25),
+        200
+    );
 }


### PR DESCRIPTION
This PR has been made following the issue #597  : optimization of grayscale morphology operators

it aims to work on the internal implementation of the `Mask` and associated functions to optimize the execution time, as well as add parallel versions of some public functions using rayon.

in the first commit that i have made, i have added bench for the `Mask` creation methods and have reworked the implementation of the `from_image` methods, which allowed a 4x speed increase (200 ms to 50ms) for a large image (200 by 200 pixels). i would expect the improvement to be less significant for smaller images, although i have not tested it.

it was brought to my attention that i was accessing image pixels in col-major order. That was due to a misunderstanding of the image layout from my part. In light of this, i have reworked the implementation of the `Mask` to facilitate and incentivize access in row-major order by storing the positions row by row.

i have also been advised to change (i16, i16) to Point<i16> for readability, which i will do in a further commit.

Finally, through my testing, i tried to use `unsafe_get_pixel` to optimize my `get_pixel` calls. While it was very efficient, i found that accessing the buffer directly and using the `chunks` method was faster by around 17% (~65  to ~50microsecond ). i tested it several times, and the slowest `chunks` time was faster than the fastest `unsafe_get_pixel` by 10 ms. 

i believe that it might be interesting to look at for other uses of `unsafe_get_pixel` which traverse the image line by line, as it potentially could be the case that directly traversing a `[u8]` might allow the compiler to do better optimizations than when these accesses are obfuscated through `unsafe_get_pixel`