### PR TITLE
Gradient enum and Kernel trait V2

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -98,7 +98,7 @@ jobs:
     # https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability
     strategy:
       matrix:
-        msrv: ["1.70.0"] # 2021 edition requires 1.56
+        msrv: ["1.75.0"] # 2021 edition requires 1.56
     name: ubuntu / ${{ matrix.msrv }}
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "imageproc"
 version = "0.25.0"
 authors = ["theotherphil"]
 # note: when changed, also update `msrv` in `.github/workflows/check.yml`
-rust-version = "1.70.0"
+rust-version = "1.75.0"
 edition = "2021"
 license = "MIT"
 description = "Image processing operations"

--- a/examples/gradients.rs
+++ b/examples/gradients.rs
@@ -5,7 +5,7 @@
 //! `cargo run --example gradients ./examples/empire-state-building.jpg ./tmp`
 
 use image::{open, GrayImage};
-use imageproc::{filter::filter3x3, gradients::GradientKernel, map::map_subpixels};
+use imageproc::{filter::filter_clamped, gradients::GradientKernel, map::map_subpixels};
 use std::{env, fs, path::Path};
 
 fn save_gradients(
@@ -15,8 +15,8 @@ fn save_gradients(
     name: &str,
     scale: i16,
 ) {
-    let horizontal_gradients = filter3x3(input, gradient_kernel.kernel1::<i16>());
-    let vertical_gradients = filter3x3(input, gradient_kernel.kernel2::<i16>());
+    let horizontal_gradients = filter_clamped(input, gradient_kernel.kernel1::<i16>());
+    let vertical_gradients = filter_clamped(input, gradient_kernel.kernel2::<i16>());
 
     let horizontal_scaled = map_subpixels(&horizontal_gradients, |p: i16| (p.abs() / scale) as u8);
     let vertical_scaled = map_subpixels(&vertical_gradients, |p: i16| (p.abs() / scale) as u8);

--- a/examples/gradients.rs
+++ b/examples/gradients.rs
@@ -4,29 +4,29 @@
 //!
 //! `cargo run --example gradients ./examples/empire-state-building.jpg ./tmp`
 
-use image::{open, GrayImage, Luma};
-use imageproc::{
-    definitions::Image,
-    gradients::{
-        horizontal_prewitt, horizontal_scharr, horizontal_sobel, vertical_prewitt, vertical_scharr,
-        vertical_sobel,
-    },
-    map::map_pixels,
-};
+use image::{open, GrayImage};
+use imageproc::{filter::filter3x3, gradients::GradientKernel, map::map_subpixels};
 use std::{env, fs, path::Path};
 
-fn compute_gradients<F>(
+fn save_gradients(
     input: &GrayImage,
-    gradient_func: F,
+    gradient_kernel: &GradientKernel,
     output_dir: &Path,
-    file_name: &str,
+    name: &str,
     scale: i16,
-) where
-    F: Fn(&GrayImage) -> Image<Luma<i16>>,
-{
-    let gradient = gradient_func(input);
-    let gradient = map_pixels(&gradient, |_, _, p| Luma([(p[0].abs() / scale) as u8]));
-    gradient.save(&output_dir.join(file_name)).unwrap();
+) {
+    let horizontal_gradients = filter3x3(input, &gradient_kernel.as_horizontal_kernel::<i16>());
+    let vertical_gradients = filter3x3(input, &gradient_kernel.as_vertical_kernel::<i16>());
+
+    let horizontal_scaled = map_subpixels(&horizontal_gradients, |p: i16| (p.abs() / scale) as u8);
+    let vertical_scaled = map_subpixels(&vertical_gradients, |p: i16| (p.abs() / scale) as u8);
+
+    horizontal_scaled
+        .save(&output_dir.join(format!("{name}_horizontal.png")))
+        .unwrap();
+    vertical_scaled
+        .save(&output_dir.join(format!("{name}_horizontal.png")))
+        .unwrap();
 }
 
 fn main() {
@@ -57,46 +57,20 @@ fn main() {
     let gray_path = output_dir.join("grey.png");
     input_image.save(&gray_path).unwrap();
 
-    compute_gradients(
-        &input_image,
-        horizontal_scharr,
-        output_dir,
-        "horizontal_scharr.png",
-        32,
-    );
-    compute_gradients(
-        &input_image,
-        vertical_scharr,
-        output_dir,
-        "vertical_scharr.png",
-        32,
-    );
-    compute_gradients(
-        &input_image,
-        horizontal_sobel,
-        output_dir,
-        "horizontal_sobel.png",
-        8,
-    );
-    compute_gradients(
-        &input_image,
-        vertical_sobel,
-        output_dir,
-        "vertical_sobel.png",
-        8,
-    );
-    compute_gradients(
-        &input_image,
-        horizontal_prewitt,
-        output_dir,
-        "horizontal_prewitt.png",
-        6,
-    );
-    compute_gradients(
-        &input_image,
-        vertical_prewitt,
-        output_dir,
-        "vertical_prewitt.png",
-        6,
-    );
+    for gradient_kernel in GradientKernel::ALL {
+        let scale = match gradient_kernel {
+            GradientKernel::Sobel => 32,
+            GradientKernel::Scharr => 8,
+            GradientKernel::Prewitt => 6,
+            GradientKernel::Roberts => 4,
+        };
+
+        save_gradients(
+            &input_image,
+            &gradient_kernel,
+            output_dir,
+            &format!("{gradient_kernel:?}"),
+            scale,
+        );
+    }
 }

--- a/examples/gradients.rs
+++ b/examples/gradients.rs
@@ -15,8 +15,8 @@ fn save_gradients(
     name: &str,
     scale: i16,
 ) {
-    let horizontal_gradients = filter3x3(input, &gradient_kernel.as_horizontal_kernel::<i16>());
-    let vertical_gradients = filter3x3(input, &gradient_kernel.as_vertical_kernel::<i16>());
+    let horizontal_gradients = filter3x3(input, gradient_kernel.horizontal_kernel::<i16>());
+    let vertical_gradients = filter3x3(input, gradient_kernel.vertical_kernel::<i16>());
 
     let horizontal_scaled = map_subpixels(&horizontal_gradients, |p: i16| (p.abs() / scale) as u8);
     let vertical_scaled = map_subpixels(&vertical_gradients, |p: i16| (p.abs() / scale) as u8);

--- a/examples/gradients.rs
+++ b/examples/gradients.rs
@@ -25,7 +25,7 @@ fn save_gradients(
         .save(&output_dir.join(format!("{name}_horizontal.png")))
         .unwrap();
     vertical_scaled
-        .save(&output_dir.join(format!("{name}_horizontal.png")))
+        .save(&output_dir.join(format!("{name}_vertical.png")))
         .unwrap();
 }
 

--- a/examples/gradients.rs
+++ b/examples/gradients.rs
@@ -5,13 +5,13 @@
 //! `cargo run --example gradients ./examples/empire-state-building.jpg ./tmp`
 
 use image::{open, GrayImage};
-use imageproc::{filter::filter_clamped, kernel::OwnedKernel, map::map_subpixels};
+use imageproc::{filter::filter_clamped, kernel::Kernel, map::map_subpixels};
 use std::{env, fs, path::Path};
 
 fn save_gradients(
     input: &GrayImage,
-    horizontal_kernel: &OwnedKernel<i16>,
-    vertical_kernel: &OwnedKernel<i16>,
+    horizontal_kernel: Kernel<i32>,
+    vertical_kernel: Kernel<i32>,
     output_dir: &Path,
     name: &str,
     scale: i16,
@@ -61,36 +61,29 @@ fn main() {
     for (name, horizontal, vertical, scale) in [
         (
             "sobel",
-            OwnedKernel::sobel_horizontal_3x3(),
-            OwnedKernel::sobel_vertical_3x3(),
+            Kernel::<i32>::SOBEL_HORIZONTAL_3X3,
+            Kernel::<i32>::SOBEL_VERTICAL_3X3,
             32,
         ),
         (
             "scharr",
-            OwnedKernel::scharr_horizontal_3x3(),
-            OwnedKernel::scharr_vertical_3x3(),
+            Kernel::<i32>::SCHARR_HORIZONTAL_3X3,
+            Kernel::<i32>::SCHARR_VERTICAL_3X3,
             8,
         ),
         (
             "prewitt",
-            OwnedKernel::prewitt_horizontal_3x3(),
-            OwnedKernel::prewitt_vertical_3x3(),
+            Kernel::<i32>::PREWITT_HORIZONTAL_3X3,
+            Kernel::<i32>::PREWITT_VERTICAL_3X3,
             6,
         ),
         (
             "roberts",
-            OwnedKernel::roberts_horizontal_2x2(),
-            OwnedKernel::roberts_vertical_2x2(),
+            Kernel::<i32>::ROBERTS_HORIZONTAL_2X2,
+            Kernel::<i32>::ROBERTS_VERTICAL_2X2,
             4,
         ),
     ] {
-        save_gradients(
-            &input_image,
-            &horizontal,
-            &vertical,
-            output_dir,
-            name,
-            scale,
-        );
+        save_gradients(&input_image, horizontal, vertical, output_dir, name, scale);
     }
 }

--- a/examples/gradients.rs
+++ b/examples/gradients.rs
@@ -15,8 +15,8 @@ fn save_gradients(
     name: &str,
     scale: i16,
 ) {
-    let horizontal_gradients = filter3x3(input, gradient_kernel.horizontal_kernel::<i16>());
-    let vertical_gradients = filter3x3(input, gradient_kernel.vertical_kernel::<i16>());
+    let horizontal_gradients = filter3x3(input, gradient_kernel.kernel1::<i16>());
+    let vertical_gradients = filter3x3(input, gradient_kernel.kernel2::<i16>());
 
     let horizontal_scaled = map_subpixels(&horizontal_gradients, |p: i16| (p.abs() / scale) as u8);
     let vertical_scaled = map_subpixels(&vertical_gradients, |p: i16| (p.abs() / scale) as u8);

--- a/examples/seam_carving.rs
+++ b/examples/seam_carving.rs
@@ -1,7 +1,7 @@
 use image::{open, GrayImage, Luma, Pixel};
 use imageproc::definitions::Clamp;
 use imageproc::gradients::gradients;
-use imageproc::gradients::GradientKernel;
+use imageproc::kernel::OwnedKernel;
 use imageproc::map::map_colors;
 use imageproc::seam_carving::*;
 use std::env;
@@ -60,10 +60,15 @@ fn main() {
     annotated.save(&annotated_path).unwrap();
 
     // Draw the seams on the gradient magnitude image.
-    let gradients = gradients(&input_image, GradientKernel::Sobel, |p| {
-        let mean = (p[0] + p[1] + p[2]) / 3;
-        Luma([mean as u32])
-    });
+    let gradients = gradients(
+        &input_image,
+        OwnedKernel::sobel_horizontal_3x3(),
+        OwnedKernel::sobel_vertical_3x3(),
+        |p| {
+            let mean = (p[0] + p[1] + p[2]) / 3;
+            Luma([mean as u32])
+        },
+    );
     let clamped_gradients: GrayImage = map_colors(&gradients, |p| Luma([Clamp::clamp(p[0])]));
     let annotated_gradients = draw_vertical_seams(&clamped_gradients, &seams);
     let gradients_path = output_dir.join("gradients.png");

--- a/examples/seam_carving.rs
+++ b/examples/seam_carving.rs
@@ -1,6 +1,7 @@
 use image::{open, GrayImage, Luma, Pixel};
 use imageproc::definitions::Clamp;
-use imageproc::gradients::sobel_gradient_map;
+use imageproc::gradients::gradients;
+use imageproc::gradients::GradientKernel;
 use imageproc::map::map_colors;
 use imageproc::seam_carving::*;
 use std::env;
@@ -59,10 +60,16 @@ fn main() {
     annotated.save(&annotated_path).unwrap();
 
     // Draw the seams on the gradient magnitude image.
-    let gradients = sobel_gradient_map(&input_image, |p| {
-        let mean = (p[0] + p[1] + p[2]) / 3;
-        Luma([mean as u32])
-    });
+    let gradient_kernel = GradientKernel::Sobel;
+    let gradients = gradients(
+        &input_image,
+        &gradient_kernel.as_horizontal_kernel(),
+        &gradient_kernel.as_vertical_kernel(),
+        |p| {
+            let mean = (p[0] + p[1] + p[2]) / 3;
+            Luma([mean as u32])
+        },
+    );
     let clamped_gradients: GrayImage = map_colors(&gradients, |p| Luma([Clamp::clamp(p[0])]));
     let annotated_gradients = draw_vertical_seams(&clamped_gradients, &seams);
     let gradients_path = output_dir.join("gradients.png");

--- a/examples/seam_carving.rs
+++ b/examples/seam_carving.rs
@@ -60,16 +60,10 @@ fn main() {
     annotated.save(&annotated_path).unwrap();
 
     // Draw the seams on the gradient magnitude image.
-    let gradient_kernel = GradientKernel::Sobel;
-    let gradients = gradients(
-        &input_image,
-        &gradient_kernel.as_horizontal_kernel(),
-        &gradient_kernel.as_vertical_kernel(),
-        |p| {
-            let mean = (p[0] + p[1] + p[2]) / 3;
-            Luma([mean as u32])
-        },
-    );
+    let gradients = gradients(&input_image, GradientKernel::Sobel, |p| {
+        let mean = (p[0] + p[1] + p[2]) / 3;
+        Luma([mean as u32])
+    });
     let clamped_gradients: GrayImage = map_colors(&gradients, |p| Luma([Clamp::clamp(p[0])]));
     let annotated_gradients = draw_vertical_seams(&clamped_gradients, &seams);
     let gradients_path = output_dir.join("gradients.png");

--- a/examples/seam_carving.rs
+++ b/examples/seam_carving.rs
@@ -1,7 +1,7 @@
 use image::{open, GrayImage, Luma, Pixel};
 use imageproc::definitions::Clamp;
 use imageproc::gradients::gradients;
-use imageproc::kernel::OwnedKernel;
+use imageproc::kernel::Kernel;
 use imageproc::map::map_colors;
 use imageproc::seam_carving::*;
 use std::env;
@@ -62,8 +62,8 @@ fn main() {
     // Draw the seams on the gradient magnitude image.
     let gradients = gradients(
         &input_image,
-        OwnedKernel::sobel_horizontal_3x3(),
-        OwnedKernel::sobel_vertical_3x3(),
+        Kernel::<i32>::SOBEL_HORIZONTAL_3X3,
+        Kernel::<i32>::SOBEL_VERTICAL_3X3,
         |p| {
             let mean = (p[0] + p[1] + p[2]) / 3;
             Luma([mean as u32])

--- a/src/edges.rs
+++ b/src/edges.rs
@@ -1,8 +1,9 @@
 //! Functions for detecting edges in images.
 
 use crate::definitions::{HasBlack, HasWhite};
+use crate::filter::filter3x3;
 use crate::filter::gaussian_blur_f32;
-use crate::gradients::{horizontal_sobel, vertical_sobel};
+use crate::gradients::GradientKernel;
 use image::{GenericImageView, GrayImage, ImageBuffer, Luma};
 use std::f32;
 
@@ -35,8 +36,9 @@ pub fn canny(image: &GrayImage, low_threshold: f32, high_threshold: f32) -> Gray
     let blurred = gaussian_blur_f32(image, SIGMA);
 
     // 2. Intensity of gradients.
-    let gx = horizontal_sobel(&blurred);
-    let gy = vertical_sobel(&blurred);
+    let gradient_kernel = GradientKernel::Sobel;
+    let gx = filter3x3(&blurred, &gradient_kernel.as_horizontal_kernel::<i16>());
+    let gy = filter3x3(&blurred, &gradient_kernel.as_vertical_kernel::<i16>());
     let g: Vec<f32> = gx
         .iter()
         .zip(gy.iter())

--- a/src/edges.rs
+++ b/src/edges.rs
@@ -37,8 +37,8 @@ pub fn canny(image: &GrayImage, low_threshold: f32, high_threshold: f32) -> Gray
 
     // 2. Intensity of gradients.
     let gradient_kernel = GradientKernel::Sobel;
-    let gx = filter3x3(&blurred, &gradient_kernel.as_horizontal_kernel::<i16>());
-    let gy = filter3x3(&blurred, &gradient_kernel.as_vertical_kernel::<i16>());
+    let gx = filter3x3::<_, i16, i16>(&blurred, &gradient_kernel.horizontal_kernel());
+    let gy = filter3x3::<_, i16, i16>(&blurred, &gradient_kernel.vertical_kernel());
     let g: Vec<f32> = gx
         .iter()
         .zip(gy.iter())

--- a/src/edges.rs
+++ b/src/edges.rs
@@ -37,8 +37,8 @@ pub fn canny(image: &GrayImage, low_threshold: f32, high_threshold: f32) -> Gray
 
     // 2. Intensity of gradients.
     let gradient_kernel = GradientKernel::Sobel;
-    let gx = filter3x3::<_, i16, i16>(&blurred, &gradient_kernel.horizontal_kernel());
-    let gy = filter3x3::<_, i16, i16>(&blurred, &gradient_kernel.vertical_kernel());
+    let gx = filter3x3::<_, i16, i16>(&blurred, &gradient_kernel.kernel1());
+    let gy = filter3x3::<_, i16, i16>(&blurred, &gradient_kernel.kernel2());
     let g: Vec<f32> = gx
         .iter()
         .zip(gy.iter())

--- a/src/edges.rs
+++ b/src/edges.rs
@@ -2,7 +2,7 @@
 
 use crate::definitions::{HasBlack, HasWhite};
 use crate::filter::{filter_clamped, gaussian_blur_f32};
-use crate::kernel::OwnedKernel;
+use crate::kernel::Kernel;
 use image::{GenericImageView, GrayImage, ImageBuffer, Luma};
 use std::f32;
 
@@ -35,8 +35,8 @@ pub fn canny(image: &GrayImage, low_threshold: f32, high_threshold: f32) -> Gray
     let blurred = gaussian_blur_f32(image, SIGMA);
 
     // 2. Intensity of gradients.
-    let gx = filter_clamped::<_, i16, i16>(&blurred, OwnedKernel::sobel_horizontal_3x3());
-    let gy = filter_clamped::<_, i16, i16>(&blurred, OwnedKernel::sobel_vertical_3x3());
+    let gx = filter_clamped(&blurred, Kernel::<i32>::SOBEL_HORIZONTAL_3X3);
+    let gy = filter_clamped(&blurred, Kernel::<i32>::SOBEL_VERTICAL_3X3);
     let g: Vec<f32> = gx
         .iter()
         .zip(gy.iter())

--- a/src/edges.rs
+++ b/src/edges.rs
@@ -2,7 +2,7 @@
 
 use crate::definitions::{HasBlack, HasWhite};
 use crate::filter::{filter_clamped, gaussian_blur_f32};
-use crate::gradients::GradientKernel;
+use crate::kernel::OwnedKernel;
 use image::{GenericImageView, GrayImage, ImageBuffer, Luma};
 use std::f32;
 
@@ -35,9 +35,8 @@ pub fn canny(image: &GrayImage, low_threshold: f32, high_threshold: f32) -> Gray
     let blurred = gaussian_blur_f32(image, SIGMA);
 
     // 2. Intensity of gradients.
-    let gradient_kernel = GradientKernel::Sobel;
-    let gx = filter_clamped::<_, i16, i16>(&blurred, &gradient_kernel.kernel1());
-    let gy = filter_clamped::<_, i16, i16>(&blurred, &gradient_kernel.kernel2());
+    let gx = filter_clamped::<_, i16, i16>(&blurred, OwnedKernel::sobel_horizontal_3x3());
+    let gy = filter_clamped::<_, i16, i16>(&blurred, OwnedKernel::sobel_vertical_3x3());
     let g: Vec<f32> = gx
         .iter()
         .zip(gy.iter())

--- a/src/edges.rs
+++ b/src/edges.rs
@@ -1,8 +1,7 @@
 //! Functions for detecting edges in images.
 
 use crate::definitions::{HasBlack, HasWhite};
-use crate::filter::filter3x3;
-use crate::filter::gaussian_blur_f32;
+use crate::filter::{filter_clamped, gaussian_blur_f32};
 use crate::gradients::GradientKernel;
 use image::{GenericImageView, GrayImage, ImageBuffer, Luma};
 use std::f32;
@@ -37,8 +36,8 @@ pub fn canny(image: &GrayImage, low_threshold: f32, high_threshold: f32) -> Gray
 
     // 2. Intensity of gradients.
     let gradient_kernel = GradientKernel::Sobel;
-    let gx = filter3x3::<_, i16, i16>(&blurred, &gradient_kernel.kernel1());
-    let gy = filter3x3::<_, i16, i16>(&blurred, &gradient_kernel.kernel2());
+    let gx = filter_clamped::<_, i16, i16>(&blurred, &gradient_kernel.kernel1());
+    let gy = filter_clamped::<_, i16, i16>(&blurred, &gradient_kernel.kernel2());
     let g: Vec<f32> = gx
         .iter()
         .zip(gy.iter())

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -242,12 +242,29 @@ where
 }
 
 /// A 2D kernel, used to filter images via convolution.
+#[derive(Debug, Clone)]
+pub struct SeparableKernel<K> {
+    pub(crate) horizontal_kernel: Kernel<K>,
+    pub(crate) vertical_kernel: Kernel<K>,
+}
+impl<K> SeparableKernel<K> {
+    /// Maps the separable kernel from type `K` to `Q` via the closure `f`.
+    pub fn map<Q>(self, f: &impl Fn(K) -> Q) -> SeparableKernel<Q> {
+        SeparableKernel {
+            horizontal_kernel: self.horizontal_kernel.map(f),
+            vertical_kernel: self.vertical_kernel.map(f),
+        }
+    }
+}
+
+/// A 2D kernel, used to filter images via convolution.
+#[derive(Debug, Clone)]
 pub struct Kernel<K> {
     pub(crate) data: Vec<K>,
     width: u32,
     height: u32,
 }
-impl<K: Num + Copy> Kernel<K> {
+impl<K> Kernel<K> {
     /// Construct a kernel from a slice and its dimensions. The input slice is
     /// in row-major form.
     pub fn new(data: Vec<K>, width: u32, height: u32) -> Kernel<K> {
@@ -264,11 +281,8 @@ impl<K: Num + Copy> Kernel<K> {
             height,
         }
     }
-    /// Maps the kernel from type `K` to `Q` via the closure `F`.
-    pub fn map<F, Q>(self, f: F) -> Kernel<Q>
-    where
-        F: Fn(K) -> Q,
-    {
+    /// Maps the kernel from type `K` to `Q` via the closure `f`.
+    pub fn map<Q>(self, f: &impl Fn(K) -> Q) -> Kernel<Q> {
         Kernel {
             data: self.data.into_iter().map(f).collect(),
             width: self.width,

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -10,6 +10,7 @@ use image::{GenericImage, GenericImageView, GrayImage, ImageBuffer, Luma, Pixel,
 
 use crate::definitions::{Clamp, Image};
 use crate::integral_image::{column_running_sum, row_running_sum};
+use crate::kernel::{Kernel, OwnedKernel};
 use crate::map::{ChannelMap, WithChannel};
 use num::Num;
 
@@ -201,7 +202,7 @@ pub fn box_filter(image: &GrayImage, x_radius: u32, y_radius: u32) -> Image<Luma
 
 /// Returns 2d correlation of an image. Intermediate calculations are performed
 /// at type K, and the results converted to pixel Q via f. Pads by continuity.
-pub fn filter<P, K, F, Q>(image: &Image<P>, kernel: &Kernel<K>, mut f: F) -> Image<Q>
+pub fn filter<P, K, F, Q>(image: &Image<P>, kernel: impl Kernel<K>, mut f: F) -> Image<Q>
 where
     P: Pixel,
     <P as Pixel>::Subpixel: Into<K>,
@@ -214,8 +215,11 @@ where
     let num_channels = P::CHANNEL_COUNT as usize;
     let zero = K::zero();
     let mut acc = vec![zero; num_channels];
-    let (k_width, k_height) = (kernel.width as i64, kernel.height as i64);
-    let (width, height) = (width as i64, height as i64);
+
+    let (k_width, k_height) = (kernel.width(), kernel.height());
+
+    let (width, height, k_width, k_height) =
+        (width as i64, height as i64, k_width as i64, k_height as i64);
 
     for y in 0..height {
         for x in 0..width {
@@ -226,7 +230,7 @@ where
                     accumulate(
                         &mut acc,
                         unsafe { &image.unsafe_get_pixel(x_p, y_p) },
-                        unsafe { *kernel.data.get_unchecked((k_y * k_width + k_x) as usize) },
+                        *kernel.get(k_x as u32, k_y as u32),
                     );
                 }
             }
@@ -241,56 +245,6 @@ where
     out
 }
 
-/// A 2D kernel, used to filter images via convolution.
-#[derive(Debug, Clone)]
-pub struct SeparableKernel<K> {
-    pub(crate) horizontal_kernel: Kernel<K>,
-    pub(crate) vertical_kernel: Kernel<K>,
-}
-impl<K> SeparableKernel<K> {
-    /// Maps the separable kernel from type `K` to `Q` via the closure `f`.
-    pub fn map<Q>(self, f: &impl Fn(K) -> Q) -> SeparableKernel<Q> {
-        SeparableKernel {
-            horizontal_kernel: self.horizontal_kernel.map(f),
-            vertical_kernel: self.vertical_kernel.map(f),
-        }
-    }
-}
-
-/// A 2D kernel, used to filter images via convolution.
-#[derive(Debug, Clone)]
-pub struct Kernel<K> {
-    pub(crate) data: Vec<K>,
-    width: u32,
-    height: u32,
-}
-impl<K> Kernel<K> {
-    /// Construct a kernel from a slice and its dimensions. The input slice is
-    /// in row-major form.
-    pub fn new(data: Vec<K>, width: u32, height: u32) -> Kernel<K> {
-        assert!(width > 0 && height > 0, "width and height must be non-zero");
-        assert!(
-            width * height == data.len() as u32,
-            "Invalid kernel len: expecting {}, found {}",
-            width * height,
-            data.len()
-        );
-        Kernel {
-            data,
-            width,
-            height,
-        }
-    }
-    /// Maps the kernel from type `K` to `Q` via the closure `f`.
-    pub fn map<Q>(self, f: &impl Fn(K) -> Q) -> Kernel<Q> {
-        Kernel {
-            data: self.data.into_iter().map(f).collect(),
-            width: self.width,
-            height: self.height,
-        }
-    }
-}
-
 #[inline]
 fn gaussian(x: f32, r: f32) -> f32 {
     ((2.0 * f32::consts::PI).sqrt() * r).recip() * (-x.powi(2) / (2.0 * r.powi(2))).exp()
@@ -298,7 +252,7 @@ fn gaussian(x: f32, r: f32) -> f32 {
 
 /// Construct a one dimensional float-valued kernel for performing a Gaussian blur
 /// with standard deviation sigma.
-fn gaussian_kernel_f32(sigma: f32) -> Kernel<f32> {
+fn gaussian_kernel_f32(sigma: f32) -> OwnedKernel<f32> {
     let kernel_radius = (2.0 * sigma).ceil() as usize;
     let mut kernel_data = vec![0.0; 2 * kernel_radius + 1];
     for i in 0..kernel_radius + 1 {
@@ -309,11 +263,8 @@ fn gaussian_kernel_f32(sigma: f32) -> Kernel<f32> {
     let sum: f32 = kernel_data.iter().sum();
     kernel_data.iter_mut().for_each(|x| *x /= sum);
 
-    Kernel {
-        width: kernel_data.len() as u32,
-        height: 1,
-        data: kernel_data,
-    }
+    let len = kernel_data.len();
+    OwnedKernel::new(kernel_data, len as u32, 1)
 }
 
 /// Blurs an image using a Gaussian of standard deviation sigma.
@@ -332,7 +283,7 @@ where
 {
     assert!(sigma > 0.0, "sigma must be > 0.0");
     let kernel = gaussian_kernel_f32(sigma);
-    separable_filter_equal(image, &kernel)
+    separable_filter_equal(image, kernel)
 }
 
 /// Returns 2d correlation of view with the outer product of the 1d
@@ -340,14 +291,25 @@ where
 #[must_use = "the function does not modify the original image"]
 pub fn separable_filter<P, K>(
     image: &Image<P>,
-    h_kernel: &Kernel<K>,
-    v_kernel: &Kernel<K>,
+    h_kernel: impl Kernel<K>,
+    v_kernel: impl Kernel<K>,
 ) -> Image<P>
 where
     P: Pixel,
     <P as Pixel>::Subpixel: Into<K> + Clamp<K>,
     K: Num + Copy,
 {
+    assert_eq!(
+        h_kernel.height(),
+        1,
+        "h_kernel in separable_filter must be 1 dimensional"
+    );
+    assert_eq!(
+        v_kernel.height(),
+        1,
+        "v_kernel in separable_filter must be 1 dimensional"
+    );
+
     let h = horizontal_filter(image, h_kernel);
     vertical_filter(&h, v_kernel)
 }
@@ -355,24 +317,25 @@ where
 /// Returns 2d correlation of an image with the outer product of the 1d
 /// kernel filter with itself.
 #[must_use = "the function does not modify the original image"]
-pub fn separable_filter_equal<P, K>(image: &Image<P>, kernel: &Kernel<K>) -> Image<P>
+pub fn separable_filter_equal<P, K>(image: &Image<P>, kernel: impl Kernel<K>) -> Image<P>
 where
     P: Pixel,
     <P as Pixel>::Subpixel: Into<K> + Clamp<K>,
     K: Num + Copy,
 {
     assert_eq!(
-        kernel.height, 1,
-        "separable_filter only works with 1 dimensional kernels"
+        kernel.height(),
+        1,
+        "the kernel in separable_filter_equal() must be 1 dimensional"
     );
 
-    separable_filter(image, kernel, kernel)
+    separable_filter(image, &kernel, &kernel)
 }
 
 /// Returns 2d correlation of an image with a 3x3 row-major kernel. Intermediate calculations are
 /// performed at type K, and the results clamped to subpixel type S. Pads by continuity.
 #[must_use = "the function does not modify the original image"]
-pub fn filter3x3<P, K, S>(image: &Image<P>, kernel: &Kernel<K>) -> Image<ChannelMap<P, S>>
+pub fn filter3x3<P, K, S>(image: &Image<P>, kernel: impl Kernel<K>) -> Image<ChannelMap<P, S>>
 where
     P::Subpixel: Into<K>,
     S: Clamp<K> + Primitive,
@@ -380,11 +343,13 @@ where
     K: Num + Copy,
 {
     assert_eq!(
-        kernel.width, 3,
+        kernel.width(),
+        3,
         "kernel width must equal 3 to use filter3x3"
     );
     assert_eq!(
-        kernel.height, 3,
+        kernel.height(),
+        3,
         "kernel height must equal 3 to use filter3x3"
     );
 
@@ -395,15 +360,16 @@ where
 /// Pads by continuity. Intermediate calculations are performed at
 /// type K.
 #[must_use = "the function does not modify the original image"]
-pub fn horizontal_filter<P, K>(image: &Image<P>, kernel: &Kernel<K>) -> Image<P>
+pub fn horizontal_filter<P, K>(image: &Image<P>, kernel: impl Kernel<K>) -> Image<P>
 where
     P: Pixel,
     <P as Pixel>::Subpixel: Into<K> + Clamp<K>,
     K: Num + Copy,
 {
     assert_eq!(
-        kernel.height, 1,
-        "horizontal_filter only works with 1 dimensional kernels"
+        kernel.height(),
+        1,
+        "horizontal_filter only works with kernels with heights of 1"
     );
 
     // Don't replace this with a call to Kernel::filter without
@@ -413,15 +379,15 @@ where
     let mut out = Image::<P>::new(width, height);
     let zero = K::zero();
     let mut acc = vec![zero; P::CHANNEL_COUNT as usize];
-    let k_width = kernel.data.len() as i32;
+    let k_width = kernel.width() as i32;
 
     // Typically the image side will be much larger than the kernel length.
     // In that case we can remove a lot of bounds checks for most pixels.
     if k_width >= width as i32 {
         for y in 0..height {
             for x in 0..width {
-                for (i, k) in kernel.data.iter().enumerate() {
-                    let x_unchecked = (x as i32) + i as i32 - k_width / 2;
+                for (k_point, k) in kernel.enumerate() {
+                    let x_unchecked = (x as i32) + k_point.x as i32 - k_width / 2;
                     let x_p = max(0, min(x_unchecked, width as i32 - 1)) as u32;
                     let p = unsafe { image.unsafe_get_pixel(x_p, y) };
                     accumulate(&mut acc, &p, *k);
@@ -443,8 +409,8 @@ where
     for y in 0..height {
         // Left margin - need to check lower bound only
         for x in 0..half_k {
-            for (i, k) in kernel.data.iter().enumerate() {
-                let x_unchecked = x + i as i32 - k_width / 2;
+            for (k_point, k) in kernel.enumerate() {
+                let x_unchecked = x + k_point.x as i32 - k_width / 2;
                 let x_p = max(0, x_unchecked) as u32;
                 let p = unsafe { image.unsafe_get_pixel(x_p, y) };
                 accumulate(&mut acc, &p, *k);
@@ -459,8 +425,8 @@ where
 
         // Neither margin - don't need bounds check on either side
         for x in half_k..(width as i32 - half_k) {
-            for (i, k) in kernel.data.iter().enumerate() {
-                let x_unchecked = x + i as i32 - k_width / 2;
+            for (k_point, k) in kernel.enumerate() {
+                let x_unchecked = x + k_point.x as i32 - k_width / 2;
                 let x_p = x_unchecked as u32;
                 let p = unsafe { image.unsafe_get_pixel(x_p, y) };
                 accumulate(&mut acc, &p, *k);
@@ -475,8 +441,8 @@ where
 
         // Right margin - need to check upper bound only
         for x in (width as i32 - half_k)..(width as i32) {
-            for (i, k) in kernel.data.iter().enumerate() {
-                let x_unchecked = x + i as i32 - k_width / 2;
+            for (k_point, k) in kernel.enumerate() {
+                let x_unchecked = x + k_point.x as i32 - k_width / 2;
                 let x_p = min(x_unchecked, width as i32 - 1) as u32;
                 let p = unsafe { image.unsafe_get_pixel(x_p, y) };
                 accumulate(&mut acc, &p, *k);
@@ -496,15 +462,16 @@ where
 /// Returns horizontal correlations between an image and a 1d kernel.
 /// Pads by continuity.
 #[must_use = "the function does not modify the original image"]
-pub fn vertical_filter<P, K>(image: &Image<P>, kernel: &Kernel<K>) -> Image<P>
+pub fn vertical_filter<P, K>(image: &Image<P>, kernel: impl Kernel<K>) -> Image<P>
 where
     P: Pixel,
     <P as Pixel>::Subpixel: Into<K> + Clamp<K>,
     K: Num + Copy,
 {
     assert_eq!(
-        kernel.height, 1,
-        "vertical_filter only works with 1 dimensional kernels"
+        kernel.width(),
+        1,
+        "vertical_filter only works with kernels with widths of 1"
     );
 
     // Don't replace this with a call to Kernel::filter without
@@ -514,15 +481,15 @@ where
     let mut out = Image::<P>::new(width, height);
     let zero = K::zero();
     let mut acc = vec![zero; P::CHANNEL_COUNT as usize];
-    let k_height = kernel.data.len() as i32;
+    let k_height = kernel.height() as i32;
 
     // Typically the image side will be much larger than the kernel length.
     // In that case we can remove a lot of bounds checks for most pixels.
     if k_height >= height as i32 {
         for y in 0..height {
             for x in 0..width {
-                for (i, k) in kernel.data.iter().enumerate() {
-                    let y_unchecked = (y as i32) + i as i32 - k_height / 2;
+                for (k_point, k) in kernel.enumerate() {
+                    let y_unchecked = (y as i32) + k_point.y as i32 - k_height / 2;
                     let y_p = max(0, min(y_unchecked, height as i32 - 1)) as u32;
                     let p = unsafe { image.unsafe_get_pixel(x, y_p) };
                     accumulate(&mut acc, &p, *k);
@@ -544,8 +511,8 @@ where
     // Top margin - need to check lower bound only
     for y in 0..half_k {
         for x in 0..width {
-            for (i, k) in kernel.data.iter().enumerate() {
-                let y_unchecked = y + i as i32 - k_height / 2;
+            for (k_point, k) in kernel.enumerate() {
+                let y_unchecked = y + k_point.y as i32 - k_height / 2;
                 let y_p = max(0, y_unchecked) as u32;
                 let p = unsafe { image.unsafe_get_pixel(x, y_p) };
                 accumulate(&mut acc, &p, *k);
@@ -562,8 +529,8 @@ where
     // Neither margin - don't need bounds check on either side
     for y in half_k..(height as i32 - half_k) {
         for x in 0..width {
-            for (i, k) in kernel.data.iter().enumerate() {
-                let y_unchecked = y + i as i32 - k_height / 2;
+            for (k_point, k) in kernel.enumerate() {
+                let y_unchecked = y + k_point.y as i32 - k_height / 2;
                 let y_p = y_unchecked as u32;
                 let p = unsafe { image.unsafe_get_pixel(x, y_p) };
                 accumulate(&mut acc, &p, *k);
@@ -580,8 +547,8 @@ where
     // Right margin - need to check upper bound only
     for y in (height as i32 - half_k)..(height as i32) {
         for x in 0..width {
-            for (i, k) in kernel.data.iter().enumerate() {
-                let y_unchecked = y + i as i32 - k_height / 2;
+            for (k_point, k) in kernel.enumerate() {
+                let y_unchecked = y + k_point.y as i32 - k_height / 2;
                 let y_p = min(y_unchecked, height as i32 - 1) as u32;
                 let p = unsafe { image.unsafe_get_pixel(x, y_p) };
                 accumulate(&mut acc, &p, *k);
@@ -619,8 +586,8 @@ where
 /// ```
 #[must_use = "the function does not modify the original image"]
 pub fn laplacian_filter(image: &GrayImage) -> Image<Luma<i16>> {
-    let kernel: Kernel<i16> = Kernel::new(vec![0, 1, 0, 1, -4, 1, 0, 1, 0], 3, 3);
-    filter3x3(image, &kernel)
+    let kernel: OwnedKernel<i16> = OwnedKernel::new(vec![0, 1, 0, 1, -4, 1, 0, 1, 0], 3, 3);
+    filter3x3(image, kernel)
 }
 
 #[cfg(test)]
@@ -684,8 +651,8 @@ mod tests {
             4, 5, 5;
             6, 7, 7);
 
-        let kernel = Kernel::new(vec![1f32 / 3f32; 3], 3, 1);
-        let filtered = separable_filter_equal(&image, &kernel);
+        let kernel = OwnedKernel::new(vec![1f32 / 3f32; 3], 3, 1);
+        let filtered = separable_filter_equal(&image, kernel);
 
         assert_pixels_eq!(filtered, expected);
     }
@@ -702,18 +669,19 @@ mod tests {
             39, 45, 51;
             57, 63, 69);
 
-        let kernel = Kernel::new(vec![1i32; 3], 3, 1);
-        let filtered = separable_filter_equal(&image, &kernel);
+        let kernel = OwnedKernel::new(vec![1i32; 3], 3, 1);
+        let filtered = separable_filter_equal(&image, kernel);
 
         assert_pixels_eq!(filtered, expected);
     }
 
     /// Reference implementation of horizontal_filter. Used to validate
     /// the (presumably faster) actual implementation.
-    fn horizontal_filter_reference(image: &GrayImage, kernel: &Kernel<f32>) -> GrayImage {
+    fn horizontal_filter_reference(image: &GrayImage, kernel: impl Kernel<f32>) -> GrayImage {
         assert_eq!(
-            kernel.height, 1,
-            "horizontal_filter_reference only works with 1 dimensional kernels"
+            kernel.height(),
+            1,
+            "horizontal_filter_reference only works kernels with heights of 1"
         );
 
         let (width, height) = image.dimensions();
@@ -723,14 +691,14 @@ mod tests {
             for x in 0..width {
                 let mut acc = 0f32;
 
-                for k in 0..kernel.data.len() {
-                    let mut x_unchecked = x as i32 + k as i32 - (kernel.data.len() / 2) as i32;
+                for (k_point, k_value) in kernel.enumerate() {
+                    let mut x_unchecked = x as i32 + k_point.x as i32 - (kernel.width() / 2) as i32;
                     x_unchecked = max(0, x_unchecked);
                     x_unchecked = min(x_unchecked, width as i32 - 1);
 
                     let x_checked = x_unchecked as u32;
                     let color = image.get_pixel(x_checked, y)[0];
-                    let weight = kernel.data[k];
+                    let weight = k_value;
 
                     acc += color as f32 * weight;
                 }
@@ -745,10 +713,11 @@ mod tests {
 
     /// Reference implementation of vertical_filter. Used to validate
     /// the (presumably faster) actual implementation.
-    fn vertical_filter_reference(image: &GrayImage, kernel: &Kernel<f32>) -> GrayImage {
+    fn vertical_filter_reference(image: &GrayImage, kernel: impl Kernel<f32>) -> GrayImage {
         assert_eq!(
-            kernel.height, 1,
-            "vertical_filter_reference only works with 1 dimensional kernels"
+            kernel.width(),
+            1,
+            "vertical_filter_reference only works kernels with width of 1"
         );
 
         let (width, height) = image.dimensions();
@@ -758,14 +727,14 @@ mod tests {
             for x in 0..width {
                 let mut acc = 0f32;
 
-                for k in 0..kernel.data.len() {
-                    let mut y_unchecked = y as i32 + k as i32 - (kernel.data.len() / 2) as i32;
+                for (k_point, k_value) in kernel.enumerate() {
+                    let mut y_unchecked = y as i32 + k_point.y as i32 - (kernel.width() / 2) as i32;
                     y_unchecked = max(0, y_unchecked);
                     y_unchecked = min(y_unchecked, height as i32 - 1);
 
                     let y_checked = y_unchecked as u32;
                     let color = image.get_pixel(x, y_checked)[0];
-                    let weight = kernel.data[k];
+                    let weight = k_value;
 
                     acc += color as f32 * weight;
                 }
@@ -790,7 +759,7 @@ mod tests {
                     for width in 0..5 {
                         for kernel_length in 1..15 {
                             let image = gray_bench_image(width, height);
-                            let kernel: Kernel<f32> = Kernel::new(
+                            let kernel: OwnedKernel<f32> = OwnedKernel::new(
                                 (0..kernel_length).map(|i| i as f32 % 1.35).collect(),
                                 kernel_length,
                                 1,
@@ -831,8 +800,8 @@ mod tests {
             5, 5, 5;
             2, 2, 2);
 
-        let kernel = Kernel::new(vec![1f32 / 3f32; 3], 3, 1);
-        let filtered = horizontal_filter(&image, &kernel);
+        let kernel = OwnedKernel::new(vec![1f32 / 3f32; 3], 3, 1);
+        let filtered = horizontal_filter(&image, kernel);
 
         assert_pixels_eq!(filtered, expected);
     }
@@ -844,8 +813,8 @@ mod tests {
             4, 7, 4;
             1, 4, 1);
 
-        let kernel = Kernel::new(vec![1f32 / 10f32; 10], 10, 1);
-        black_box(horizontal_filter(&image, &kernel));
+        let kernel = OwnedKernel::new(vec![1f32 / 10f32; 10], 10, 1);
+        black_box(horizontal_filter(&image, kernel));
     }
     #[test]
     fn test_vertical_filter() {
@@ -859,8 +828,8 @@ mod tests {
             2, 5, 2;
             2, 5, 2);
 
-        let kernel = Kernel::new(vec![1f32 / 3f32; 3], 3, 1);
-        let filtered = vertical_filter(&image, &kernel);
+        let kernel = OwnedKernel::new(vec![1f32 / 3f32; 3], 3, 1);
+        let filtered = vertical_filter(&image, kernel);
 
         assert_pixels_eq!(filtered, expected);
     }
@@ -872,13 +841,13 @@ mod tests {
             4, 7, 4;
             1, 4, 1);
 
-        let kernel = Kernel::new(vec![1f32 / 10f32; 10], 10, 1);
-        black_box(vertical_filter(&image, &kernel));
+        let kernel = OwnedKernel::new(vec![1f32 / 10f32; 10], 10, 1);
+        black_box(vertical_filter(&image, kernel));
     }
     #[test]
     fn test_filter3x3_with_results_outside_input_channel_range() {
         #[rustfmt::skip]
-        let kernel: Kernel<i32> = Kernel::new(vec![
+        let kernel: OwnedKernel<i32> = OwnedKernel::new(vec![
             -1, 0, 1,
             -2, 0, 2,
             -1, 0, 1
@@ -895,7 +864,7 @@ mod tests {
             -4, -8, -4
         );
 
-        let filtered = filter3x3(&image, &kernel);
+        let filtered = filter3x3(&image, kernel);
         assert_pixels_eq!(filtered, expected);
     }
 
@@ -903,7 +872,7 @@ mod tests {
     #[should_panic]
     fn test_kernel_must_be_nonempty() {
         let k: Vec<u8> = Vec::new();
-        let _ = Kernel::new(k, 0, 0);
+        let _ = OwnedKernel::new(k, 0, 0);
     }
 
     #[test]
@@ -913,8 +882,8 @@ mod tests {
             4, 1);
 
         let k = vec![1u8, 2u8];
-        let kernel = Kernel::new(k, 2, 1);
-        let filtered = filter(&image, &kernel, |c, a| *c = a);
+        let kernel = OwnedKernel::new(k, 2, 1);
+        let filtered = filter(&image, kernel, |c, a| *c = a);
 
         let expected = gray_image!(
              9,  7;
@@ -928,8 +897,8 @@ mod tests {
         let image = gray_image!();
 
         let k = vec![2u8];
-        let kernel = Kernel::new(k, 1, 1);
-        let filtered = filter(&image, &kernel, |c, a| *c = a);
+        let kernel = OwnedKernel::new(k, 1, 1);
+        let filtered = filter(&image, kernel, |c, a| *c = a);
 
         let expected = gray_image!();
         assert_pixels_eq!(filtered, expected);
@@ -947,9 +916,9 @@ mod tests {
             0.2, 0.4, 0.2,
             0.1, 0.2, 0.1
         ];
-        let kernel = Kernel::new(k, 3, 3);
+        let kernel = OwnedKernel::new(k, 3, 3);
         let filtered: Image<Luma<u8>> =
-            filter(&image, &kernel, |c, a| *c = <u8 as Clamp<f32>>::clamp(a));
+            filter(&image, kernel, |c, a| *c = <u8 as Clamp<f32>>::clamp(a));
 
         let expected = gray_image!(
             11,  7;
@@ -1025,8 +994,8 @@ mod benches {
     #[bench]
     fn bench_separable_filter(b: &mut Bencher) {
         let image = gray_bench_image(300, 300);
-        let h_kernel = Kernel::new(vec![1f32 / 5f32; 5], 5, 1);
-        let v_kernel = Kernel::new(vec![0.1f32, 0.4f32, 0.3f32, 0.1f32, 0.1f32], 5, 1);
+        let h_kernel = OwnedKernel::new(vec![1f32 / 5f32; 5], 5, 1);
+        let v_kernel = OwnedKernel::new(vec![0.1f32, 0.4f32, 0.3f32, 0.1f32, 0.1f32], 5, 1);
         b.iter(|| {
             let filtered = separable_filter(&image, &h_kernel, &v_kernel);
             black_box(filtered);
@@ -1036,7 +1005,7 @@ mod benches {
     #[bench]
     fn bench_horizontal_filter(b: &mut Bencher) {
         let image = gray_bench_image(500, 500);
-        let kernel = Kernel::new(vec![1f32 / 5f32; 5], 5, 1);
+        let kernel = OwnedKernel::new(vec![1f32 / 5f32; 5], 5, 1);
         b.iter(|| {
             let filtered = horizontal_filter(&image, &kernel);
             black_box(filtered);
@@ -1046,7 +1015,7 @@ mod benches {
     #[bench]
     fn bench_vertical_filter(b: &mut Bencher) {
         let image = gray_bench_image(500, 500);
-        let kernel = Kernel::new(vec![1f32 / 5f32; 5], 5, 1);
+        let kernel = OwnedKernel::new(vec![1f32 / 5f32; 5], 5, 1);
         b.iter(|| {
             let filtered = vertical_filter(&image, &kernel);
             black_box(filtered);
@@ -1057,7 +1026,7 @@ mod benches {
     fn bench_filter3x3_i32_filter(b: &mut Bencher) {
         let image = gray_bench_image(500, 500);
         #[rustfmt::skip]
-        let kernel: Kernel<i32> = Kernel::new(vec![
+        let kernel: OwnedKernel<i32> = OwnedKernel::new(vec![
             -1, 0, 1,
             -2, 0, 2,
             -1, 0, 1

--- a/src/filter/sharpen.rs
+++ b/src/filter/sharpen.rs
@@ -1,4 +1,4 @@
-use super::{filter3x3, gaussian_blur_f32};
+use super::{filter3x3, gaussian_blur_f32, Kernel};
 use crate::{
     definitions::{Clamp, Image},
     map::{map_colors2, map_subpixels},
@@ -8,7 +8,7 @@ use image::{GrayImage, Luma};
 /// Sharpens a grayscale image by applying a 3x3 approximation to the Laplacian.
 #[must_use = "the function does not modify the original image"]
 pub fn sharpen3x3(image: &GrayImage) -> GrayImage {
-    let identity_minus_laplacian = [0, -1, 0, -1, 5, -1, 0, -1, 0];
+    let identity_minus_laplacian = Kernel::new(vec![0, -1, 0, -1, 5, -1, 0, -1, 0], 3, 3);
     filter3x3(image, &identity_minus_laplacian)
 }
 

--- a/src/filter/sharpen.rs
+++ b/src/filter/sharpen.rs
@@ -1,6 +1,7 @@
-use super::{filter3x3, gaussian_blur_f32, Kernel};
+use super::{filter3x3, gaussian_blur_f32};
 use crate::{
     definitions::{Clamp, Image},
+    kernel::OwnedKernel,
     map::{map_colors2, map_subpixels},
 };
 use image::{GrayImage, Luma};
@@ -8,8 +9,8 @@ use image::{GrayImage, Luma};
 /// Sharpens a grayscale image by applying a 3x3 approximation to the Laplacian.
 #[must_use = "the function does not modify the original image"]
 pub fn sharpen3x3(image: &GrayImage) -> GrayImage {
-    let identity_minus_laplacian = Kernel::new(vec![0, -1, 0, -1, 5, -1, 0, -1, 0], 3, 3);
-    filter3x3(image, &identity_minus_laplacian)
+    let identity_minus_laplacian = OwnedKernel::new(vec![0, -1, 0, -1, 5, -1, 0, -1, 0], 3, 3);
+    filter3x3(image, identity_minus_laplacian)
 }
 
 /// Sharpens a grayscale image using a Gaussian as a low-pass filter.

--- a/src/filter/sharpen.rs
+++ b/src/filter/sharpen.rs
@@ -1,4 +1,4 @@
-use super::{filter3x3, gaussian_blur_f32};
+use super::{filter_clamped, gaussian_blur_f32};
 use crate::{
     definitions::{Clamp, Image},
     kernel::OwnedKernel,
@@ -10,7 +10,7 @@ use image::{GrayImage, Luma};
 #[must_use = "the function does not modify the original image"]
 pub fn sharpen3x3(image: &GrayImage) -> GrayImage {
     let identity_minus_laplacian = OwnedKernel::new(vec![0, -1, 0, -1, 5, -1, 0, -1, 0], 3, 3);
-    filter3x3(image, identity_minus_laplacian)
+    filter_clamped(image, identity_minus_laplacian)
 }
 
 /// Sharpens a grayscale image using a Gaussian as a low-pass filter.

--- a/src/filter/sharpen.rs
+++ b/src/filter/sharpen.rs
@@ -1,7 +1,7 @@
 use super::{filter_clamped, gaussian_blur_f32};
 use crate::{
     definitions::{Clamp, Image},
-    kernel::OwnedKernel,
+    kernel::Kernel,
     map::{map_colors2, map_subpixels},
 };
 use image::{GrayImage, Luma};
@@ -9,7 +9,7 @@ use image::{GrayImage, Luma};
 /// Sharpens a grayscale image by applying a 3x3 approximation to the Laplacian.
 #[must_use = "the function does not modify the original image"]
 pub fn sharpen3x3(image: &GrayImage) -> GrayImage {
-    let identity_minus_laplacian = OwnedKernel::new(vec![0, -1, 0, -1, 5, -1, 0, -1, 0], 3, 3);
+    let identity_minus_laplacian = Kernel::new(&[0, -1, 0, -1, 5, -1, 0, -1, 0], 3, 3);
     filter_clamped(image, identity_minus_laplacian)
 }
 

--- a/src/gradients.rs
+++ b/src/gradients.rs
@@ -8,6 +8,8 @@ use image::{GenericImage, GenericImageView, Pixel};
 use itertools::multizip;
 
 /// Different kernels for finding detecting gradients in images.
+///
+/// See [`gradients()`] for how it can be used.
 #[derive(Debug, Copy, Clone)]
 pub enum GradientKernel {
     /// The 3x3 Sobel kernel
@@ -30,33 +32,33 @@ impl GradientKernel {
         GradientKernel::Roberts,
     ];
 
-    /// The vertical gradient kernel component
-    pub fn horizontal_kernel<K>(&self) -> OwnedKernel<K>
+    /// The first gradient kernel component
+    pub fn kernel1<K>(&self) -> OwnedKernel<K>
     where
         K: From<i8>,
     {
-        let horizontal = match self {
+        let x = match self {
             GradientKernel::Sobel => OwnedKernel::new(vec![-1, 0, 1, -2, 0, 2, -1, 0, 1], 3, 3),
             GradientKernel::Scharr => OwnedKernel::new(vec![-3, 0, 3, -10, 0, 10, -3, 0, 3], 3, 3),
             GradientKernel::Prewitt => OwnedKernel::new(vec![-1, 0, 1, -1, 0, 1, -1, 0, 1], 3, 3),
             GradientKernel::Roberts => OwnedKernel::new(vec![0, 1, -1, -0], 2, 2),
         };
 
-        horizontal.map(&K::from)
+        x.map(&K::from)
     }
-    /// The vertical gradient kernel component
-    pub fn vertical_kernel<K>(&self) -> OwnedKernel<K>
+    /// The second gradient kernel component
+    pub fn kernel2<K>(&self) -> OwnedKernel<K>
     where
         K: From<i8>,
     {
-        let vertical = match self {
+        let x = match self {
             GradientKernel::Sobel => OwnedKernel::new(vec![-1, -2, -1, 0, 0, 0, 1, 2, 1], 3, 3),
             GradientKernel::Scharr => OwnedKernel::new(vec![-3, -10, -3, 0, 0, 0, 3, 10, 3], 3, 3),
             GradientKernel::Prewitt => OwnedKernel::new(vec![-1, -1, -1, 0, 0, 0, 1, 1, 1], 3, 3),
             GradientKernel::Roberts => OwnedKernel::new(vec![1, 0, 0, -1], 2, 2),
         };
 
-        vertical.map(&K::from)
+        x.map(&K::from)
     }
 }
 impl<K> From<GradientKernel> for TwoKernels<OwnedKernel<K>>
@@ -65,8 +67,8 @@ where
 {
     fn from(value: GradientKernel) -> Self {
         TwoKernels {
-            kernel1: value.horizontal_kernel(),
-            kernel2: value.vertical_kernel(),
+            kernel1: value.kernel1(),
+            kernel2: value.kernel2(),
         }
     }
 }
@@ -255,7 +257,7 @@ mod tests {
             -4, -8, -4;
             -4, -8, -4);
 
-        let filtered = filter3x3(&image, GradientKernel::Sobel.horizontal_kernel::<i16>());
+        let filtered = filter3x3(&image, GradientKernel::Sobel.kernel1::<i16>());
         assert_pixels_eq!(filtered, expected);
     }
 
@@ -271,7 +273,7 @@ mod tests {
             -8, -8, -8;
             -4, -4, -4);
 
-        let filtered = filter3x3(&image, GradientKernel::Sobel.vertical_kernel::<i16>());
+        let filtered = filter3x3(&image, GradientKernel::Sobel.kernel2::<i16>());
         assert_pixels_eq!(filtered, expected);
     }
 
@@ -287,7 +289,7 @@ mod tests {
             -16, -32, -16;
             -16, -32, -16);
 
-        let filtered = filter3x3(&image, GradientKernel::Scharr.horizontal_kernel::<i16>());
+        let filtered = filter3x3(&image, GradientKernel::Scharr.kernel1::<i16>());
         assert_pixels_eq!(filtered, expected);
     }
 
@@ -303,7 +305,7 @@ mod tests {
             -32, -32, -32;
             -16, -16, -16);
 
-        let filtered = filter3x3(&image, GradientKernel::Scharr.vertical_kernel::<i16>());
+        let filtered = filter3x3(&image, GradientKernel::Scharr.kernel2::<i16>());
         assert_pixels_eq!(filtered, expected);
     }
 
@@ -319,7 +321,7 @@ mod tests {
             -3, -6, -3;
             -3, -6, -3);
 
-        let filtered = filter3x3(&image, GradientKernel::Prewitt.horizontal_kernel::<i16>());
+        let filtered = filter3x3(&image, GradientKernel::Prewitt.kernel1::<i16>());
         assert_pixels_eq!(filtered, expected);
     }
 
@@ -335,7 +337,7 @@ mod tests {
             -6, -6, -6;
             -3, -3, -3);
 
-        let filtered = filter3x3(&image, GradientKernel::Prewitt.vertical_kernel::<i16>());
+        let filtered = filter3x3(&image, GradientKernel::Prewitt.kernel2::<i16>());
         assert_pixels_eq!(filtered, expected);
     }
 }

--- a/src/gradients.rs
+++ b/src/gradients.rs
@@ -179,8 +179,8 @@ where
             //      as measured by bench_sobel_gradients
             //  Correctness
             //      x and y are in bounds for image by construction,
-            //      vertical and horizontal are the result of calling filter3x3 on image,
-            //      and filter3x3 returns an image of the same size as its input
+            //      vertical and horizontal are the result of calling filter_clamped on image,
+            //      and filter_clamped returns an image of the same size as its input
             let (h, v) = unsafe { (pass1.unsafe_get_pixel(x, y), pass2.unsafe_get_pixel(x, y)) };
             let mut p = ChannelMap::<P, u16>::black();
 
@@ -211,7 +211,7 @@ fn gradient_magnitude(dx: f32, dy: f32) -> u16 {
 
 #[cfg(test)]
 mod tests {
-    use crate::filter::filter3x3;
+    use crate::filter::filter_clamped;
 
     use super::*;
     use image::{ImageBuffer, Luma};
@@ -257,7 +257,7 @@ mod tests {
             -4, -8, -4;
             -4, -8, -4);
 
-        let filtered = filter3x3(&image, GradientKernel::Sobel.kernel1::<i16>());
+        let filtered = filter_clamped(&image, GradientKernel::Sobel.kernel1::<i16>());
         assert_pixels_eq!(filtered, expected);
     }
 
@@ -273,7 +273,7 @@ mod tests {
             -8, -8, -8;
             -4, -4, -4);
 
-        let filtered = filter3x3(&image, GradientKernel::Sobel.kernel2::<i16>());
+        let filtered = filter_clamped(&image, GradientKernel::Sobel.kernel2::<i16>());
         assert_pixels_eq!(filtered, expected);
     }
 
@@ -289,7 +289,7 @@ mod tests {
             -16, -32, -16;
             -16, -32, -16);
 
-        let filtered = filter3x3(&image, GradientKernel::Scharr.kernel1::<i16>());
+        let filtered = filter_clamped(&image, GradientKernel::Scharr.kernel1::<i16>());
         assert_pixels_eq!(filtered, expected);
     }
 
@@ -305,7 +305,7 @@ mod tests {
             -32, -32, -32;
             -16, -16, -16);
 
-        let filtered = filter3x3(&image, GradientKernel::Scharr.kernel2::<i16>());
+        let filtered = filter_clamped(&image, GradientKernel::Scharr.kernel2::<i16>());
         assert_pixels_eq!(filtered, expected);
     }
 
@@ -321,7 +321,7 @@ mod tests {
             -3, -6, -3;
             -3, -6, -3);
 
-        let filtered = filter3x3(&image, GradientKernel::Prewitt.kernel1::<i16>());
+        let filtered = filter_clamped(&image, GradientKernel::Prewitt.kernel1::<i16>());
         assert_pixels_eq!(filtered, expected);
     }
 
@@ -337,7 +337,7 @@ mod tests {
             -6, -6, -6;
             -3, -3, -3);
 
-        let filtered = filter3x3(&image, GradientKernel::Prewitt.kernel2::<i16>());
+        let filtered = filter_clamped(&image, GradientKernel::Prewitt.kernel2::<i16>());
         assert_pixels_eq!(filtered, expected);
     }
 }

--- a/src/gradients.rs
+++ b/src/gradients.rs
@@ -1,7 +1,7 @@
 //! Functions for computing gradients of image intensities.
 
 use crate::definitions::{Clamp, HasBlack, Image};
-use crate::filter::{filter, filter3x3};
+use crate::filter::filter;
 use crate::kernel::{Kernel, OwnedKernel, TwoKernels};
 use crate::map::{ChannelMap, WithChannel};
 use image::{GenericImage, GenericImageView, Pixel};

--- a/src/gradients.rs
+++ b/src/gradients.rs
@@ -2,76 +2,10 @@
 
 use crate::definitions::{Clamp, HasBlack, Image};
 use crate::filter::filter;
-use crate::kernel::{Kernel, OwnedKernel, TwoKernels};
+use crate::kernel::Kernel;
 use crate::map::{ChannelMap, WithChannel};
 use image::{GenericImage, GenericImageView, Pixel};
 use itertools::multizip;
-
-/// Different kernels for finding detecting gradients in images.
-///
-/// See [`gradients()`] for how it can be used.
-#[derive(Debug, Copy, Clone)]
-pub enum GradientKernel {
-    /// The 3x3 Sobel kernel
-    /// See <https://en.wikipedia.org/wiki/Sobel_operator>
-    Sobel,
-    /// The 3x3 Scharr kernel
-    Scharr,
-    /// The 3x3 Prewitt kernel
-    Prewitt,
-    /// The 2x2 Roberts kernel
-    /// See <https://en.wikipedia.org/wiki/Roberts_cross>
-    Roberts,
-}
-impl GradientKernel {
-    /// A slice of all the [`GradientKernel`] variants.
-    pub const ALL: [GradientKernel; 4] = [
-        GradientKernel::Sobel,
-        GradientKernel::Scharr,
-        GradientKernel::Prewitt,
-        GradientKernel::Roberts,
-    ];
-
-    /// The first gradient kernel component
-    pub fn kernel1<K>(&self) -> OwnedKernel<K>
-    where
-        K: From<i8>,
-    {
-        let x = match self {
-            GradientKernel::Sobel => OwnedKernel::new(vec![-1, 0, 1, -2, 0, 2, -1, 0, 1], 3, 3),
-            GradientKernel::Scharr => OwnedKernel::new(vec![-3, 0, 3, -10, 0, 10, -3, 0, 3], 3, 3),
-            GradientKernel::Prewitt => OwnedKernel::new(vec![-1, 0, 1, -1, 0, 1, -1, 0, 1], 3, 3),
-            GradientKernel::Roberts => OwnedKernel::new(vec![0, 1, -1, -0], 2, 2),
-        };
-
-        x.map(&K::from)
-    }
-    /// The second gradient kernel component
-    pub fn kernel2<K>(&self) -> OwnedKernel<K>
-    where
-        K: From<i8>,
-    {
-        let x = match self {
-            GradientKernel::Sobel => OwnedKernel::new(vec![-1, -2, -1, 0, 0, 0, 1, 2, 1], 3, 3),
-            GradientKernel::Scharr => OwnedKernel::new(vec![-3, -10, -3, 0, 0, 0, 3, 10, 3], 3, 3),
-            GradientKernel::Prewitt => OwnedKernel::new(vec![-1, -1, -1, 0, 0, 0, 1, 1, 1], 3, 3),
-            GradientKernel::Roberts => OwnedKernel::new(vec![1, 0, 0, -1], 2, 2),
-        };
-
-        x.map(&K::from)
-    }
-}
-impl<K> From<GradientKernel> for TwoKernels<OwnedKernel<K>>
-where
-    K: From<i8>,
-{
-    fn from(value: GradientKernel) -> Self {
-        TwoKernels {
-            kernel1: value.kernel1(),
-            kernel2: value.kernel2(),
-        }
-    }
-}
 
 // TODO: Returns directions as well as magnitudes.
 // TODO: Support filtering without allocating a fresh image - filtering functions could
@@ -87,7 +21,8 @@ where
 /// # #[macro_use]
 /// # extern crate imageproc;
 /// # fn main() {
-/// use imageproc::gradients::{gradients, GradientKernel};
+/// use imageproc::gradients::gradients;
+/// use imageproc::kernel::OwnedKernel;
 /// use image::Luma;
 /// use std::cmp;
 ///
@@ -107,10 +42,11 @@ where
 ///     [ 4,  0,  8], [ 8,  0,  8], [ 4,  0,  8]
 /// );
 ///
-/// let gradient_kernel = GradientKernel::Sobel;
+/// let horizontal_kernel = OwnedKernel::sobel_horizontal_3x3();
+/// let vertical_kernel = OwnedKernel::sobel_vertical_3x3();
 ///
 /// assert_pixels_eq!(
-///     gradients(&input, gradient_kernel, |p| p),
+///     gradients(&input, &horizontal_kernel, &vertical_kernel, |p| p),
 ///     channel_gradient
 /// );
 ///
@@ -123,7 +59,7 @@ where
 /// );
 ///
 /// assert_pixels_eq!(
-///     gradients(&input, gradient_kernel, |p| {
+///     gradients(&input, &horizontal_kernel, &vertical_kernel, |p| {
 ///         let mean = (p[0] + p[1] + p[2]) / 3;
 ///         Luma([mean])
 ///     }),
@@ -139,16 +75,17 @@ where
 /// );
 ///
 /// assert_pixels_eq!(
-///     gradients(&input, gradient_kernel, |p| {
+///     gradients(&input, &horizontal_kernel, &vertical_kernel, |p| {
 ///         let max = cmp::max(cmp::max(p[0], p[1]), p[2]);
 ///         Luma([max])
 ///     }),
 ///     max_gradient
 /// );
 /// # }
-pub fn gradients<P, F, Q, T>(
+pub fn gradients<P, F, Q>(
     image: &Image<P>,
-    two_kernels: impl Into<TwoKernels<T>>,
+    kernel1: impl Kernel<i32>,
+    kernel2: impl Kernel<i32>,
     f: F,
 ) -> Image<Q>
 where
@@ -156,14 +93,11 @@ where
     Q: Pixel,
     ChannelMap<P, u16>: HasBlack,
     F: Fn(ChannelMap<P, u16>) -> Q,
-    T: Kernel<i32>,
 {
-    let two_kernels: TwoKernels<_> = two_kernels.into();
-
-    let pass1: Image<ChannelMap<P, i16>> = filter(image, two_kernels.kernel1, |channel, acc| {
+    let pass1: Image<ChannelMap<P, i16>> = filter(image, kernel1, |channel, acc| {
         *channel = <i16 as Clamp<i32>>::clamp(acc)
     });
-    let pass2: Image<ChannelMap<P, i16>> = filter(image, two_kernels.kernel2, |channel, acc| {
+    let pass2: Image<ChannelMap<P, i16>> = filter(image, kernel2, |channel, acc| {
         *channel = <i16 as Clamp<i32>>::clamp(acc)
     });
 
@@ -211,7 +145,7 @@ fn gradient_magnitude(dx: f32, dy: f32) -> u16 {
 
 #[cfg(test)]
 mod tests {
-    use crate::filter::filter_clamped;
+    use crate::{filter::filter_clamped, kernel::OwnedKernel};
 
     use super::*;
     use image::{ImageBuffer, Luma};
@@ -221,28 +155,60 @@ mod tests {
         let image = ImageBuffer::from_pixel(5, 5, Luma([15u8]));
         let expected = ImageBuffer::from_pixel(5, 5, Luma([0u16]));
 
-        assert_pixels_eq!(gradients(&image, GradientKernel::Sobel, |p| p), expected);
+        assert_pixels_eq!(
+            gradients(
+                &image,
+                OwnedKernel::sobel_horizontal_3x3(),
+                OwnedKernel::sobel_vertical_3x3(),
+                |p| p
+            ),
+            expected
+        );
     }
     #[test]
     fn test_gradients_constant_image_scharr() {
         let image = ImageBuffer::from_pixel(5, 5, Luma([15u8]));
         let expected = ImageBuffer::from_pixel(5, 5, Luma([0u16]));
 
-        assert_pixels_eq!(gradients(&image, GradientKernel::Scharr, |p| p), expected);
+        assert_pixels_eq!(
+            gradients(
+                &image,
+                OwnedKernel::scharr_horizontal_3x3(),
+                OwnedKernel::scharr_vertical_3x3(),
+                |p| p
+            ),
+            expected
+        );
     }
     #[test]
     fn test_gradients_constant_image_prewitt() {
         let image = ImageBuffer::from_pixel(5, 5, Luma([15u8]));
         let expected = ImageBuffer::from_pixel(5, 5, Luma([0u16]));
 
-        assert_pixels_eq!(gradients(&image, GradientKernel::Prewitt, |p| p), expected);
+        assert_pixels_eq!(
+            gradients(
+                &image,
+                OwnedKernel::prewitt_horizontal_3x3(),
+                OwnedKernel::prewitt_vertical_3x3(),
+                |p| p
+            ),
+            expected
+        );
     }
     #[test]
     fn test_gradients_constant_image_roberts() {
         let image = ImageBuffer::from_pixel(5, 5, Luma([15u8]));
         let expected = ImageBuffer::from_pixel(5, 5, Luma([0u16]));
 
-        assert_pixels_eq!(gradients(&image, GradientKernel::Roberts, |p| p), expected);
+        assert_pixels_eq!(
+            gradients(
+                &image,
+                OwnedKernel::roberts_horizontal_2x2(),
+                OwnedKernel::roberts_vertical_2x2(),
+                |p| p
+            ),
+            expected
+        );
     }
 
     #[test]
@@ -257,7 +223,7 @@ mod tests {
             -4, -8, -4;
             -4, -8, -4);
 
-        let filtered = filter_clamped(&image, GradientKernel::Sobel.kernel1::<i16>());
+        let filtered = filter_clamped(&image, OwnedKernel::<i16>::sobel_horizontal_3x3());
         assert_pixels_eq!(filtered, expected);
     }
 
@@ -273,7 +239,7 @@ mod tests {
             -8, -8, -8;
             -4, -4, -4);
 
-        let filtered = filter_clamped(&image, GradientKernel::Sobel.kernel2::<i16>());
+        let filtered = filter_clamped(&image, OwnedKernel::<i16>::sobel_vertical_3x3());
         assert_pixels_eq!(filtered, expected);
     }
 
@@ -289,7 +255,7 @@ mod tests {
             -16, -32, -16;
             -16, -32, -16);
 
-        let filtered = filter_clamped(&image, GradientKernel::Scharr.kernel1::<i16>());
+        let filtered = filter_clamped(&image, OwnedKernel::<i16>::scharr_horizontal_3x3());
         assert_pixels_eq!(filtered, expected);
     }
 
@@ -305,7 +271,7 @@ mod tests {
             -32, -32, -32;
             -16, -16, -16);
 
-        let filtered = filter_clamped(&image, GradientKernel::Scharr.kernel2::<i16>());
+        let filtered = filter_clamped(&image, OwnedKernel::<i16>::scharr_vertical_3x3());
         assert_pixels_eq!(filtered, expected);
     }
 
@@ -321,7 +287,7 @@ mod tests {
             -3, -6, -3;
             -3, -6, -3);
 
-        let filtered = filter_clamped(&image, GradientKernel::Prewitt.kernel1::<i16>());
+        let filtered = filter_clamped(&image, OwnedKernel::<i16>::prewitt_horizontal_3x3());
         assert_pixels_eq!(filtered, expected);
     }
 
@@ -337,7 +303,38 @@ mod tests {
             -6, -6, -6;
             -3, -3, -3);
 
-        let filtered = filter_clamped(&image, GradientKernel::Prewitt.kernel2::<i16>());
+        let filtered = filter_clamped(&image, OwnedKernel::<i16>::prewitt_vertical_3x3());
+        assert_pixels_eq!(filtered, expected);
+    }
+
+    #[test]
+    fn test_horizontal_roberts_gradient_image() {
+        let image = gray_image!(
+            3, 6, 9;
+            2, 5, 8;
+            1, 4, 7);
+
+        let expected = gray_image!(type: i16,
+            0, -3, -3;
+            1, -2, -2;
+            1, -2, -2);
+
+        let filtered = filter_clamped(&image, OwnedKernel::<i16>::roberts_horizontal_2x2());
+        assert_pixels_eq!(filtered, expected);
+    }
+    #[test]
+    fn test_vertical_roberts_gradient_image() {
+        let image = gray_image!(
+            3, 6, 9;
+            2, 5, 8;
+            1, 4, 7);
+
+        let expected = gray_image!(type: i16,
+            0, 3, 3;
+            1, 4, 4;
+            1, 4, 4);
+
+        let filtered = filter_clamped(&image, OwnedKernel::<i16>::roberts_vertical_2x2());
         assert_pixels_eq!(filtered, expected);
     }
 }
@@ -346,14 +343,19 @@ mod tests {
 #[cfg(test)]
 mod benches {
     use super::*;
-    use crate::utils::gray_bench_image;
+    use crate::{kernel::OwnedKernel, utils::gray_bench_image};
     use test::{black_box, Bencher};
 
     #[bench]
     fn bench_sobel_gradients(b: &mut Bencher) {
         let image = gray_bench_image(500, 500);
         b.iter(|| {
-            let gradients = gradients(&image, GradientKernel::Sobel, |p| p);
+            let gradients = gradients(
+                &image,
+                OwnedKernel::sobel_horizontal_3x3(),
+                OwnedKernel::sobel_vertical_3x3(),
+                |p| p,
+            );
             black_box(gradients);
         });
     }

--- a/src/gradients.rs
+++ b/src/gradients.rs
@@ -22,7 +22,7 @@ use itertools::multizip;
 /// # extern crate imageproc;
 /// # fn main() {
 /// use imageproc::gradients::gradients;
-/// use imageproc::kernel::OwnedKernel;
+/// use imageproc::kernel::Kernel;
 /// use image::Luma;
 /// use std::cmp;
 ///
@@ -42,8 +42,8 @@ use itertools::multizip;
 ///     [ 4,  0,  8], [ 8,  0,  8], [ 4,  0,  8]
 /// );
 ///
-/// let horizontal_kernel = OwnedKernel::sobel_horizontal_3x3();
-/// let vertical_kernel = OwnedKernel::sobel_vertical_3x3();
+/// let horizontal_kernel = Kernel::SOBEL_HORIZONTAL_3X3;
+/// let vertical_kernel = Kernel::SOBEL_VERTICAL_3X3;
 ///
 /// assert_pixels_eq!(
 ///     gradients(&input, &horizontal_kernel, &vertical_kernel, |p| p),
@@ -84,8 +84,8 @@ use itertools::multizip;
 /// # }
 pub fn gradients<P, F, Q>(
     image: &Image<P>,
-    kernel1: impl Kernel<i32>,
-    kernel2: impl Kernel<i32>,
+    kernel1: Kernel<i32>,
+    kernel2: Kernel<i32>,
     f: F,
 ) -> Image<Q>
 where
@@ -145,7 +145,7 @@ fn gradient_magnitude(dx: f32, dy: f32) -> u16 {
 
 #[cfg(test)]
 mod tests {
-    use crate::{filter::filter_clamped, kernel::OwnedKernel};
+    use crate::{filter::filter_clamped, kernel::Kernel};
 
     use super::*;
     use image::{ImageBuffer, Luma};
@@ -158,8 +158,8 @@ mod tests {
         assert_pixels_eq!(
             gradients(
                 &image,
-                OwnedKernel::sobel_horizontal_3x3(),
-                OwnedKernel::sobel_vertical_3x3(),
+                Kernel::<i32>::SOBEL_HORIZONTAL_3X3,
+                Kernel::<i32>::SOBEL_VERTICAL_3X3,
                 |p| p
             ),
             expected
@@ -173,8 +173,8 @@ mod tests {
         assert_pixels_eq!(
             gradients(
                 &image,
-                OwnedKernel::scharr_horizontal_3x3(),
-                OwnedKernel::scharr_vertical_3x3(),
+                Kernel::<i32>::SCHARR_HORIZONTAL_3X3,
+                Kernel::<i32>::SCHARR_VERTICAL_3X3,
                 |p| p
             ),
             expected
@@ -188,8 +188,8 @@ mod tests {
         assert_pixels_eq!(
             gradients(
                 &image,
-                OwnedKernel::prewitt_horizontal_3x3(),
-                OwnedKernel::prewitt_vertical_3x3(),
+                Kernel::<i32>::PREWITT_HORIZONTAL_3X3,
+                Kernel::<i32>::PREWITT_VERTICAL_3X3,
                 |p| p
             ),
             expected
@@ -203,8 +203,8 @@ mod tests {
         assert_pixels_eq!(
             gradients(
                 &image,
-                OwnedKernel::roberts_horizontal_2x2(),
-                OwnedKernel::roberts_vertical_2x2(),
+                Kernel::<i32>::ROBERTS_HORIZONTAL_2X2,
+                Kernel::<i32>::ROBERTS_VERTICAL_2X2,
                 |p| p
             ),
             expected
@@ -223,7 +223,7 @@ mod tests {
             -4, -8, -4;
             -4, -8, -4);
 
-        let filtered = filter_clamped(&image, OwnedKernel::<i16>::sobel_horizontal_3x3());
+        let filtered = filter_clamped(&image, Kernel::<i16>::SOBEL_HORIZONTAL_3X3);
         assert_pixels_eq!(filtered, expected);
     }
 
@@ -239,7 +239,7 @@ mod tests {
             -8, -8, -8;
             -4, -4, -4);
 
-        let filtered = filter_clamped(&image, OwnedKernel::<i16>::sobel_vertical_3x3());
+        let filtered = filter_clamped(&image, Kernel::<i16>::SOBEL_VERTICAL_3X3);
         assert_pixels_eq!(filtered, expected);
     }
 
@@ -255,7 +255,7 @@ mod tests {
             -16, -32, -16;
             -16, -32, -16);
 
-        let filtered = filter_clamped(&image, OwnedKernel::<i16>::scharr_horizontal_3x3());
+        let filtered = filter_clamped(&image, Kernel::<i16>::SCHARR_HORIZONTAL_3X3);
         assert_pixels_eq!(filtered, expected);
     }
 
@@ -271,7 +271,7 @@ mod tests {
             -32, -32, -32;
             -16, -16, -16);
 
-        let filtered = filter_clamped(&image, OwnedKernel::<i16>::scharr_vertical_3x3());
+        let filtered = filter_clamped(&image, Kernel::<i16>::SCHARR_VERTICAL_3X3);
         assert_pixels_eq!(filtered, expected);
     }
 
@@ -287,7 +287,7 @@ mod tests {
             -3, -6, -3;
             -3, -6, -3);
 
-        let filtered = filter_clamped(&image, OwnedKernel::<i16>::prewitt_horizontal_3x3());
+        let filtered = filter_clamped(&image, Kernel::<i16>::PREWITT_HORIZONTAL_3X3);
         assert_pixels_eq!(filtered, expected);
     }
 
@@ -303,7 +303,7 @@ mod tests {
             -6, -6, -6;
             -3, -3, -3);
 
-        let filtered = filter_clamped(&image, OwnedKernel::<i16>::prewitt_vertical_3x3());
+        let filtered = filter_clamped(&image, Kernel::<i16>::PREWITT_VERTICAL_3X3);
         assert_pixels_eq!(filtered, expected);
     }
 
@@ -319,7 +319,7 @@ mod tests {
             1, -2, -2;
             1, -2, -2);
 
-        let filtered = filter_clamped(&image, OwnedKernel::<i16>::roberts_horizontal_2x2());
+        let filtered = filter_clamped(&image, Kernel::<i16>::ROBERTS_HORIZONTAL_2X2);
         assert_pixels_eq!(filtered, expected);
     }
     #[test]
@@ -334,7 +334,7 @@ mod tests {
             1, 4, 4;
             1, 4, 4);
 
-        let filtered = filter_clamped(&image, OwnedKernel::<i16>::roberts_vertical_2x2());
+        let filtered = filter_clamped(&image, Kernel::<i16>::ROBERTS_VERTICAL_2X2);
         assert_pixels_eq!(filtered, expected);
     }
 }
@@ -343,7 +343,7 @@ mod tests {
 #[cfg(test)]
 mod benches {
     use super::*;
-    use crate::{kernel::OwnedKernel, utils::gray_bench_image};
+    use crate::{kernel::Kernel, utils::gray_bench_image};
     use test::{black_box, Bencher};
 
     #[bench]
@@ -352,8 +352,8 @@ mod benches {
         b.iter(|| {
             let gradients = gradients(
                 &image,
-                OwnedKernel::sobel_horizontal_3x3(),
-                OwnedKernel::sobel_vertical_3x3(),
+                Kernel::<i32>::SOBEL_HORIZONTAL_3X3,
+                Kernel::<i32>::SOBEL_VERTICAL_3X3,
                 |p| p,
             );
             black_box(gradients);

--- a/src/hog.rs
+++ b/src/hog.rs
@@ -2,7 +2,7 @@
 //! and helpers for visualizing them.
 
 use crate::definitions::{Clamp, Image};
-use crate::filter::filter3x3;
+use crate::filter::filter_clamped;
 use crate::gradients::GradientKernel;
 use crate::math::l2_norm;
 use image::{GenericImage, GrayImage, ImageBuffer, Luma};
@@ -260,8 +260,8 @@ pub fn cell_histograms(image: &GrayImage, spec: HogSpec) -> Array3d<f32> {
     let cell_side = spec.options.cell_side as f32;
 
     let gradient_kernel = GradientKernel::Sobel;
-    let horizontal = filter3x3::<_, _, i32>(image, &gradient_kernel.kernel1());
-    let vertical = filter3x3::<_, _, i32>(image, &gradient_kernel.kernel2());
+    let horizontal = filter_clamped::<_, _, i32>(image, &gradient_kernel.kernel1());
+    let vertical = filter_clamped::<_, _, i32>(image, &gradient_kernel.kernel2());
     let interval = orientation_bin_width(spec.options);
     let range = direction_range(spec.options);
 

--- a/src/hog.rs
+++ b/src/hog.rs
@@ -3,7 +3,7 @@
 
 use crate::definitions::{Clamp, Image};
 use crate::filter::filter_clamped;
-use crate::kernel::OwnedKernel;
+use crate::kernel::Kernel;
 use crate::math::l2_norm;
 use image::{GenericImage, GrayImage, ImageBuffer, Luma};
 use num::Zero;
@@ -259,8 +259,8 @@ pub fn cell_histograms(image: &GrayImage, spec: HogSpec) -> Array3d<f32> {
     let cell_area = spec.cell_area() as f32;
     let cell_side = spec.options.cell_side as f32;
 
-    let horizontal = filter_clamped::<_, _, i32>(image, OwnedKernel::sobel_horizontal_3x3());
-    let vertical = filter_clamped::<_, _, i32>(image, OwnedKernel::sobel_vertical_3x3());
+    let horizontal = filter_clamped::<_, _, i32>(image, Kernel::<i32>::SOBEL_HORIZONTAL_3X3);
+    let vertical = filter_clamped::<_, _, i32>(image, Kernel::<i32>::SOBEL_VERTICAL_3X3);
     let interval = orientation_bin_width(spec.options);
     let range = direction_range(spec.options);
 

--- a/src/hog.rs
+++ b/src/hog.rs
@@ -260,8 +260,8 @@ pub fn cell_histograms(image: &GrayImage, spec: HogSpec) -> Array3d<f32> {
     let cell_side = spec.options.cell_side as f32;
 
     let gradient_kernel = GradientKernel::Sobel;
-    let horizontal = filter3x3::<_, _, i32>(image, &gradient_kernel.as_horizontal_kernel());
-    let vertical = filter3x3::<_, _, i32>(image, &gradient_kernel.as_vertical_kernel());
+    let horizontal = filter3x3::<_, _, i32>(image, &gradient_kernel.horizontal_kernel());
+    let vertical = filter3x3::<_, _, i32>(image, &gradient_kernel.vertical_kernel());
     let interval = orientation_bin_width(spec.options);
     let range = direction_range(spec.options);
 

--- a/src/hog.rs
+++ b/src/hog.rs
@@ -2,7 +2,8 @@
 //! and helpers for visualizing them.
 
 use crate::definitions::{Clamp, Image};
-use crate::gradients::{horizontal_sobel, vertical_sobel};
+use crate::filter::filter3x3;
+use crate::gradients::GradientKernel;
 use crate::math::l2_norm;
 use image::{GenericImage, GrayImage, ImageBuffer, Luma};
 use num::Zero;
@@ -257,8 +258,10 @@ pub fn cell_histograms(image: &GrayImage, spec: HogSpec) -> Array3d<f32> {
     let mut grid = Array3d::new(spec.cell_grid_lengths());
     let cell_area = spec.cell_area() as f32;
     let cell_side = spec.options.cell_side as f32;
-    let horizontal = horizontal_sobel(image);
-    let vertical = vertical_sobel(image);
+
+    let gradient_kernel = GradientKernel::Sobel;
+    let horizontal = filter3x3::<_, _, i32>(image, &gradient_kernel.as_horizontal_kernel());
+    let vertical = filter3x3::<_, _, i32>(image, &gradient_kernel.as_vertical_kernel());
     let interval = orientation_bin_width(spec.options);
     let range = direction_range(spec.options);
 

--- a/src/hog.rs
+++ b/src/hog.rs
@@ -260,8 +260,8 @@ pub fn cell_histograms(image: &GrayImage, spec: HogSpec) -> Array3d<f32> {
     let cell_side = spec.options.cell_side as f32;
 
     let gradient_kernel = GradientKernel::Sobel;
-    let horizontal = filter3x3::<_, _, i32>(image, &gradient_kernel.horizontal_kernel());
-    let vertical = filter3x3::<_, _, i32>(image, &gradient_kernel.vertical_kernel());
+    let horizontal = filter3x3::<_, _, i32>(image, &gradient_kernel.kernel1());
+    let vertical = filter3x3::<_, _, i32>(image, &gradient_kernel.kernel2());
     let interval = orientation_bin_width(spec.options);
     let range = direction_range(spec.options);
 

--- a/src/hog.rs
+++ b/src/hog.rs
@@ -3,7 +3,7 @@
 
 use crate::definitions::{Clamp, Image};
 use crate::filter::filter_clamped;
-use crate::gradients::GradientKernel;
+use crate::kernel::OwnedKernel;
 use crate::math::l2_norm;
 use image::{GenericImage, GrayImage, ImageBuffer, Luma};
 use num::Zero;
@@ -259,9 +259,8 @@ pub fn cell_histograms(image: &GrayImage, spec: HogSpec) -> Array3d<f32> {
     let cell_area = spec.cell_area() as f32;
     let cell_side = spec.options.cell_side as f32;
 
-    let gradient_kernel = GradientKernel::Sobel;
-    let horizontal = filter_clamped::<_, _, i32>(image, &gradient_kernel.kernel1());
-    let vertical = filter_clamped::<_, _, i32>(image, &gradient_kernel.kernel2());
+    let horizontal = filter_clamped::<_, _, i32>(image, OwnedKernel::sobel_horizontal_3x3());
+    let vertical = filter_clamped::<_, _, i32>(image, OwnedKernel::sobel_vertical_3x3());
     let interval = orientation_bin_width(spec.options);
     let range = direction_range(spec.options);
 

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -1,57 +1,17 @@
-//! Traits and Structs for the abstraction of kernels used in gradient methods
+//! The kernel type for filter operations
 
-use itertools::Itertools;
-
-use crate::point::Point;
-
-/// A 2D kernel
-///
-/// Used in methods such as [`gradients()`](crate::gradients::gradients)
-pub trait Kernel<K> {
-    /// The width of the kernel
-    fn width(&self) -> u32;
-    /// The height of the kernel
-    fn height(&self) -> u32;
-
-    /// Access an element of the kernel
-    fn get(&self, x: u32, y: u32) -> &K;
-    /// Enumerate all elements of the kernel
-    fn enumerate<'a>(&'a self) -> impl Iterator<Item = (Point<u32>, &'a K)>
-    where
-        K: 'a;
-}
-impl<T, K> Kernel<K> for &T
-where
-    T: Kernel<K>,
-{
-    fn width(&self) -> u32 {
-        (*self).width()
-    }
-    fn height(&self) -> u32 {
-        (*self).height()
-    }
-    fn get(&self, x: u32, y: u32) -> &K {
-        (*self).get(x, y)
-    }
-    fn enumerate<'a>(&'a self) -> impl Iterator<Item = (Point<u32>, &'a K)>
-    where
-        K: 'a,
-    {
-        (*self).enumerate()
-    }
+/// An borrowed 2D kernel, used to filter images via convolution.
+#[derive(Debug, Copy, Clone)]
+pub struct Kernel<'a, K> {
+    pub(crate) data: &'a [K],
+    pub(crate) width: u32,
+    pub(crate) height: u32,
 }
 
-/// An owned 2D kernel, used to filter images via convolution.
-#[derive(Debug, Clone)]
-pub struct OwnedKernel<K> {
-    data: Vec<K>,
-    width: u32,
-    height: u32,
-}
-impl<K> OwnedKernel<K> {
+impl<'a, K> Kernel<'a, K> {
     /// Construct a kernel from a slice and its dimensions. The input slice is
     /// in row-major form.
-    pub fn new(data: Vec<K>, width: u32, height: u32) -> OwnedKernel<K> {
+    pub fn new(data: &'a [K], width: u32, height: u32) -> Kernel<'a, K> {
         assert!(width > 0 && height > 0, "width and height must be non-zero");
         assert!(
             width * height == data.len() as u32,
@@ -59,172 +19,75 @@ impl<K> OwnedKernel<K> {
             width * height,
             data.len()
         );
-        OwnedKernel {
+        Kernel {
             data,
             width,
             height,
         }
     }
-    /// Maps the kernel from type `K` to `Q` via the closure `f`.
-    pub fn map<Q>(self, f: &impl Fn(K) -> Q) -> OwnedKernel<Q> {
-        OwnedKernel {
-            data: self.data.into_iter().map(f).collect(),
-            width: self.width,
-            height: self.height,
-        }
-    }
 
-    /// Returns the sobel horizontal 3x3 kernel.
-    pub fn sobel_horizontal_3x3() -> Self
-    where
-        K: From<i8> + Clone,
-    {
-        Self {
-            data: [-1, 0, 1, -2, 0, 2, -1, 0, 1].map(K::from).to_vec(),
-            width: 3,
-            height: 3,
-        }
-    }
-    /// Returns the sobel vertical 3x3 kernel.
-    pub fn sobel_vertical_3x3() -> Self
-    where
-        K: From<i8> + Clone,
-    {
-        Self {
-            data: [-1, -2, -1, 0, 0, 0, 1, 2, 1].map(K::from).to_vec(),
-            width: 3,
-            height: 3,
-        }
-    }
-
-    /// Returns the scharr horizontal 3x3 kernel.
-    pub fn scharr_horizontal_3x3() -> Self
-    where
-        K: From<i8> + Clone,
-    {
-        Self {
-            data: [-3, 0, 3, -10, 0, 10, -3, 0, 3].map(K::from).to_vec(),
-            width: 3,
-            height: 3,
-        }
-    }
-    /// Returns the scharr vertical 3x3 kernel.
-    pub fn scharr_vertical_3x3() -> Self
-    where
-        K: From<i8> + Clone,
-    {
-        Self {
-            data: [-3, -10, -3, 0, 0, 0, 3, 10, 3].map(K::from).to_vec(),
-            width: 3,
-            height: 3,
-        }
-    }
-
-    /// Returns the prewitt horizontal 3x3 kernel.
-    pub fn prewitt_horizontal_3x3() -> Self
-    where
-        K: From<i8> + Clone,
-    {
-        Self {
-            data: [-1, 0, 1, -1, 0, 1, -1, 0, 1].map(K::from).to_vec(),
-            width: 3,
-            height: 3,
-        }
-    }
-    /// Returns the prewitt vertical 3x3 kernel.
-    pub fn prewitt_vertical_3x3() -> Self
-    where
-        K: From<i8> + Clone,
-    {
-        Self {
-            data: [-1, -1, -1, 0, 0, 0, 1, 1, 1].map(K::from).to_vec(),
-            width: 3,
-            height: 3,
-        }
-    }
-
-    /// Returns the roberts horizontal 3x3 kernel.
-    pub fn roberts_horizontal_2x2() -> Self
-    where
-        K: From<i8> + Clone,
-    {
-        Self {
-            data: [1, 0, 0, -1].map(K::from).to_vec(),
-            width: 2,
-            height: 2,
-        }
-    }
-    /// Returns the roberts vertical 3x3 kernel.
-    pub fn roberts_vertical_2x2() -> Self
-    where
-        K: From<i8> + Clone,
-    {
-        Self {
-            data: [0, 1, -1, -0].map(K::from).to_vec(),
-            width: 2,
-            height: 2,
-        }
-    }
-
-    /// Returns the laplacian 3x3 kernel.
-    pub fn laplacian_3x3() -> Self
-    where
-        K: From<i8> + Clone,
-    {
-        Self {
-            data: [0, 1, 0, 1, -4, 1, 0, 1, 0].map(K::from).to_vec(),
-            width: 3,
-            height: 3,
-        }
-    }
-}
-impl<K> Kernel<K> for OwnedKernel<K> {
-    fn width(&self) -> u32 {
-        self.width
-    }
-    fn height(&self) -> u32 {
-        self.height
-    }
-    fn get(&self, x: u32, y: u32) -> &K {
+    /// Get the value in the kernel at the given `x` and `y` position.
+    #[inline]
+    pub fn get_unchecked(&self, x: u32, y: u32) -> &K {
         &self.data[(y * self.width + x) as usize]
     }
-    fn enumerate<'a>(&'a self) -> impl Iterator<Item = (Point<u32>, &'a K)>
-    where
-        K: 'a,
-    {
-        let points = (0..self.height)
-            .cartesian_product(0..self.width)
-            .map(|(y, x)| Point { x, y });
 
-        points.zip(self.data.iter())
-    }
-}
+    /// The sobel horizontal 3x3 kernel.
+    pub const SOBEL_HORIZONTAL_3X3: Kernel<'static, i32> = Kernel {
+        data: &[-1, 0, 1, -2, 0, 2, -1, 0, 1],
+        width: 3,
+        height: 3,
+    };
+    /// The sobel vertical 3x3 kernel.
+    pub const SOBEL_VERTICAL_3X3: Kernel<'static, i32> = Kernel {
+        data: &[-1, -2, -1, 0, 0, 0, 1, 2, 1],
+        width: 3,
+        height: 3,
+    };
 
-#[derive(Debug)]
-/// An borrowed 2D kernel, used to filter images via convolution.
-pub struct BorrowedKernel<'a, K> {
-    data: &'a [K],
-    width: u32,
-    height: u32,
-}
-impl<'b, K> Kernel<K> for BorrowedKernel<'b, K> {
-    fn width(&self) -> u32 {
-        self.width
-    }
-    fn height(&self) -> u32 {
-        self.height
-    }
-    fn get(&self, x: u32, y: u32) -> &K {
-        &self.data[(y * self.width + x) as usize]
-    }
-    fn enumerate<'a>(&'a self) -> impl Iterator<Item = (Point<u32>, &'a K)>
-    where
-        K: 'a,
-    {
-        let points = (0..self.height)
-            .cartesian_product(0..self.width)
-            .map(|(y, x)| Point { x, y });
+    /// The scharr horizontal 3x3 kernel.
+    pub const SCHARR_HORIZONTAL_3X3: Kernel<'static, i32> = Kernel {
+        data: &[-3, 0, 3, -10, 0, 10, -3, 0, 3],
+        width: 3,
+        height: 3,
+    };
+    /// The scharr vertical 3x3 kernel.
+    pub const SCHARR_VERTICAL_3X3: Kernel<'static, i32> = Kernel {
+        data: &[-3, -10, -3, 0, 0, 0, 3, 10, 3],
+        width: 3,
+        height: 3,
+    };
 
-        points.zip(self.data.iter())
-    }
+    /// The prewitt horizontal 3x3 kernel.
+    pub const PREWITT_HORIZONTAL_3X3: Kernel<'static, i32> = Kernel {
+        data: &[-1, 0, 1, -1, 0, 1, -1, 0, 1],
+        width: 3,
+        height: 3,
+    };
+    /// The prewitt vertical 3x3 kernel.
+    pub const PREWITT_VERTICAL_3X3: Kernel<'static, i32> = Kernel {
+        data: &[-1, -1, -1, 0, 0, 0, 1, 1, 1],
+        width: 3,
+        height: 3,
+    };
+
+    /// The roberts horizontal 3x3 kernel.
+    pub const ROBERTS_HORIZONTAL_2X2: Kernel<'static, i32> = Kernel {
+        data: &[1, 0, 0, -1],
+        width: 2,
+        height: 2,
+    };
+    /// The roberts vertical 3x3 kernel.
+    pub const ROBERTS_VERTICAL_2X2: Kernel<'static, i32> = Kernel {
+        data: &[0, 1, -1, -0],
+        width: 2,
+        height: 2,
+    };
+
+    /// The laplacian 3x3 kernel.
+    pub const LAPLACIAN_3X3: Kernel<'static, i16> = Kernel {
+        data: &[0, 1, 0, 1, -4, 1, 0, 1, 0],
+        width: 3,
+        height: 3,
+    };
 }

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -6,7 +6,7 @@ use crate::point::Point;
 
 /// A kernel object, in column major layout
 ///
-/// Used in methods such as [`gradients()`]
+/// Used in methods such as [`gradients()`](crate::gradients::gradients)
 pub trait Kernel<K> {
     /// The width of the kernel
     fn width(&self) -> u32;

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -73,6 +73,110 @@ impl<K> OwnedKernel<K> {
             height: self.height,
         }
     }
+
+    /// Returns the sobel horizontal 3x3 kernel.
+    pub fn sobel_horizontal_3x3() -> Self
+    where
+        K: From<i8> + Clone,
+    {
+        Self {
+            data: [-1, 0, 1, -2, 0, 2, -1, 0, 1].map(K::from).to_vec(),
+            width: 3,
+            height: 3,
+        }
+    }
+    /// Returns the sobel vertical 3x3 kernel.
+    pub fn sobel_vertical_3x3() -> Self
+    where
+        K: From<i8> + Clone,
+    {
+        Self {
+            data: [-1, -2, -1, 0, 0, 0, 1, 2, 1].map(K::from).to_vec(),
+            width: 3,
+            height: 3,
+        }
+    }
+
+    /// Returns the scharr horizontal 3x3 kernel.
+    pub fn scharr_horizontal_3x3() -> Self
+    where
+        K: From<i8> + Clone,
+    {
+        Self {
+            data: [-3, 0, 3, -10, 0, 10, -3, 0, 3].map(K::from).to_vec(),
+            width: 3,
+            height: 3,
+        }
+    }
+    /// Returns the scharr vertical 3x3 kernel.
+    pub fn scharr_vertical_3x3() -> Self
+    where
+        K: From<i8> + Clone,
+    {
+        Self {
+            data: [-3, -10, -3, 0, 0, 0, 3, 10, 3].map(K::from).to_vec(),
+            width: 3,
+            height: 3,
+        }
+    }
+
+    /// Returns the prewitt horizontal 3x3 kernel.
+    pub fn prewitt_horizontal_3x3() -> Self
+    where
+        K: From<i8> + Clone,
+    {
+        Self {
+            data: [-1, 0, 1, -1, 0, 1, -1, 0, 1].map(K::from).to_vec(),
+            width: 3,
+            height: 3,
+        }
+    }
+    /// Returns the prewitt vertical 3x3 kernel.
+    pub fn prewitt_vertical_3x3() -> Self
+    where
+        K: From<i8> + Clone,
+    {
+        Self {
+            data: [-1, -1, -1, 0, 0, 0, 1, 1, 1].map(K::from).to_vec(),
+            width: 3,
+            height: 3,
+        }
+    }
+
+    /// Returns the roberts horizontal 3x3 kernel.
+    pub fn roberts_horizontal_2x2() -> Self
+    where
+        K: From<i8> + Clone,
+    {
+        Self {
+            data: [1, 0, 0, -1].map(K::from).to_vec(),
+            width: 2,
+            height: 2,
+        }
+    }
+    /// Returns the roberts vertical 3x3 kernel.
+    pub fn roberts_vertical_2x2() -> Self
+    where
+        K: From<i8> + Clone,
+    {
+        Self {
+            data: [0, 1, -1, -0].map(K::from).to_vec(),
+            width: 2,
+            height: 2,
+        }
+    }
+
+    /// Returns the laplacian 3x3 kernel.
+    pub fn laplacian_3x3() -> Self
+    where
+        K: From<i8> + Clone,
+    {
+        Self {
+            data: [0, 1, 0, 1, -4, 1, 0, 1, 0].map(K::from).to_vec(),
+            width: 3,
+            height: 3,
+        }
+    }
 }
 impl<K> Kernel<K> for OwnedKernel<K> {
     fn width(&self) -> u32 {
@@ -123,12 +227,4 @@ impl<'b, K> Kernel<K> for BorrowedKernel<'b, K> {
 
         points.zip(self.data.iter())
     }
-}
-
-/// A type for combining two kernels into one struct
-pub struct TwoKernels<T> {
-    /// The first of the two kernels
-    pub kernel1: T,
-    /// The second of the two kernels
-    pub kernel2: T,
 }

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -4,7 +4,7 @@ use itertools::Itertools;
 
 use crate::point::Point;
 
-/// A kernel object, in column major layout
+/// A 2D kernel
 ///
 /// Used in methods such as [`gradients()`](crate::gradients::gradients)
 pub trait Kernel<K> {

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -74,8 +74,36 @@ impl<K> OwnedKernel<K> {
         }
     }
 }
-
 impl<K> Kernel<K> for OwnedKernel<K> {
+    fn width(&self) -> u32 {
+        self.width
+    }
+    fn height(&self) -> u32 {
+        self.height
+    }
+    fn get(&self, x: u32, y: u32) -> &K {
+        &self.data[(y * self.width + x) as usize]
+    }
+    fn enumerate<'a>(&'a self) -> impl Iterator<Item = (Point<u32>, &'a K)>
+    where
+        K: 'a,
+    {
+        let points = (0..self.height)
+            .cartesian_product(0..self.width)
+            .map(|(y, x)| Point { x, y });
+
+        points.zip(self.data.iter())
+    }
+}
+
+#[derive(Debug)]
+/// An borrowed 2D kernel, used to filter images via convolution.
+pub struct BorrowedKernel<'a, K> {
+    data: &'a [K],
+    width: u32,
+    height: u32,
+}
+impl<'b, K> Kernel<K> for BorrowedKernel<'b, K> {
     fn width(&self) -> u32 {
         self.width
     }

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -6,7 +6,7 @@ use crate::point::Point;
 
 /// A kernel object, in column major layout
 ///
-/// Used in methods such as [`gradents()`]
+/// Used in methods such as [`gradients()`]
 pub trait Kernel<K> {
     /// The width of the kernel
     fn width(&self) -> u32;

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -1,0 +1,106 @@
+//! Traits and Structs for the abstraction of kernels used in gradient methods
+
+use itertools::Itertools;
+
+use crate::point::Point;
+
+/// A kernel object, in column major layout
+///
+/// Used in methods such as [`gradents()`]
+pub trait Kernel<K> {
+    /// The width of the kernel
+    fn width(&self) -> u32;
+    /// The height of the kernel
+    fn height(&self) -> u32;
+
+    /// Access an element of the kernel
+    fn get(&self, x: u32, y: u32) -> &K;
+    /// Enumerate all elements of the kernel
+    fn enumerate<'a>(&'a self) -> impl Iterator<Item = (Point<u32>, &'a K)>
+    where
+        K: 'a;
+}
+impl<T, K> Kernel<K> for &T
+where
+    T: Kernel<K>,
+{
+    fn width(&self) -> u32 {
+        (*self).width()
+    }
+    fn height(&self) -> u32 {
+        (*self).height()
+    }
+    fn get(&self, x: u32, y: u32) -> &K {
+        (*self).get(x, y)
+    }
+    fn enumerate<'a>(&'a self) -> impl Iterator<Item = (Point<u32>, &'a K)>
+    where
+        K: 'a,
+    {
+        (*self).enumerate()
+    }
+}
+
+/// An owned 2D kernel, used to filter images via convolution.
+#[derive(Debug, Clone)]
+pub struct OwnedKernel<K> {
+    data: Vec<K>,
+    width: u32,
+    height: u32,
+}
+impl<K> OwnedKernel<K> {
+    /// Construct a kernel from a slice and its dimensions. The input slice is
+    /// in row-major form.
+    pub fn new(data: Vec<K>, width: u32, height: u32) -> OwnedKernel<K> {
+        assert!(width > 0 && height > 0, "width and height must be non-zero");
+        assert!(
+            width * height == data.len() as u32,
+            "Invalid kernel len: expecting {}, found {}",
+            width * height,
+            data.len()
+        );
+        OwnedKernel {
+            data,
+            width,
+            height,
+        }
+    }
+    /// Maps the kernel from type `K` to `Q` via the closure `f`.
+    pub fn map<Q>(self, f: &impl Fn(K) -> Q) -> OwnedKernel<Q> {
+        OwnedKernel {
+            data: self.data.into_iter().map(f).collect(),
+            width: self.width,
+            height: self.height,
+        }
+    }
+}
+
+impl<K> Kernel<K> for OwnedKernel<K> {
+    fn width(&self) -> u32 {
+        self.width
+    }
+    fn height(&self) -> u32 {
+        self.height
+    }
+    fn get(&self, x: u32, y: u32) -> &K {
+        &self.data[(y * self.width + x) as usize]
+    }
+    fn enumerate<'a>(&'a self) -> impl Iterator<Item = (Point<u32>, &'a K)>
+    where
+        K: 'a,
+    {
+        let points = (0..self.height)
+            .cartesian_product(0..self.width)
+            .map(|(y, x)| Point { x, y });
+
+        points.zip(self.data.iter())
+    }
+}
+
+/// A type for combining two kernels into one struct
+pub struct TwoKernels<T> {
+    /// The first of the two kernels
+    pub kernel1: T,
+    /// The second of the two kernels
+    pub kernel2: T,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,7 @@ pub mod haar;
 pub mod hog;
 pub mod hough;
 pub mod integral_image;
+pub mod kernel;
 pub mod local_binary_patterns;
 pub mod map;
 pub mod math;

--- a/src/seam_carving.rs
+++ b/src/seam_carving.rs
@@ -5,7 +5,7 @@
 
 use crate::definitions::{HasBlack, Image};
 use crate::gradients::gradients;
-use crate::kernel::OwnedKernel;
+use crate::kernel::Kernel;
 use crate::map::{map_colors, WithChannel};
 use image::{GrayImage, Luma, Pixel, Rgb};
 use std::cmp::min;
@@ -57,8 +57,8 @@ where
 
     let mut gradients = gradients(
         image,
-        OwnedKernel::sobel_horizontal_3x3(),
-        OwnedKernel::sobel_vertical_3x3(),
+        Kernel::<i32>::SOBEL_HORIZONTAL_3X3,
+        Kernel::<i32>::SOBEL_VERTICAL_3X3,
         |p| {
             let gradient_sum: u16 = p.channels().iter().sum();
             let gradient_mean: u16 = gradient_sum / P::CHANNEL_COUNT as u16;

--- a/src/seam_carving.rs
+++ b/src/seam_carving.rs
@@ -4,7 +4,7 @@
 //! [seam carving]: https://en.wikipedia.org/wiki/Seam_carving
 
 use crate::definitions::{HasBlack, Image};
-use crate::gradients::sobel_gradient_map;
+use crate::gradients::{gradients, GradientKernel};
 use crate::map::{map_colors, WithChannel};
 use image::{GrayImage, Luma, Pixel, Rgb};
 use std::cmp::min;
@@ -54,11 +54,17 @@ where
         "Cannot find seams if image width is < 2"
     );
 
-    let mut gradients = sobel_gradient_map(image, |p| {
-        let gradient_sum: u16 = p.channels().iter().sum();
-        let gradient_mean: u16 = gradient_sum / P::CHANNEL_COUNT as u16;
-        Luma([gradient_mean as u32])
-    });
+    let gradient_kernel = GradientKernel::Sobel;
+    let mut gradients = gradients(
+        image,
+        &gradient_kernel.as_horizontal_kernel(),
+        &gradient_kernel.as_vertical_kernel(),
+        |p| {
+            let gradient_sum: u16 = p.channels().iter().sum();
+            let gradient_mean: u16 = gradient_sum / P::CHANNEL_COUNT as u16;
+            Luma([gradient_mean as u32])
+        },
+    );
 
     // Find the least energy path through the gradient image.
     for y in 1..height {

--- a/src/seam_carving.rs
+++ b/src/seam_carving.rs
@@ -4,7 +4,8 @@
 //! [seam carving]: https://en.wikipedia.org/wiki/Seam_carving
 
 use crate::definitions::{HasBlack, Image};
-use crate::gradients::{gradients, GradientKernel};
+use crate::gradients::gradients;
+use crate::kernel::OwnedKernel;
 use crate::map::{map_colors, WithChannel};
 use image::{GrayImage, Luma, Pixel, Rgb};
 use std::cmp::min;
@@ -54,11 +55,16 @@ where
         "Cannot find seams if image width is < 2"
     );
 
-    let mut gradients = gradients(image, GradientKernel::Sobel, |p| {
-        let gradient_sum: u16 = p.channels().iter().sum();
-        let gradient_mean: u16 = gradient_sum / P::CHANNEL_COUNT as u16;
-        Luma([gradient_mean as u32])
-    });
+    let mut gradients = gradients(
+        image,
+        OwnedKernel::sobel_horizontal_3x3(),
+        OwnedKernel::sobel_vertical_3x3(),
+        |p| {
+            let gradient_sum: u16 = p.channels().iter().sum();
+            let gradient_mean: u16 = gradient_sum / P::CHANNEL_COUNT as u16;
+            Luma([gradient_mean as u32])
+        },
+    );
 
     // Find the least energy path through the gradient image.
     for y in 1..height {

--- a/src/seam_carving.rs
+++ b/src/seam_carving.rs
@@ -54,17 +54,11 @@ where
         "Cannot find seams if image width is < 2"
     );
 
-    let gradient_kernel = GradientKernel::Sobel;
-    let mut gradients = gradients(
-        image,
-        &gradient_kernel.as_horizontal_kernel(),
-        &gradient_kernel.as_vertical_kernel(),
-        |p| {
-            let gradient_sum: u16 = p.channels().iter().sum();
-            let gradient_mean: u16 = gradient_sum / P::CHANNEL_COUNT as u16;
-            Luma([gradient_mean as u32])
-        },
-    );
+    let mut gradients = gradients(image, GradientKernel::Sobel, |p| {
+        let gradient_sum: u16 = p.channels().iter().sum();
+        let gradient_mean: u16 = gradient_sum / P::CHANNEL_COUNT as u16;
+        Luma([gradient_mean as u32])
+    });
 
     // Find the least energy path through the gradient image.
     for y in 1..height {

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -23,6 +23,7 @@ use image::{
 };
 
 use imageproc::contrast::ThresholdType;
+use imageproc::gradients::GradientKernel;
 use imageproc::{
     definitions::{Clamp, HasBlack, HasWhite},
     edges::canny,
@@ -303,7 +304,12 @@ fn test_affine_bicubic_rgb() {
 fn test_sobel_gradients() {
     fn sobel_gradients(image: &GrayImage) -> GrayImage {
         imageproc::map::map_subpixels(
-            &gradients::sobel_gradients(image),
+            &gradients::gradients(
+                image,
+                &GradientKernel::Sobel.as_horizontal_kernel(),
+                &GradientKernel::Sobel.as_vertical_kernel(),
+                |p| p,
+            ),
             <u8 as Clamp<u16>>::clamp,
         )
     }

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -304,12 +304,7 @@ fn test_affine_bicubic_rgb() {
 fn test_sobel_gradients() {
     fn sobel_gradients(image: &GrayImage) -> GrayImage {
         imageproc::map::map_subpixels(
-            &gradients::gradients(
-                image,
-                &GradientKernel::Sobel.as_horizontal_kernel(),
-                &GradientKernel::Sobel.as_vertical_kernel(),
-                |p| p,
-            ),
+            &gradients::gradients(image, GradientKernel::Sobel, |p| p),
             <u8 as Clamp<u16>>::clamp,
         )
     }

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -23,7 +23,7 @@ use image::{
 };
 
 use imageproc::contrast::ThresholdType;
-use imageproc::gradients::GradientKernel;
+use imageproc::kernel::OwnedKernel;
 use imageproc::{
     definitions::{Clamp, HasBlack, HasWhite},
     edges::canny,
@@ -304,7 +304,12 @@ fn test_affine_bicubic_rgb() {
 fn test_sobel_gradients() {
     fn sobel_gradients(image: &GrayImage) -> GrayImage {
         imageproc::map::map_subpixels(
-            &gradients::gradients(image, GradientKernel::Sobel, |p| p),
+            &gradients::gradients(
+                image,
+                OwnedKernel::sobel_horizontal_3x3(),
+                OwnedKernel::sobel_vertical_3x3(),
+                |p| p,
+            ),
             <u8 as Clamp<u16>>::clamp,
         )
     }

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -23,7 +23,7 @@ use image::{
 };
 
 use imageproc::contrast::ThresholdType;
-use imageproc::kernel::OwnedKernel;
+use imageproc::kernel::Kernel;
 use imageproc::{
     definitions::{Clamp, HasBlack, HasWhite},
     edges::canny,
@@ -306,8 +306,8 @@ fn test_sobel_gradients() {
         imageproc::map::map_subpixels(
             &gradients::gradients(
                 image,
-                OwnedKernel::sobel_horizontal_3x3(),
-                OwnedKernel::sobel_vertical_3x3(),
+                Kernel::<i32>::SOBEL_HORIZONTAL_3X3,
+                Kernel::<i32>::SOBEL_VERTICAL_3X3,
                 |p| p,
             ),
             <u8 as Clamp<u16>>::clamp,


### PR DESCRIPTION
This is a version 2 PR of #596

This time I've added a `Kernel` trait to allow heap OR stack allocated kernel usage using `OwnedKernel` and `BorrowedKernel` respectively. I also rolled back the 1D kernel function back to taking `&[K]`.

Summary:

- Made more functions taking 2D kernels the `impl Kernel<K>` trait for Heap or Stack kernels
- Moved `HORIZONTAL_SOBEL` and similar constants to `OwnedKernel::sobel_horizontal_3x3()` and made them generic for any `T: From<i8>
- Removed `horizontal_*` and `vertical_*` functions since they can all be achieved via composition such as `filter(image, OwnedKernel::sobel_horizontal_3x3())` which is more explicit and rusty.
- Bumped MSRV to 1.75.0 for the `enumerate()` method of `Kernel` which uses return position impl traits.
- Made `Kernel::filter` a free-standing function which is more consistent with the rest of the library `crate::filter::filter()`
- Added a `filter_clamped()` function
- Removed the `filter3x3()` function as it is no different from `filter_clamped()`