### PR TITLE
Add docs.rs feature description

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@
 //! [image]: https://github.com/image-rs/image
 #![deny(missing_docs)]
 #![cfg_attr(test, feature(test))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![allow(
     clippy::cast_lossless,
     clippy::too_many_arguments,
@@ -68,6 +69,7 @@ pub mod suppress;
 pub mod template_matching;
 pub mod union_find;
 #[cfg(feature = "display-window")]
+#[cfg_attr(docsrs, doc(cfg(feature = "display-window")))]
 pub mod window;
 
 pub use image;

--- a/src/template_matching.rs
+++ b/src/template_matching.rs
@@ -92,6 +92,7 @@ pub fn match_template(
 }
 
 #[cfg(feature = "rayon")]
+#[cfg_attr(docsrs, doc(cfg(feature = "rayon")))]
 /// Slides a `template` over an `image` and scores the match at each point using
 /// the requested `method`. This version uses rayon to parallelize the computation.
 ///


### PR DESCRIPTION
This adds the `#[cfg_attr(docsrs, doc(cfg(feature = "...")))]` markers to inform docs.rs about feature conditions. It looks somewhat like this;

![image](https://github.com/image-rs/imageproc/assets/495335/714fb5d4-ee1f-4f44-8086-469e75067766)

Since this is a feature that only works with docs.rs, it's gated by the `#![cfg_attr(docsrs, feature(doc_cfg))]` attribute in `lib.rs`.