### PR TITLE
Gradient Refactor V3

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -98,7 +98,7 @@ jobs:
     # https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability
     strategy:
       matrix:
-        msrv: ["1.75.0"] # 2021 edition requires 1.56
+        msrv: ["1.70.0"] # 2021 edition requires 1.56
     name: ubuntu / ${{ matrix.msrv }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -98,7 +98,7 @@ jobs:
     # https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability
     strategy:
       matrix:
-        msrv: ["1.70.0"] # 2021 edition requires 1.56
+        msrv: ["1.75.0"] # 2021 edition requires 1.56
     name: ubuntu / ${{ matrix.msrv }}
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "imageproc"
-version = "0.25.0"
+version = "0.26.0"
 authors = ["theotherphil"]
 # note: when changed, also update `msrv` in `.github/workflows/check.yml`
 rust-version = "1.70.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "imageproc"
 version = "0.25.0"
 authors = ["theotherphil"]
 # note: when changed, also update `msrv` in `.github/workflows/check.yml`
-rust-version = "1.75.0"
+rust-version = "1.70.0"
 edition = "2021"
 license = "MIT"
 description = "Image processing operations"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "imageproc"
 version = "0.25.0"
 authors = ["theotherphil"]
 # note: when changed, also update `msrv` in `.github/workflows/check.yml`
-rust-version = "1.70.0"
+rust-version = "1.75.0"
 edition = "2021"
 license = "MIT"
 description = "Image processing operations"

--- a/examples/gradients.rs
+++ b/examples/gradients.rs
@@ -5,7 +5,11 @@
 //! `cargo run --example gradients ./examples/empire-state-building.jpg ./tmp`
 
 use image::{open, GrayImage};
-use imageproc::{filter::filter_clamped, kernel::{self, Kernel}, map::map_subpixels};
+use imageproc::{
+    filter::filter_clamped,
+    kernel::{self, Kernel},
+    map::map_subpixels,
+};
 use std::{env, fs, path::Path};
 
 fn save_gradients(

--- a/examples/gradients.rs
+++ b/examples/gradients.rs
@@ -61,26 +61,26 @@ fn main() {
     for (name, horizontal, vertical, scale) in [
         (
             "sobel",
-            Kernel::<i32>::SOBEL_HORIZONTAL_3X3,
-            Kernel::<i32>::SOBEL_VERTICAL_3X3,
+            Kernel::SOBEL_HORIZONTAL_3X3,
+            Kernel::SOBEL_VERTICAL_3X3,
             32,
         ),
         (
             "scharr",
-            Kernel::<i32>::SCHARR_HORIZONTAL_3X3,
-            Kernel::<i32>::SCHARR_VERTICAL_3X3,
+            Kernel::SCHARR_HORIZONTAL_3X3,
+            Kernel::SCHARR_VERTICAL_3X3,
             8,
         ),
         (
             "prewitt",
-            Kernel::<i32>::PREWITT_HORIZONTAL_3X3,
-            Kernel::<i32>::PREWITT_VERTICAL_3X3,
+            Kernel::PREWITT_HORIZONTAL_3X3,
+            Kernel::PREWITT_VERTICAL_3X3,
             6,
         ),
         (
             "roberts",
-            Kernel::<i32>::ROBERTS_HORIZONTAL_2X2,
-            Kernel::<i32>::ROBERTS_VERTICAL_2X2,
+            Kernel::ROBERTS_HORIZONTAL_2X2,
+            Kernel::ROBERTS_VERTICAL_2X2,
             4,
         ),
     ] {

--- a/examples/gradients.rs
+++ b/examples/gradients.rs
@@ -5,7 +5,7 @@
 //! `cargo run --example gradients ./examples/empire-state-building.jpg ./tmp`
 
 use image::{open, GrayImage};
-use imageproc::{filter::filter_clamped, kernel::Kernel, map::map_subpixels};
+use imageproc::{filter::filter_clamped, kernel::{self, Kernel}, map::map_subpixels};
 use std::{env, fs, path::Path};
 
 fn save_gradients(
@@ -61,26 +61,26 @@ fn main() {
     for (name, horizontal, vertical, scale) in [
         (
             "sobel",
-            Kernel::SOBEL_HORIZONTAL_3X3,
-            Kernel::SOBEL_VERTICAL_3X3,
+            kernel::SOBEL_HORIZONTAL_3X3,
+            kernel::SOBEL_VERTICAL_3X3,
             32,
         ),
         (
             "scharr",
-            Kernel::SCHARR_HORIZONTAL_3X3,
-            Kernel::SCHARR_VERTICAL_3X3,
+            kernel::SCHARR_HORIZONTAL_3X3,
+            kernel::SCHARR_VERTICAL_3X3,
             8,
         ),
         (
             "prewitt",
-            Kernel::PREWITT_HORIZONTAL_3X3,
-            Kernel::PREWITT_VERTICAL_3X3,
+            kernel::PREWITT_HORIZONTAL_3X3,
+            kernel::PREWITT_VERTICAL_3X3,
             6,
         ),
         (
             "roberts",
-            Kernel::ROBERTS_HORIZONTAL_2X2,
-            Kernel::ROBERTS_VERTICAL_2X2,
+            kernel::ROBERTS_HORIZONTAL_2X2,
+            kernel::ROBERTS_VERTICAL_2X2,
             4,
         ),
     ] {

--- a/examples/gradients.rs
+++ b/examples/gradients.rs
@@ -4,29 +4,30 @@
 //!
 //! `cargo run --example gradients ./examples/empire-state-building.jpg ./tmp`
 
-use image::{open, GrayImage, Luma};
-use imageproc::{
-    definitions::Image,
-    gradients::{
-        horizontal_prewitt, horizontal_scharr, horizontal_sobel, vertical_prewitt, vertical_scharr,
-        vertical_sobel,
-    },
-    map::map_pixels,
-};
+use image::{open, GrayImage};
+use imageproc::{filter::filter_clamped, kernel::Kernel, map::map_subpixels};
 use std::{env, fs, path::Path};
 
-fn compute_gradients<F>(
+fn save_gradients(
     input: &GrayImage,
-    gradient_func: F,
+    horizontal_kernel: Kernel<i32>,
+    vertical_kernel: Kernel<i32>,
     output_dir: &Path,
-    file_name: &str,
+    name: &str,
     scale: i16,
-) where
-    F: Fn(&GrayImage) -> Image<Luma<i16>>,
-{
-    let gradient = gradient_func(input);
-    let gradient = map_pixels(&gradient, |_, _, p| Luma([(p[0].abs() / scale) as u8]));
-    gradient.save(&output_dir.join(file_name)).unwrap();
+) {
+    let horizontal_gradients = filter_clamped(input, horizontal_kernel);
+    let vertical_gradients = filter_clamped(input, vertical_kernel);
+
+    let horizontal_scaled = map_subpixels(&horizontal_gradients, |p: i16| (p.abs() / scale) as u8);
+    let vertical_scaled = map_subpixels(&vertical_gradients, |p: i16| (p.abs() / scale) as u8);
+
+    horizontal_scaled
+        .save(&output_dir.join(format!("{name}_horizontal.png")))
+        .unwrap();
+    vertical_scaled
+        .save(&output_dir.join(format!("{name}_vertical.png")))
+        .unwrap();
 }
 
 fn main() {
@@ -57,46 +58,32 @@ fn main() {
     let gray_path = output_dir.join("grey.png");
     input_image.save(&gray_path).unwrap();
 
-    compute_gradients(
-        &input_image,
-        horizontal_scharr,
-        output_dir,
-        "horizontal_scharr.png",
-        32,
-    );
-    compute_gradients(
-        &input_image,
-        vertical_scharr,
-        output_dir,
-        "vertical_scharr.png",
-        32,
-    );
-    compute_gradients(
-        &input_image,
-        horizontal_sobel,
-        output_dir,
-        "horizontal_sobel.png",
-        8,
-    );
-    compute_gradients(
-        &input_image,
-        vertical_sobel,
-        output_dir,
-        "vertical_sobel.png",
-        8,
-    );
-    compute_gradients(
-        &input_image,
-        horizontal_prewitt,
-        output_dir,
-        "horizontal_prewitt.png",
-        6,
-    );
-    compute_gradients(
-        &input_image,
-        vertical_prewitt,
-        output_dir,
-        "vertical_prewitt.png",
-        6,
-    );
+    for (name, horizontal, vertical, scale) in [
+        (
+            "sobel",
+            Kernel::<i32>::SOBEL_HORIZONTAL_3X3,
+            Kernel::<i32>::SOBEL_VERTICAL_3X3,
+            32,
+        ),
+        (
+            "scharr",
+            Kernel::<i32>::SCHARR_HORIZONTAL_3X3,
+            Kernel::<i32>::SCHARR_VERTICAL_3X3,
+            8,
+        ),
+        (
+            "prewitt",
+            Kernel::<i32>::PREWITT_HORIZONTAL_3X3,
+            Kernel::<i32>::PREWITT_VERTICAL_3X3,
+            6,
+        ),
+        (
+            "roberts",
+            Kernel::<i32>::ROBERTS_HORIZONTAL_2X2,
+            Kernel::<i32>::ROBERTS_VERTICAL_2X2,
+            4,
+        ),
+    ] {
+        save_gradients(&input_image, horizontal, vertical, output_dir, name, scale);
+    }
 }

--- a/examples/seam_carving.rs
+++ b/examples/seam_carving.rs
@@ -1,6 +1,7 @@
 use image::{open, GrayImage, Luma, Pixel};
 use imageproc::definitions::Clamp;
-use imageproc::gradients::sobel_gradient_map;
+use imageproc::gradients::gradients;
+use imageproc::kernel::Kernel;
 use imageproc::map::map_colors;
 use imageproc::seam_carving::*;
 use std::env;
@@ -59,10 +60,15 @@ fn main() {
     annotated.save(&annotated_path).unwrap();
 
     // Draw the seams on the gradient magnitude image.
-    let gradients = sobel_gradient_map(&input_image, |p| {
-        let mean = (p[0] + p[1] + p[2]) / 3;
-        Luma([mean as u32])
-    });
+    let gradients = gradients(
+        &input_image,
+        Kernel::<i32>::SOBEL_HORIZONTAL_3X3,
+        Kernel::<i32>::SOBEL_VERTICAL_3X3,
+        |p| {
+            let mean = (p[0] + p[1] + p[2]) / 3;
+            Luma([mean as u32])
+        },
+    );
     let clamped_gradients: GrayImage = map_colors(&gradients, |p| Luma([Clamp::clamp(p[0])]));
     let annotated_gradients = draw_vertical_seams(&clamped_gradients, &seams);
     let gradients_path = output_dir.join("gradients.png");

--- a/examples/seam_carving.rs
+++ b/examples/seam_carving.rs
@@ -1,7 +1,7 @@
 use image::{open, GrayImage, Luma, Pixel};
 use imageproc::definitions::Clamp;
 use imageproc::gradients::gradients;
-use imageproc::kernel::Kernel;
+use imageproc::kernel;
 use imageproc::map::map_colors;
 use imageproc::seam_carving::*;
 use std::env;
@@ -62,8 +62,8 @@ fn main() {
     // Draw the seams on the gradient magnitude image.
     let gradients = gradients(
         &input_image,
-        Kernel::SOBEL_HORIZONTAL_3X3,
-        Kernel::SOBEL_VERTICAL_3X3,
+        kernel::SOBEL_HORIZONTAL_3X3,
+        kernel::SOBEL_VERTICAL_3X3,
         |p| {
             let mean = (p[0] + p[1] + p[2]) / 3;
             Luma([mean as u32])

--- a/examples/seam_carving.rs
+++ b/examples/seam_carving.rs
@@ -62,8 +62,8 @@ fn main() {
     // Draw the seams on the gradient magnitude image.
     let gradients = gradients(
         &input_image,
-        Kernel::<i32>::SOBEL_HORIZONTAL_3X3,
-        Kernel::<i32>::SOBEL_VERTICAL_3X3,
+        Kernel::SOBEL_HORIZONTAL_3X3,
+        Kernel::SOBEL_VERTICAL_3X3,
         |p| {
             let mean = (p[0] + p[1] + p[2]) / 3;
             Luma([mean as u32])

--- a/src/edges.rs
+++ b/src/edges.rs
@@ -35,8 +35,8 @@ pub fn canny(image: &GrayImage, low_threshold: f32, high_threshold: f32) -> Gray
     let blurred = gaussian_blur_f32(image, SIGMA);
 
     // 2. Intensity of gradients.
-    let gx = filter_clamped(&blurred, Kernel::<i32>::SOBEL_HORIZONTAL_3X3);
-    let gy = filter_clamped(&blurred, Kernel::<i32>::SOBEL_VERTICAL_3X3);
+    let gx = filter_clamped(&blurred, Kernel::SOBEL_HORIZONTAL_3X3);
+    let gy = filter_clamped(&blurred, Kernel::SOBEL_VERTICAL_3X3);
     let g: Vec<f32> = gx
         .iter()
         .zip(gy.iter())

--- a/src/edges.rs
+++ b/src/edges.rs
@@ -2,7 +2,7 @@
 
 use crate::definitions::{HasBlack, HasWhite};
 use crate::filter::{filter_clamped, gaussian_blur_f32};
-use crate::kernel::Kernel;
+use crate::kernel::{self};
 use image::{GenericImageView, GrayImage, ImageBuffer, Luma};
 use std::f32;
 
@@ -35,8 +35,8 @@ pub fn canny(image: &GrayImage, low_threshold: f32, high_threshold: f32) -> Gray
     let blurred = gaussian_blur_f32(image, SIGMA);
 
     // 2. Intensity of gradients.
-    let gx = filter_clamped(&blurred, Kernel::SOBEL_HORIZONTAL_3X3);
-    let gy = filter_clamped(&blurred, Kernel::SOBEL_VERTICAL_3X3);
+    let gx = filter_clamped(&blurred, kernel::SOBEL_HORIZONTAL_3X3);
+    let gy = filter_clamped(&blurred, kernel::SOBEL_VERTICAL_3X3);
     let g: Vec<f32> = gx
         .iter()
         .zip(gy.iter())

--- a/src/edges.rs
+++ b/src/edges.rs
@@ -1,8 +1,8 @@
 //! Functions for detecting edges in images.
 
 use crate::definitions::{HasBlack, HasWhite};
-use crate::filter::gaussian_blur_f32;
-use crate::gradients::{horizontal_sobel, vertical_sobel};
+use crate::filter::{filter_clamped, gaussian_blur_f32};
+use crate::kernel::Kernel;
 use image::{GenericImageView, GrayImage, ImageBuffer, Luma};
 use std::f32;
 
@@ -35,8 +35,8 @@ pub fn canny(image: &GrayImage, low_threshold: f32, high_threshold: f32) -> Gray
     let blurred = gaussian_blur_f32(image, SIGMA);
 
     // 2. Intensity of gradients.
-    let gx = horizontal_sobel(&blurred);
-    let gy = vertical_sobel(&blurred);
+    let gx = filter_clamped(&blurred, Kernel::<i32>::SOBEL_HORIZONTAL_3X3);
+    let gy = filter_clamped(&blurred, Kernel::<i32>::SOBEL_VERTICAL_3X3);
     let g: Vec<f32> = gx
         .iter()
         .zip(gy.iter())

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -962,18 +962,9 @@ mod proptests {
             ker in arbitrary_image::<Luma<f32>>(1..20, 1..20),
         ) {
             let kernel = Kernel::new(&ker, ker.width(), ker.height());
-            let out: Image<Luma<f32>> = kernel.filter(&img, |dst, src| {
+            let out: Image<Luma<f32>> = filter(&img, kernel, |dst, src| {
                 *dst = src;
             });
-            assert_eq!(out.dimensions(), img.dimensions());
-        }
-
-        #[test]
-        fn proptest_filter3x3(
-            img in arbitrary_image::<Luma<u8>>(0..50, 0..50),
-            ker in proptest::collection::vec(any::<f32>(), 9),
-        ) {
-            let out: Image<Luma<f32>> = filter3x3(&img, &ker);
             assert_eq!(out.dimensions(), img.dimensions());
         }
 

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -10,7 +10,7 @@ use image::{GenericImage, GenericImageView, GrayImage, ImageBuffer, Luma, Pixel,
 
 use crate::definitions::{Clamp, Image};
 use crate::integral_image::{column_running_sum, row_running_sum};
-use crate::kernel::Kernel;
+use crate::kernel::{self, Kernel};
 use crate::map::{ChannelMap, WithChannel};
 use num::Num;
 
@@ -341,7 +341,7 @@ where
     <P as Pixel>::Subpixel: Into<K> + Clamp<K>,
     K: Num + Copy,
 {
-    // Don't replace this with a call to Kernel::filter without
+    // Don't replace this with a call to filter() without
     // checking the benchmark results. At the time of writing this
     // specialised implementation is faster.
     let (width, height) = image.dimensions();
@@ -441,7 +441,7 @@ where
     <P as Pixel>::Subpixel: Into<K> + Clamp<K>,
     K: Num + Copy,
 {
-    // Don't replace this with a call to Kernel::filter without
+    // Don't replace this with a call to filter() without
     // checking the benchmark results. At the time of writing this
     // specialised implementation is faster.
     let (width, height) = image.dimensions();
@@ -557,7 +557,7 @@ where
 /// ```
 #[must_use = "the function does not modify the original image"]
 pub fn laplacian_filter(image: &GrayImage) -> Image<Luma<i16>> {
-    filter_clamped(image, Kernel::FOUR_LAPLACIAN_3X3)
+    filter_clamped(image, kernel::FOUR_LAPLACIAN_3X3)
 }
 
 #[cfg(test)]

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -10,6 +10,7 @@ use image::{GenericImage, GenericImageView, GrayImage, ImageBuffer, Luma, Pixel,
 
 use crate::definitions::{Clamp, Image};
 use crate::integral_image::{column_running_sum, row_running_sum};
+use crate::kernel::Kernel;
 use crate::map::{ChannelMap, WithChannel};
 use num::Num;
 
@@ -202,78 +203,49 @@ pub fn box_filter(image: &GrayImage, x_radius: u32, y_radius: u32) -> Image<Luma
     out
 }
 
-/// A 2D kernel, used to filter images via convolution.
-pub struct Kernel<'a, K> {
-    data: &'a [K],
-    width: u32,
-    height: u32,
-}
+/// Returns 2d correlation of an image. Intermediate calculations are performed
+/// at type K, and the results converted to pixel Q via f. Pads by continuity.
+pub fn filter<P, K, F, Q>(image: &Image<P>, kernel: Kernel<K>, mut f: F) -> Image<Q>
+where
+    P: Pixel,
+    <P as Pixel>::Subpixel: Into<K>,
+    Q: Pixel,
+    F: FnMut(&mut Q::Subpixel, K),
+    K: num::Num + Copy,
+{
+    let (width, height) = image.dimensions();
+    let mut out = Image::<Q>::new(width, height);
+    let num_channels = P::CHANNEL_COUNT as usize;
+    let zero = K::zero();
+    let mut acc = vec![zero; num_channels];
 
-impl<'a, K: Num + Copy + 'a> Kernel<'a, K> {
-    /// Construct a kernel from a slice and its dimensions. The input slice is
-    /// in row-major form.
-    ///
-    /// # Panics
-    ///
-    /// If `width == 0 || height == 0`.
-    pub fn new(data: &'a [K], width: u32, height: u32) -> Kernel<'a, K> {
-        assert!(width > 0 && height > 0, "width and height must be non-zero");
-        assert!(
-            width * height == data.len() as u32,
-            "Invalid kernel len: expecting {}, found {}",
-            width * height,
-            data.len()
-        );
-        Kernel {
-            data,
-            width,
-            height,
-        }
-    }
+    let (k_width, k_height) = (kernel.width, kernel.height);
 
-    /// Returns 2d correlation of an image. Intermediate calculations are performed
-    /// at type K, and the results converted to pixel Q via f. Pads by continuity.
-    pub fn filter<P, F, Q>(&self, image: &Image<P>, mut f: F) -> Image<Q>
-    where
-        P: Pixel,
-        <P as Pixel>::Subpixel: Into<K>,
-        Q: Pixel,
-        F: FnMut(&mut Q::Subpixel, K),
-    {
-        let (width, height) = image.dimensions();
-        let mut out = Image::<Q>::new(width, height);
-        let num_channels = P::CHANNEL_COUNT as usize;
-        let zero = K::zero();
-        let mut acc = vec![zero; num_channels];
-        let (k_width, k_height) = (self.width as i64, self.height as i64);
-        let (width, height) = (width as i64, height as i64);
+    let (width, height, k_width, k_height) =
+        (width as i64, height as i64, k_width as i64, k_height as i64);
 
-        for y in 0..height {
-            for x in 0..width {
-                for k_y in 0..k_height {
-                    let y_p = min(height - 1, max(0, y + k_y - k_height / 2)) as u32;
-                    for k_x in 0..k_width {
-                        let x_p = min(width - 1, max(0, x + k_x - k_width / 2)) as u32;
-
-                        debug_assert!(image.in_bounds(x_p, y_p));
-                        debug_assert!(((k_y * k_width + k_x) as usize) < self.data.len());
-                        accumulate(
-                            &mut acc,
-                            unsafe { &image.unsafe_get_pixel(x_p, y_p) },
-                            unsafe { *self.data.get_unchecked((k_y * k_width + k_x) as usize) },
-                        );
-                    }
-                }
-                let out_channels = out.get_pixel_mut(x as u32, y as u32).channels_mut();
-                for (a, c) in acc.iter_mut().zip(out_channels.iter_mut()) {
-                    f(c, *a);
-                    *a = zero;
+    for y in 0..height {
+        for x in 0..width {
+            for k_y in 0..k_height {
+                let y_p = min(height - 1, max(0, y + k_y - k_height / 2)) as u32;
+                for k_x in 0..k_width {
+                    let x_p = min(width - 1, max(0, x + k_x - k_width / 2)) as u32;
+                    accumulate(
+                        &mut acc,
+                        unsafe { &image.unsafe_get_pixel(x_p, y_p) },
+                        *kernel.get_unchecked(k_x as u32, k_y as u32),
+                    );
                 }
             }
+            let out_channels = out.get_pixel_mut(x as u32, y as u32).channels_mut();
+            for (a, c) in acc.iter_mut().zip(out_channels.iter_mut()) {
+                f(c, *a);
+                *a = zero;
+            }
         }
-
-        out
     }
+
+    out
 }
 
 #[inline]
@@ -293,6 +265,7 @@ fn gaussian_kernel_f32(sigma: f32) -> Vec<f32> {
     }
     let sum: f32 = kernel_data.iter().sum();
     kernel_data.iter_mut().for_each(|x| *x /= sum);
+
     kernel_data
 }
 
@@ -324,6 +297,12 @@ where
     <P as Pixel>::Subpixel: Into<K> + Clamp<K>,
     K: Num + Copy,
 {
+    assert_eq!(
+        h_kernel.len(),
+        v_kernel.len(),
+        "the two 1D kernels must be the same length"
+    );
+
     let h = horizontal_filter(image, h_kernel);
     vertical_filter(&h, v_kernel)
 }
@@ -340,18 +319,16 @@ where
     separable_filter(image, kernel, kernel)
 }
 
-/// Returns 2d correlation of an image with a 3x3 row-major kernel. Intermediate calculations are
+/// Returns 2d correlation of an image with a row-major kernel. Intermediate calculations are
 /// performed at type K, and the results clamped to subpixel type S. Pads by continuity.
-#[must_use = "the function does not modify the original image"]
-pub fn filter3x3<P, K, S>(image: &Image<P>, kernel: &[K]) -> Image<ChannelMap<P, S>>
+pub fn filter_clamped<P, K, S>(image: &Image<P>, kernel: Kernel<K>) -> Image<ChannelMap<P, S>>
 where
     P::Subpixel: Into<K>,
     S: Clamp<K> + Primitive,
     P: WithChannel<S>,
     K: Num + Copy,
 {
-    let kernel = Kernel::new(kernel, 3, 3);
-    kernel.filter(image, |channel, acc| *channel = S::clamp(acc))
+    filter(image, kernel, |channel, acc| *channel = S::clamp(acc))
 }
 
 /// Returns horizontal correlations between an image and a 1d kernel.
@@ -580,8 +557,7 @@ where
 /// ```
 #[must_use = "the function does not modify the original image"]
 pub fn laplacian_filter(image: &GrayImage) -> Image<Luma<i16>> {
-    let kernel: [i16; 9] = [0, 1, 0, 1, -4, 1, 0, 1, 0];
-    filter3x3(image, &kernel)
+    filter_clamped(image, Kernel::<i16>::FOUR_LAPLACIAN_3X3)
 }
 
 #[cfg(test)]
@@ -645,7 +621,7 @@ mod tests {
             4, 5, 5;
             6, 7, 7);
 
-        let kernel = vec![1f32 / 3f32; 3];
+        let kernel = [1f32 / 3f32; 3];
         let filtered = separable_filter_equal(&image, &kernel);
 
         assert_pixels_eq!(filtered, expected);
@@ -663,7 +639,7 @@ mod tests {
             39, 45, 51;
             57, 63, 69);
 
-        let kernel = vec![1i32; 3];
+        let kernel = [1i32; 3];
         let filtered = separable_filter_equal(&image, &kernel);
 
         assert_pixels_eq!(filtered, expected);
@@ -679,14 +655,14 @@ mod tests {
             for x in 0..width {
                 let mut acc = 0f32;
 
-                for k in 0..kernel.len() {
-                    let mut x_unchecked = x as i32 + k as i32 - (kernel.len() / 2) as i32;
+                for (i, k) in kernel.iter().enumerate() {
+                    let mut x_unchecked = x as i32 + i as i32 - (kernel.len() / 2) as i32;
                     x_unchecked = max(0, x_unchecked);
                     x_unchecked = min(x_unchecked, width as i32 - 1);
 
                     let x_checked = x_unchecked as u32;
                     let color = image.get_pixel(x_checked, y)[0];
-                    let weight = kernel[k];
+                    let weight = k;
 
                     acc += color as f32 * weight;
                 }
@@ -709,14 +685,14 @@ mod tests {
             for x in 0..width {
                 let mut acc = 0f32;
 
-                for k in 0..kernel.len() {
-                    let mut y_unchecked = y as i32 + k as i32 - (kernel.len() / 2) as i32;
+                for (i, k) in kernel.iter().enumerate() {
+                    let mut y_unchecked = y as i32 + i as i32 - (kernel.len() / 2) as i32;
                     y_unchecked = max(0, y_unchecked);
                     y_unchecked = min(y_unchecked, height as i32 - 1);
 
                     let y_checked = y_unchecked as u32;
                     let color = image.get_pixel(x, y_checked)[0];
-                    let weight = kernel[k];
+                    let weight = k;
 
                     acc += color as f32 * weight;
                 }
@@ -779,7 +755,7 @@ mod tests {
             5, 5, 5;
             2, 2, 2);
 
-        let kernel = vec![1f32 / 3f32; 3];
+        let kernel = [1f32 / 3f32; 3];
         let filtered = horizontal_filter(&image, &kernel);
 
         assert_pixels_eq!(filtered, expected);
@@ -792,7 +768,7 @@ mod tests {
             4, 7, 4;
             1, 4, 1);
 
-        let kernel = vec![1f32 / 10f32; 10];
+        let kernel = [1f32 / 10f32; 10];
         black_box(horizontal_filter(&image, &kernel));
     }
     #[test]
@@ -807,7 +783,7 @@ mod tests {
             2, 5, 2;
             2, 5, 2);
 
-        let kernel = vec![1f32 / 3f32; 3];
+        let kernel = [1f32 / 3f32; 3];
         let filtered = vertical_filter(&image, &kernel);
 
         assert_pixels_eq!(filtered, expected);
@@ -820,17 +796,17 @@ mod tests {
             4, 7, 4;
             1, 4, 1);
 
-        let kernel = vec![1f32 / 10f32; 10];
+        let kernel = [1f32 / 10f32; 10];
         black_box(vertical_filter(&image, &kernel));
     }
     #[test]
-    fn test_filter3x3_with_results_outside_input_channel_range() {
+    fn test_filter_clamped_with_results_outside_input_channel_range() {
         #[rustfmt::skip]
-        let kernel: Vec<i32> = vec![
+        let kernel: Kernel<i32> = Kernel::new(&[
             -1, 0, 1,
             -2, 0, 2,
             -1, 0, 1
-        ];
+        ], 3, 3);
 
         let image = gray_image!(
             3, 2, 1;
@@ -843,15 +819,15 @@ mod tests {
             -4, -8, -4
         );
 
-        let filtered = filter3x3(&image, &kernel);
+        let filtered = filter_clamped(&image, kernel);
         assert_pixels_eq!(filtered, expected);
     }
 
     #[test]
     #[should_panic]
     fn test_kernel_must_be_nonempty() {
-        let k: Vec<u8> = Vec::new();
-        let _ = Kernel::new(&k, 0, 0);
+        let k: &[u8] = &[];
+        let _ = Kernel::new(k, 0, 0);
     }
 
     #[test]
@@ -860,9 +836,9 @@ mod tests {
             3, 2;
             4, 1);
 
-        let k = vec![1u8, 2u8];
-        let kernel = Kernel::new(&k, 2, 1);
-        let filtered = kernel.filter(&image, |c, a| *c = a);
+        let k = &[1u8, 2u8];
+        let kernel = Kernel::new(k, 2, 1);
+        let filtered = filter(&image, kernel, |c, a| *c = a);
 
         let expected = gray_image!(
              9,  7;
@@ -875,9 +851,9 @@ mod tests {
     fn test_kernel_filter_with_empty_image() {
         let image = gray_image!();
 
-        let k = vec![2u8];
-        let kernel = Kernel::new(&k, 1, 1);
-        let filtered = kernel.filter(&image, |c, a| *c = a);
+        let k = &[2u8];
+        let kernel = Kernel::new(k, 1, 1);
+        let filtered = filter(&image, kernel, |c, a| *c = a);
 
         let expected = gray_image!();
         assert_pixels_eq!(filtered, expected);
@@ -890,14 +866,14 @@ mod tests {
             8, 1);
 
         #[rustfmt::skip]
-        let k: Vec<f32> = vec![
+        let k: &[f32] = &[
             0.1, 0.2, 0.1,
             0.2, 0.4, 0.2,
             0.1, 0.2, 0.1
         ];
-        let kernel = Kernel::new(&k, 3, 3);
+        let kernel = Kernel::new(k, 3, 3);
         let filtered: Image<Luma<u8>> =
-            kernel.filter(&image, |c, a| *c = <u8 as Clamp<f32>>::clamp(a));
+            filter(&image, kernel, |c, a| *c = <u8 as Clamp<f32>>::clamp(a));
 
         let expected = gray_image!(
             11,  7;
@@ -1060,8 +1036,8 @@ mod benches {
     #[bench]
     fn bench_separable_filter(b: &mut Bencher) {
         let image = gray_bench_image(300, 300);
-        let h_kernel = vec![1f32 / 5f32; 5];
-        let v_kernel = vec![0.1f32, 0.4f32, 0.3f32, 0.1f32, 0.1f32];
+        let h_kernel = [1f32 / 5f32; 5];
+        let v_kernel = [0.1f32, 0.4f32, 0.3f32, 0.1f32, 0.1f32];
         b.iter(|| {
             let filtered = separable_filter(&image, &h_kernel, &v_kernel);
             black_box(filtered);
@@ -1071,7 +1047,7 @@ mod benches {
     #[bench]
     fn bench_horizontal_filter(b: &mut Bencher) {
         let image = gray_bench_image(500, 500);
-        let kernel = vec![1f32 / 5f32; 5];
+        let kernel = [1f32 / 5f32; 5];
         b.iter(|| {
             let filtered = horizontal_filter(&image, &kernel);
             black_box(filtered);
@@ -1081,7 +1057,7 @@ mod benches {
     #[bench]
     fn bench_vertical_filter(b: &mut Bencher) {
         let image = gray_bench_image(500, 500);
-        let kernel = vec![1f32 / 5f32; 5];
+        let kernel = [1f32 / 5f32; 5];
         b.iter(|| {
             let filtered = vertical_filter(&image, &kernel);
             black_box(filtered);
@@ -1089,18 +1065,18 @@ mod benches {
     }
 
     #[bench]
-    fn bench_filter3x3_i32_filter(b: &mut Bencher) {
+    fn bench_filter_clamped_i32_filter(b: &mut Bencher) {
         let image = gray_bench_image(500, 500);
         #[rustfmt::skip]
-        let kernel: Vec<i32> = vec![
+        let kernel: Kernel<i32> = Kernel::new(&[
             -1, 0, 1,
             -2, 0, 2,
             -1, 0, 1
-        ];
+        ], 3, 3);
 
         b.iter(|| {
             let filtered: ImageBuffer<Luma<i16>, Vec<i16>> =
-                filter3x3::<_, _, i16>(&image, &kernel);
+                filter_clamped::<_, _, i16>(&image, kernel);
             black_box(filtered);
         });
     }

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -233,7 +233,7 @@ where
                     accumulate(
                         &mut acc,
                         unsafe { &image.unsafe_get_pixel(x_p, y_p) },
-                        *kernel.get_unchecked(k_x as u32, k_y as u32),
+                        *kernel.at(k_x as u32, k_y as u32),
                     );
                 }
             }
@@ -557,7 +557,7 @@ where
 /// ```
 #[must_use = "the function does not modify the original image"]
 pub fn laplacian_filter(image: &GrayImage) -> Image<Luma<i16>> {
-    filter_clamped(image, Kernel::<i16>::FOUR_LAPLACIAN_3X3)
+    filter_clamped(image, Kernel::FOUR_LAPLACIAN_3X3)
 }
 
 #[cfg(test)]

--- a/src/filter/sharpen.rs
+++ b/src/filter/sharpen.rs
@@ -1,6 +1,7 @@
-use super::{filter3x3, gaussian_blur_f32};
+use super::{filter_clamped, gaussian_blur_f32};
 use crate::{
     definitions::{Clamp, Image},
+    kernel::Kernel,
     map::{map_colors2, map_subpixels},
 };
 use image::{GrayImage, Luma};
@@ -8,8 +9,8 @@ use image::{GrayImage, Luma};
 /// Sharpens a grayscale image by applying a 3x3 approximation to the Laplacian.
 #[must_use = "the function does not modify the original image"]
 pub fn sharpen3x3(image: &GrayImage) -> GrayImage {
-    let identity_minus_laplacian = [0, -1, 0, -1, 5, -1, 0, -1, 0];
-    filter3x3(image, &identity_minus_laplacian)
+    let identity_minus_laplacian = Kernel::new(&[0, -1, 0, -1, 5, -1, 0, -1, 0], 3, 3);
+    filter_clamped(image, identity_minus_laplacian)
 }
 
 /// Sharpens a grayscale image using a Gaussian as a low-pass filter.

--- a/src/gradients.rs
+++ b/src/gradients.rs
@@ -2,7 +2,7 @@
 
 use crate::definitions::{Clamp, HasBlack, Image};
 use crate::filter::{filter, filter_clamped};
-use crate::kernel::Kernel;
+use crate::kernel::{self, Kernel};
 use crate::map::{ChannelMap, WithChannel};
 use image::{GenericImage, GenericImageView, GrayImage, Luma, Pixel};
 use itertools::multizip;
@@ -33,6 +33,7 @@ pub fn gradients_greyscale<P, F, Q>(
 /// # fn main() {
 /// use imageproc::gradients::gradients;
 /// use imageproc::kernel::Kernel;
+/// use imageproc::kernel;
 /// use image::Luma;
 /// use std::cmp;
 ///
@@ -52,8 +53,8 @@ pub fn gradients_greyscale<P, F, Q>(
 ///     [ 4,  0,  8], [ 8,  0,  8], [ 4,  0,  8]
 /// );
 ///
-/// let horizontal_kernel = Kernel::SOBEL_HORIZONTAL_3X3;
-/// let vertical_kernel = Kernel::SOBEL_VERTICAL_3X3;
+/// let horizontal_kernel = kernel::SOBEL_HORIZONTAL_3X3;
+/// let vertical_kernel = kernel::SOBEL_VERTICAL_3X3;
 ///
 /// assert_pixels_eq!(
 ///     gradients(&input, horizontal_kernel, vertical_kernel, |p| p),
@@ -157,72 +158,72 @@ fn gradient_magnitude(dx: f32, dy: f32) -> u16 {
 /// kernel to detect horizontal gradients.
 #[deprecated(
     since = "0.25.0",
-    note = "users should instead use `filter_clamped(image, Kernel::SOBEL_HORIZONTAL_3X3)` which is more flexible and explicit"
+    note = "users should instead use `filter_clamped(image, kernel::SOBEL_HORIZONTAL_3X3)` which is more flexible and explicit"
 )]
 pub fn horizontal_sobel(image: &GrayImage) -> Image<Luma<i16>> {
-    filter_clamped(image, Kernel::SOBEL_HORIZONTAL_3X3)
+    filter_clamped(image, kernel::SOBEL_HORIZONTAL_3X3)
 }
 
 /// Convolves an image with the [`VERTICAL_SOBEL`](static.VERTICAL_SOBEL.html)
 /// kernel to detect vertical gradients.
 #[deprecated(
     since = "0.25.0",
-    note = "users should instead use `filter_clamped(image, Kernel::SOBEL_VERTICAL_3X3)` which is more flexible and explicit"
+    note = "users should instead use `filter_clamped(image, kernel::SOBEL_VERTICAL_3X3)` which is more flexible and explicit"
 )]
 pub fn vertical_sobel(image: &GrayImage) -> Image<Luma<i16>> {
-    filter_clamped(image, Kernel::SOBEL_VERTICAL_3X3)
+    filter_clamped(image, kernel::SOBEL_VERTICAL_3X3)
 }
 
 /// Convolves an image with the [`HORIZONTAL_SCHARR`](static.HORIZONTAL_SCHARR.html)
 /// kernel to detect horizontal gradients.
 #[deprecated(
     since = "0.25.0",
-    note = "users should instead use `filter_clamped(image, Kernel::SCHARR_HORIZONTAL_3X3)` which is more flexible and explicit"
+    note = "users should instead use `filter_clamped(image, kernel::SCHARR_HORIZONTAL_3X3)` which is more flexible and explicit"
 )]
 pub fn horizontal_scharr(image: &GrayImage) -> Image<Luma<i16>> {
-    filter_clamped(image, Kernel::SCHARR_HORIZONTAL_3X3)
+    filter_clamped(image, kernel::SCHARR_HORIZONTAL_3X3)
 }
 
 /// Convolves an image with the [`VERTICAL_SCHARR`](static.VERTICAL_SCHARR.html)
 /// kernel to detect vertical gradients.
 #[deprecated(
     since = "0.25.0",
-    note = "users should instead use `filter_clamped(image, Kernel::SCHARR_VERTICAL_3X3)` which is more flexible and explicit"
+    note = "users should instead use `filter_clamped(image, kernel::SCHARR_VERTICAL_3X3)` which is more flexible and explicit"
 )]
 pub fn vertical_scharr(image: &GrayImage) -> Image<Luma<i16>> {
-    filter_clamped(image, Kernel::SCHARR_VERTICAL_3X3)
+    filter_clamped(image, kernel::SCHARR_VERTICAL_3X3)
 }
 
 /// Convolves an image with the [`HORIZONTAL_PREWITT`](static.HORIZONTAL_PREWITT.html)
 /// kernel to detect horizontal gradients.
 #[deprecated(
     since = "0.25.0",
-    note = "users should instead use `filter_clamped(image, Kernel::PREWITT_HORIZONTAL_3X3)` which is more flexible and explicit"
+    note = "users should instead use `filter_clamped(image, kernel::PREWITT_HORIZONTAL_3X3)` which is more flexible and explicit"
 )]
 pub fn horizontal_prewitt(image: &GrayImage) -> Image<Luma<i16>> {
-    filter_clamped(image, Kernel::PREWITT_HORIZONTAL_3X3)
+    filter_clamped(image, kernel::PREWITT_HORIZONTAL_3X3)
 }
 
 /// Convolves an image with the [`VERTICAL_PREWITT`](static.VERTICAL_PREWITT.html)
 /// kernel to detect vertical gradients.
 #[deprecated(
     since = "0.25.0",
-    note = "users should instead use `filter_clamped(image, Kernel::PREWITT_VERTICAL_3X3)` which is more flexible and explicit"
+    note = "users should instead use `filter_clamped(image, kernel::PREWITT_VERTICAL_3X3)` which is more flexible and explicit"
 )]
 pub fn vertical_prewitt(image: &GrayImage) -> Image<Luma<i16>> {
-    filter_clamped(image, Kernel::PREWITT_VERTICAL_3X3)
+    filter_clamped(image, kernel::PREWITT_VERTICAL_3X3)
 }
 
 /// Returns the magnitudes of gradients in an image using Sobel filters.
 #[deprecated(
     since = "0.25.0",
-    note = "users should instead use `gradients_greyscale(image, Kernel::SOBEL_HORIZONTAL_3X3, Kernel::SOBEL_VERTICAL_3X3)` which is more flexible and explicit"
+    note = "users should instead use `gradients_greyscale(image, kernel::SOBEL_HORIZONTAL_3X3, Kernel::SOBEL_VERTICAL_3X3)` which is more flexible and explicit"
 )]
 pub fn sobel_gradients(image: &GrayImage) -> Image<Luma<u16>> {
     gradients(
         image,
-        Kernel::SOBEL_HORIZONTAL_3X3,
-        Kernel::SOBEL_VERTICAL_3X3,
+        kernel::SOBEL_HORIZONTAL_3X3,
+        kernel::SOBEL_VERTICAL_3X3,
         |p| p,
     )
 }
@@ -230,13 +231,13 @@ pub fn sobel_gradients(image: &GrayImage) -> Image<Luma<u16>> {
 /// Returns the magnitudes of gradients in an image using Prewitt filters.
 #[deprecated(
     since = "0.25.0",
-    note = "users should instead use `gradients_greyscale(image, Kernel::PREWITT_HORIZONTAL_3X3, Kernel::PREWITT_VERTICAL_3X3)` which is more flexible and explicit"
+    note = "users should instead use `gradients_greyscale(image, kernel::PREWITT_HORIZONTAL_3X3, Kernel::PREWITT_VERTICAL_3X3)` which is more flexible and explicit"
 )]
 pub fn prewitt_gradients(image: &GrayImage) -> Image<Luma<u16>> {
     gradients(
         image,
-        Kernel::PREWITT_HORIZONTAL_3X3,
-        Kernel::PREWITT_VERTICAL_3X3,
+        kernel::PREWITT_HORIZONTAL_3X3,
+        kernel::PREWITT_VERTICAL_3X3,
         |p| p,
     )
 }
@@ -309,7 +310,7 @@ pub fn prewitt_gradients(image: &GrayImage) -> Image<Luma<u16>> {
 /// # }
 #[deprecated(
     since = "0.25.0",
-    note = "users should instead use `gradients(image, Kernel::SOBEL_HORIZONTAL_3X3, Kernel::SOBEL_VERTICAL_3X3, f)` which is more flexible and explicit"
+    note = "users should instead use `gradients(image, kernel::SOBEL_HORIZONTAL_3X3, Kernel::SOBEL_VERTICAL_3X3, f)` which is more flexible and explicit"
 )]
 pub fn sobel_gradient_map<P, F, Q>(image: &Image<P>, f: F) -> Image<Q>
 where
@@ -320,15 +321,15 @@ where
 {
     gradients(
         image,
-        Kernel::SOBEL_HORIZONTAL_3X3,
-        Kernel::SOBEL_VERTICAL_3X3,
+        kernel::SOBEL_HORIZONTAL_3X3,
+        kernel::SOBEL_VERTICAL_3X3,
         f,
     )
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::{filter::filter_clamped, kernel::Kernel};
+    use crate::filter::filter_clamped;
 
     use super::*;
     use image::{ImageBuffer, Luma};
@@ -341,8 +342,8 @@ mod tests {
         assert_pixels_eq!(
             gradients(
                 &image,
-                Kernel::SOBEL_HORIZONTAL_3X3,
-                Kernel::SOBEL_VERTICAL_3X3,
+                kernel::SOBEL_HORIZONTAL_3X3,
+                kernel::SOBEL_VERTICAL_3X3,
                 |p| p
             ),
             expected
@@ -356,8 +357,8 @@ mod tests {
         assert_pixels_eq!(
             gradients(
                 &image,
-                Kernel::SCHARR_HORIZONTAL_3X3,
-                Kernel::SCHARR_VERTICAL_3X3,
+                kernel::SCHARR_HORIZONTAL_3X3,
+                kernel::SCHARR_VERTICAL_3X3,
                 |p| p
             ),
             expected
@@ -371,8 +372,8 @@ mod tests {
         assert_pixels_eq!(
             gradients(
                 &image,
-                Kernel::PREWITT_HORIZONTAL_3X3,
-                Kernel::PREWITT_VERTICAL_3X3,
+                kernel::PREWITT_HORIZONTAL_3X3,
+                kernel::PREWITT_VERTICAL_3X3,
                 |p| p
             ),
             expected
@@ -386,8 +387,8 @@ mod tests {
         assert_pixels_eq!(
             gradients(
                 &image,
-                Kernel::ROBERTS_HORIZONTAL_2X2,
-                Kernel::ROBERTS_VERTICAL_2X2,
+                kernel::ROBERTS_HORIZONTAL_2X2,
+                kernel::ROBERTS_VERTICAL_2X2,
                 |p| p
             ),
             expected
@@ -406,7 +407,7 @@ mod tests {
             -4, -8, -4;
             -4, -8, -4);
 
-        let filtered = filter_clamped(&image, Kernel::SOBEL_HORIZONTAL_3X3);
+        let filtered = filter_clamped(&image, kernel::SOBEL_HORIZONTAL_3X3);
         assert_pixels_eq!(filtered, expected);
     }
 
@@ -422,7 +423,7 @@ mod tests {
             -8, -8, -8;
             -4, -4, -4);
 
-        let filtered = filter_clamped(&image, Kernel::SOBEL_VERTICAL_3X3);
+        let filtered = filter_clamped(&image, kernel::SOBEL_VERTICAL_3X3);
         assert_pixels_eq!(filtered, expected);
     }
 
@@ -438,7 +439,7 @@ mod tests {
             -16, -32, -16;
             -16, -32, -16);
 
-        let filtered = filter_clamped(&image, Kernel::SCHARR_HORIZONTAL_3X3);
+        let filtered = filter_clamped(&image, kernel::SCHARR_HORIZONTAL_3X3);
         assert_pixels_eq!(filtered, expected);
     }
 
@@ -454,7 +455,7 @@ mod tests {
             -32, -32, -32;
             -16, -16, -16);
 
-        let filtered = filter_clamped(&image, Kernel::SCHARR_VERTICAL_3X3);
+        let filtered = filter_clamped(&image, kernel::SCHARR_VERTICAL_3X3);
         assert_pixels_eq!(filtered, expected);
     }
 
@@ -470,7 +471,7 @@ mod tests {
             -3, -6, -3;
             -3, -6, -3);
 
-        let filtered = filter_clamped(&image, Kernel::PREWITT_HORIZONTAL_3X3);
+        let filtered = filter_clamped(&image, kernel::PREWITT_HORIZONTAL_3X3);
         assert_pixels_eq!(filtered, expected);
     }
 
@@ -486,7 +487,7 @@ mod tests {
             -6, -6, -6;
             -3, -3, -3);
 
-        let filtered = filter_clamped(&image, Kernel::PREWITT_VERTICAL_3X3);
+        let filtered = filter_clamped(&image, kernel::PREWITT_VERTICAL_3X3);
         assert_pixels_eq!(filtered, expected);
     }
 
@@ -502,7 +503,7 @@ mod tests {
             1, -2, -2;
             1, -2, -2);
 
-        let filtered = filter_clamped(&image, Kernel::ROBERTS_HORIZONTAL_2X2);
+        let filtered = filter_clamped(&image, kernel::ROBERTS_HORIZONTAL_2X2);
         assert_pixels_eq!(filtered, expected);
     }
     #[test]
@@ -517,7 +518,7 @@ mod tests {
             1, 4, 4;
             1, 4, 4);
 
-        let filtered = filter_clamped(&image, Kernel::ROBERTS_VERTICAL_2X2);
+        let filtered = filter_clamped(&image, kernel::ROBERTS_VERTICAL_2X2);
         assert_pixels_eq!(filtered, expected);
     }
 }
@@ -526,7 +527,7 @@ mod tests {
 #[cfg(test)]
 mod benches {
     use super::*;
-    use crate::{kernel::Kernel, utils::gray_bench_image};
+    use crate::utils::gray_bench_image;
     use test::{black_box, Bencher};
 
     #[bench]
@@ -535,8 +536,8 @@ mod benches {
         b.iter(|| {
             let gradients = gradients(
                 &image,
-                Kernel::SOBEL_HORIZONTAL_3X3,
-                Kernel::SOBEL_VERTICAL_3X3,
+                kernel::SOBEL_HORIZONTAL_3X3,
+                kernel::SOBEL_VERTICAL_3X3,
                 |p| p,
             );
             black_box(gradients);

--- a/src/gradients.rs
+++ b/src/gradients.rs
@@ -42,8 +42,8 @@ use itertools::multizip;
 ///     [ 4,  0,  8], [ 8,  0,  8], [ 4,  0,  8]
 /// );
 ///
-/// let horizontal_kernel = Kernel::<i32>::SOBEL_HORIZONTAL_3X3;
-/// let vertical_kernel = Kernel::<i32>::SOBEL_VERTICAL_3X3;
+/// let horizontal_kernel = Kernel::SOBEL_HORIZONTAL_3X3;
+/// let vertical_kernel = Kernel::SOBEL_VERTICAL_3X3;
 ///
 /// assert_pixels_eq!(
 ///     gradients(&input, horizontal_kernel, vertical_kernel, |p| p),
@@ -158,8 +158,8 @@ mod tests {
         assert_pixels_eq!(
             gradients(
                 &image,
-                Kernel::<i32>::SOBEL_HORIZONTAL_3X3,
-                Kernel::<i32>::SOBEL_VERTICAL_3X3,
+                Kernel::SOBEL_HORIZONTAL_3X3,
+                Kernel::SOBEL_VERTICAL_3X3,
                 |p| p
             ),
             expected
@@ -173,8 +173,8 @@ mod tests {
         assert_pixels_eq!(
             gradients(
                 &image,
-                Kernel::<i32>::SCHARR_HORIZONTAL_3X3,
-                Kernel::<i32>::SCHARR_VERTICAL_3X3,
+                Kernel::SCHARR_HORIZONTAL_3X3,
+                Kernel::SCHARR_VERTICAL_3X3,
                 |p| p
             ),
             expected
@@ -188,8 +188,8 @@ mod tests {
         assert_pixels_eq!(
             gradients(
                 &image,
-                Kernel::<i32>::PREWITT_HORIZONTAL_3X3,
-                Kernel::<i32>::PREWITT_VERTICAL_3X3,
+                Kernel::PREWITT_HORIZONTAL_3X3,
+                Kernel::PREWITT_VERTICAL_3X3,
                 |p| p
             ),
             expected
@@ -203,8 +203,8 @@ mod tests {
         assert_pixels_eq!(
             gradients(
                 &image,
-                Kernel::<i32>::ROBERTS_HORIZONTAL_2X2,
-                Kernel::<i32>::ROBERTS_VERTICAL_2X2,
+                Kernel::ROBERTS_HORIZONTAL_2X2,
+                Kernel::ROBERTS_VERTICAL_2X2,
                 |p| p
             ),
             expected
@@ -223,7 +223,7 @@ mod tests {
             -4, -8, -4;
             -4, -8, -4);
 
-        let filtered = filter_clamped(&image, Kernel::<i16>::SOBEL_HORIZONTAL_3X3);
+        let filtered = filter_clamped(&image, Kernel::SOBEL_HORIZONTAL_3X3);
         assert_pixels_eq!(filtered, expected);
     }
 
@@ -239,7 +239,7 @@ mod tests {
             -8, -8, -8;
             -4, -4, -4);
 
-        let filtered = filter_clamped(&image, Kernel::<i16>::SOBEL_VERTICAL_3X3);
+        let filtered = filter_clamped(&image, Kernel::SOBEL_VERTICAL_3X3);
         assert_pixels_eq!(filtered, expected);
     }
 
@@ -255,7 +255,7 @@ mod tests {
             -16, -32, -16;
             -16, -32, -16);
 
-        let filtered = filter_clamped(&image, Kernel::<i16>::SCHARR_HORIZONTAL_3X3);
+        let filtered = filter_clamped(&image, Kernel::SCHARR_HORIZONTAL_3X3);
         assert_pixels_eq!(filtered, expected);
     }
 
@@ -271,7 +271,7 @@ mod tests {
             -32, -32, -32;
             -16, -16, -16);
 
-        let filtered = filter_clamped(&image, Kernel::<i16>::SCHARR_VERTICAL_3X3);
+        let filtered = filter_clamped(&image, Kernel::SCHARR_VERTICAL_3X3);
         assert_pixels_eq!(filtered, expected);
     }
 
@@ -287,7 +287,7 @@ mod tests {
             -3, -6, -3;
             -3, -6, -3);
 
-        let filtered = filter_clamped(&image, Kernel::<i16>::PREWITT_HORIZONTAL_3X3);
+        let filtered = filter_clamped(&image, Kernel::PREWITT_HORIZONTAL_3X3);
         assert_pixels_eq!(filtered, expected);
     }
 
@@ -303,7 +303,7 @@ mod tests {
             -6, -6, -6;
             -3, -3, -3);
 
-        let filtered = filter_clamped(&image, Kernel::<i16>::PREWITT_VERTICAL_3X3);
+        let filtered = filter_clamped(&image, Kernel::PREWITT_VERTICAL_3X3);
         assert_pixels_eq!(filtered, expected);
     }
 
@@ -319,7 +319,7 @@ mod tests {
             1, -2, -2;
             1, -2, -2);
 
-        let filtered = filter_clamped(&image, Kernel::<i16>::ROBERTS_HORIZONTAL_2X2);
+        let filtered = filter_clamped(&image, Kernel::ROBERTS_HORIZONTAL_2X2);
         assert_pixels_eq!(filtered, expected);
     }
     #[test]
@@ -334,7 +334,7 @@ mod tests {
             1, 4, 4;
             1, 4, 4);
 
-        let filtered = filter_clamped(&image, Kernel::<i16>::ROBERTS_VERTICAL_2X2);
+        let filtered = filter_clamped(&image, Kernel::ROBERTS_VERTICAL_2X2);
         assert_pixels_eq!(filtered, expected);
     }
 }
@@ -352,8 +352,8 @@ mod benches {
         b.iter(|| {
             let gradients = gradients(
                 &image,
-                Kernel::<i32>::SOBEL_HORIZONTAL_3X3,
-                Kernel::<i32>::SOBEL_VERTICAL_3X3,
+                Kernel::SOBEL_HORIZONTAL_3X3,
+                Kernel::SOBEL_VERTICAL_3X3,
                 |p| p,
             );
             black_box(gradients);

--- a/src/hog.rs
+++ b/src/hog.rs
@@ -2,7 +2,8 @@
 //! and helpers for visualizing them.
 
 use crate::definitions::{Clamp, Image};
-use crate::gradients::{horizontal_sobel, vertical_sobel};
+use crate::filter::filter_clamped;
+use crate::kernel::Kernel;
 use crate::math::l2_norm;
 use image::{GenericImage, GrayImage, ImageBuffer, Luma};
 use num::Zero;
@@ -257,8 +258,9 @@ pub fn cell_histograms(image: &GrayImage, spec: HogSpec) -> Array3d<f32> {
     let mut grid = Array3d::new(spec.cell_grid_lengths());
     let cell_area = spec.cell_area() as f32;
     let cell_side = spec.options.cell_side as f32;
-    let horizontal = horizontal_sobel(image);
-    let vertical = vertical_sobel(image);
+
+    let horizontal = filter_clamped::<_, _, i32>(image, Kernel::<i32>::SOBEL_HORIZONTAL_3X3);
+    let vertical = filter_clamped::<_, _, i32>(image, Kernel::<i32>::SOBEL_VERTICAL_3X3);
     let interval = orientation_bin_width(spec.options);
     let range = direction_range(spec.options);
 

--- a/src/hog.rs
+++ b/src/hog.rs
@@ -3,7 +3,7 @@
 
 use crate::definitions::{Clamp, Image};
 use crate::filter::filter_clamped;
-use crate::kernel::Kernel;
+use crate::kernel::{self};
 use crate::math::l2_norm;
 use image::{GenericImage, GrayImage, ImageBuffer, Luma};
 use num::Zero;
@@ -259,8 +259,8 @@ pub fn cell_histograms(image: &GrayImage, spec: HogSpec) -> Array3d<f32> {
     let cell_area = spec.cell_area() as f32;
     let cell_side = spec.options.cell_side as f32;
 
-    let horizontal = filter_clamped::<_, _, i32>(image, Kernel::SOBEL_HORIZONTAL_3X3);
-    let vertical = filter_clamped::<_, _, i32>(image, Kernel::SOBEL_VERTICAL_3X3);
+    let horizontal = filter_clamped::<_, _, i32>(image, kernel::SOBEL_HORIZONTAL_3X3);
+    let vertical = filter_clamped::<_, _, i32>(image, kernel::SOBEL_VERTICAL_3X3);
     let interval = orientation_bin_width(spec.options);
     let range = direction_range(spec.options);
 

--- a/src/hog.rs
+++ b/src/hog.rs
@@ -259,8 +259,8 @@ pub fn cell_histograms(image: &GrayImage, spec: HogSpec) -> Array3d<f32> {
     let cell_area = spec.cell_area() as f32;
     let cell_side = spec.options.cell_side as f32;
 
-    let horizontal = filter_clamped::<_, _, i32>(image, Kernel::<i32>::SOBEL_HORIZONTAL_3X3);
-    let vertical = filter_clamped::<_, _, i32>(image, Kernel::<i32>::SOBEL_VERTICAL_3X3);
+    let horizontal = filter_clamped::<_, _, i32>(image, Kernel::SOBEL_HORIZONTAL_3X3);
+    let vertical = filter_clamped::<_, _, i32>(image, Kernel::SOBEL_VERTICAL_3X3);
     let interval = orientation_bin_width(spec.options);
     let range = direction_range(spec.options);
 

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -95,7 +95,6 @@ pub const FOUR_LAPLACIAN_3X3: Kernel<'static, i16> = Kernel {
     width: 3,
     height: 3,
 };
-
 /// The 8-connectivity laplacian 3x3 kernel.
 pub const EIGHT_LAPLACIAN_3X3: Kernel<'static, i16> = Kernel {
     data: &[1, 1, 1, 1, -8, 1, 1, 1, 1],

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -27,11 +27,17 @@ impl<'a, K> Kernel<'a, K> {
     }
 
     /// Get the value in the kernel at the given `x` and `y` position.
+    ///
+    /// # Panics
+    ///
+    /// If the `x` or `y` is outside of the width or height of the kernel.
     #[inline]
-    pub fn get_unchecked(&self, x: u32, y: u32) -> &K {
+    pub fn at(&self, x: u32, y: u32) -> &K {
         &self.data[(y * self.width + x) as usize]
     }
+}
 
+impl<'a> Kernel<'a, i32> {
     /// The sobel horizontal 3x3 kernel.
     pub const SOBEL_HORIZONTAL_3X3: Kernel<'static, i32> = Kernel {
         data: &[-1, 0, 1, -2, 0, 2, -1, 0, 1],

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -37,70 +37,68 @@ impl<'a, K> Kernel<'a, K> {
     }
 }
 
-impl<'a> Kernel<'a, i32> {
-    /// The sobel horizontal 3x3 kernel.
-    pub const SOBEL_HORIZONTAL_3X3: Kernel<'static, i32> = Kernel {
-        data: &[-1, 0, 1, -2, 0, 2, -1, 0, 1],
-        width: 3,
-        height: 3,
-    };
-    /// The sobel vertical 3x3 kernel.
-    pub const SOBEL_VERTICAL_3X3: Kernel<'static, i32> = Kernel {
-        data: &[-1, -2, -1, 0, 0, 0, 1, 2, 1],
-        width: 3,
-        height: 3,
-    };
+/// The sobel horizontal 3x3 kernel.
+pub const SOBEL_HORIZONTAL_3X3: Kernel<'static, i32> = Kernel {
+    data: &[-1, 0, 1, -2, 0, 2, -1, 0, 1],
+    width: 3,
+    height: 3,
+};
+/// The sobel vertical 3x3 kernel.
+pub const SOBEL_VERTICAL_3X3: Kernel<'static, i32> = Kernel {
+    data: &[-1, -2, -1, 0, 0, 0, 1, 2, 1],
+    width: 3,
+    height: 3,
+};
 
-    /// The scharr horizontal 3x3 kernel.
-    pub const SCHARR_HORIZONTAL_3X3: Kernel<'static, i32> = Kernel {
-        data: &[-3, 0, 3, -10, 0, 10, -3, 0, 3],
-        width: 3,
-        height: 3,
-    };
-    /// The scharr vertical 3x3 kernel.
-    pub const SCHARR_VERTICAL_3X3: Kernel<'static, i32> = Kernel {
-        data: &[-3, -10, -3, 0, 0, 0, 3, 10, 3],
-        width: 3,
-        height: 3,
-    };
+/// The scharr horizontal 3x3 kernel.
+pub const SCHARR_HORIZONTAL_3X3: Kernel<'static, i32> = Kernel {
+    data: &[-3, 0, 3, -10, 0, 10, -3, 0, 3],
+    width: 3,
+    height: 3,
+};
+/// The scharr vertical 3x3 kernel.
+pub const SCHARR_VERTICAL_3X3: Kernel<'static, i32> = Kernel {
+    data: &[-3, -10, -3, 0, 0, 0, 3, 10, 3],
+    width: 3,
+    height: 3,
+};
 
-    /// The prewitt horizontal 3x3 kernel.
-    pub const PREWITT_HORIZONTAL_3X3: Kernel<'static, i32> = Kernel {
-        data: &[-1, 0, 1, -1, 0, 1, -1, 0, 1],
-        width: 3,
-        height: 3,
-    };
-    /// The prewitt vertical 3x3 kernel.
-    pub const PREWITT_VERTICAL_3X3: Kernel<'static, i32> = Kernel {
-        data: &[-1, -1, -1, 0, 0, 0, 1, 1, 1],
-        width: 3,
-        height: 3,
-    };
+/// The prewitt horizontal 3x3 kernel.
+pub const PREWITT_HORIZONTAL_3X3: Kernel<'static, i32> = Kernel {
+    data: &[-1, 0, 1, -1, 0, 1, -1, 0, 1],
+    width: 3,
+    height: 3,
+};
+/// The prewitt vertical 3x3 kernel.
+pub const PREWITT_VERTICAL_3X3: Kernel<'static, i32> = Kernel {
+    data: &[-1, -1, -1, 0, 0, 0, 1, 1, 1],
+    width: 3,
+    height: 3,
+};
 
-    /// The roberts horizontal 3x3 kernel.
-    pub const ROBERTS_HORIZONTAL_2X2: Kernel<'static, i32> = Kernel {
-        data: &[1, 0, 0, -1],
-        width: 2,
-        height: 2,
-    };
-    /// The roberts vertical 3x3 kernel.
-    pub const ROBERTS_VERTICAL_2X2: Kernel<'static, i32> = Kernel {
-        data: &[0, 1, -1, -0],
-        width: 2,
-        height: 2,
-    };
+/// The roberts horizontal 3x3 kernel.
+pub const ROBERTS_HORIZONTAL_2X2: Kernel<'static, i32> = Kernel {
+    data: &[1, 0, 0, -1],
+    width: 2,
+    height: 2,
+};
+/// The roberts vertical 3x3 kernel.
+pub const ROBERTS_VERTICAL_2X2: Kernel<'static, i32> = Kernel {
+    data: &[0, 1, -1, -0],
+    width: 2,
+    height: 2,
+};
 
-    /// The 4-connectivity laplacian 3x3 kernel.
-    pub const FOUR_LAPLACIAN_3X3: Kernel<'static, i16> = Kernel {
-        data: &[1, 1, 1, 1, -4, 1, 1, 1, 1],
-        width: 3,
-        height: 3,
-    };
+/// The 4-connectivity laplacian 3x3 kernel.
+pub const FOUR_LAPLACIAN_3X3: Kernel<'static, i16> = Kernel {
+    data: &[1, 1, 1, 1, -4, 1, 1, 1, 1],
+    width: 3,
+    height: 3,
+};
 
-    /// The 8-connectivity laplacian 3x3 kernel.
-    pub const EIGHT_LAPLACIAN_3X3: Kernel<'static, i16> = Kernel {
-        data: &[1, 1, 1, 1, -8, 1, 1, 1, 1],
-        width: 3,
-        height: 3,
-    };
-}
+/// The 8-connectivity laplacian 3x3 kernel.
+pub const EIGHT_LAPLACIAN_3X3: Kernel<'static, i16> = Kernel {
+    data: &[1, 1, 1, 1, -8, 1, 1, 1, 1],
+    width: 3,
+    height: 3,
+};

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -1,0 +1,100 @@
+//! The kernel type for filter operations
+
+/// An borrowed 2D kernel, used to filter images via convolution.
+#[derive(Debug, Copy, Clone)]
+pub struct Kernel<'a, K> {
+    pub(crate) data: &'a [K],
+    pub(crate) width: u32,
+    pub(crate) height: u32,
+}
+
+impl<'a, K> Kernel<'a, K> {
+    /// Construct a kernel from a slice and its dimensions. The input slice is
+    /// in row-major form.
+    pub fn new(data: &'a [K], width: u32, height: u32) -> Kernel<'a, K> {
+        assert!(width > 0 && height > 0, "width and height must be non-zero");
+        assert!(
+            width * height == data.len() as u32,
+            "Invalid kernel len: expecting {}, found {}",
+            width * height,
+            data.len()
+        );
+        Kernel {
+            data,
+            width,
+            height,
+        }
+    }
+
+    /// Get the value in the kernel at the given `x` and `y` position.
+    #[inline]
+    pub fn get_unchecked(&self, x: u32, y: u32) -> &K {
+        &self.data[(y * self.width + x) as usize]
+    }
+
+    /// The sobel horizontal 3x3 kernel.
+    pub const SOBEL_HORIZONTAL_3X3: Kernel<'static, i32> = Kernel {
+        data: &[-1, 0, 1, -2, 0, 2, -1, 0, 1],
+        width: 3,
+        height: 3,
+    };
+    /// The sobel vertical 3x3 kernel.
+    pub const SOBEL_VERTICAL_3X3: Kernel<'static, i32> = Kernel {
+        data: &[-1, -2, -1, 0, 0, 0, 1, 2, 1],
+        width: 3,
+        height: 3,
+    };
+
+    /// The scharr horizontal 3x3 kernel.
+    pub const SCHARR_HORIZONTAL_3X3: Kernel<'static, i32> = Kernel {
+        data: &[-3, 0, 3, -10, 0, 10, -3, 0, 3],
+        width: 3,
+        height: 3,
+    };
+    /// The scharr vertical 3x3 kernel.
+    pub const SCHARR_VERTICAL_3X3: Kernel<'static, i32> = Kernel {
+        data: &[-3, -10, -3, 0, 0, 0, 3, 10, 3],
+        width: 3,
+        height: 3,
+    };
+
+    /// The prewitt horizontal 3x3 kernel.
+    pub const PREWITT_HORIZONTAL_3X3: Kernel<'static, i32> = Kernel {
+        data: &[-1, 0, 1, -1, 0, 1, -1, 0, 1],
+        width: 3,
+        height: 3,
+    };
+    /// The prewitt vertical 3x3 kernel.
+    pub const PREWITT_VERTICAL_3X3: Kernel<'static, i32> = Kernel {
+        data: &[-1, -1, -1, 0, 0, 0, 1, 1, 1],
+        width: 3,
+        height: 3,
+    };
+
+    /// The roberts horizontal 3x3 kernel.
+    pub const ROBERTS_HORIZONTAL_2X2: Kernel<'static, i32> = Kernel {
+        data: &[1, 0, 0, -1],
+        width: 2,
+        height: 2,
+    };
+    /// The roberts vertical 3x3 kernel.
+    pub const ROBERTS_VERTICAL_2X2: Kernel<'static, i32> = Kernel {
+        data: &[0, 1, -1, -0],
+        width: 2,
+        height: 2,
+    };
+
+    /// The 4-connectivity laplacian 3x3 kernel.
+    pub const FOUR_LAPLACIAN_3X3: Kernel<'static, i16> = Kernel {
+        data: &[1, 1, 1, 1, -4, 1, 1, 1, 1],
+        width: 3,
+        height: 3,
+    };
+
+    /// The 8-connectivity laplacian 3x3 kernel.
+    pub const EIGHT_LAPLACIAN_3X3: Kernel<'static, i16> = Kernel {
+        data: &[1, 1, 1, 1, -8, 1, 1, 1, 1],
+        width: 3,
+        height: 3,
+    };
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@ pub mod haar;
 pub mod hog;
 pub mod hough;
 pub mod integral_image;
+pub mod kernel;
 pub mod local_binary_patterns;
 pub mod map;
 pub mod math;

--- a/src/seam_carving.rs
+++ b/src/seam_carving.rs
@@ -57,8 +57,8 @@ where
 
     let mut gradients = gradients(
         image,
-        Kernel::<i32>::SOBEL_HORIZONTAL_3X3,
-        Kernel::<i32>::SOBEL_VERTICAL_3X3,
+        Kernel::SOBEL_HORIZONTAL_3X3,
+        Kernel::SOBEL_VERTICAL_3X3,
         |p| {
             let gradient_sum: u16 = p.channels().iter().sum();
             let gradient_mean: u16 = gradient_sum / P::CHANNEL_COUNT as u16;

--- a/src/seam_carving.rs
+++ b/src/seam_carving.rs
@@ -4,7 +4,8 @@
 //! [seam carving]: https://en.wikipedia.org/wiki/Seam_carving
 
 use crate::definitions::{HasBlack, Image};
-use crate::gradients::sobel_gradient_map;
+use crate::gradients::gradients;
+use crate::kernel::Kernel;
 use crate::map::{map_colors, WithChannel};
 use image::{GrayImage, Luma, Pixel, Rgb};
 use std::cmp::min;
@@ -54,11 +55,16 @@ where
         "Cannot find seams if image width is < 2"
     );
 
-    let mut gradients = sobel_gradient_map(image, |p| {
-        let gradient_sum: u16 = p.channels().iter().sum();
-        let gradient_mean: u16 = gradient_sum / P::CHANNEL_COUNT as u16;
-        Luma([gradient_mean as u32])
-    });
+    let mut gradients = gradients(
+        image,
+        Kernel::<i32>::SOBEL_HORIZONTAL_3X3,
+        Kernel::<i32>::SOBEL_VERTICAL_3X3,
+        |p| {
+            let gradient_sum: u16 = p.channels().iter().sum();
+            let gradient_mean: u16 = gradient_sum / P::CHANNEL_COUNT as u16;
+            Luma([gradient_mean as u32])
+        },
+    );
 
     // Find the least energy path through the gradient image.
     for y in 1..height {

--- a/src/seam_carving.rs
+++ b/src/seam_carving.rs
@@ -5,7 +5,7 @@
 
 use crate::definitions::{HasBlack, Image};
 use crate::gradients::gradients;
-use crate::kernel::Kernel;
+use crate::kernel::{self};
 use crate::map::{map_colors, WithChannel};
 use image::{GrayImage, Luma, Pixel, Rgb};
 use std::cmp::min;
@@ -57,8 +57,8 @@ where
 
     let mut gradients = gradients(
         image,
-        Kernel::SOBEL_HORIZONTAL_3X3,
-        Kernel::SOBEL_VERTICAL_3X3,
+        kernel::SOBEL_HORIZONTAL_3X3,
+        kernel::SOBEL_VERTICAL_3X3,
         |p| {
             let gradient_sum: u16 = p.channels().iter().sum();
             let gradient_mean: u16 = gradient_sum / P::CHANNEL_COUNT as u16;

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -23,7 +23,7 @@ use image::{
 };
 
 use imageproc::contrast::ThresholdType;
-use imageproc::kernel::Kernel;
+use imageproc::kernel::{self};
 use imageproc::{
     definitions::{Clamp, HasBlack, HasWhite},
     edges::canny,
@@ -306,8 +306,8 @@ fn test_sobel_gradients() {
         imageproc::map::map_subpixels(
             &gradients::gradients(
                 image,
-                Kernel::SOBEL_HORIZONTAL_3X3,
-                Kernel::SOBEL_VERTICAL_3X3,
+                kernel::SOBEL_HORIZONTAL_3X3,
+                kernel::SOBEL_VERTICAL_3X3,
                 |p| p,
             ),
             <u8 as Clamp<u16>>::clamp,

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -23,6 +23,7 @@ use image::{
 };
 
 use imageproc::contrast::ThresholdType;
+use imageproc::kernel::Kernel;
 use imageproc::{
     definitions::{Clamp, HasBlack, HasWhite},
     edges::canny,
@@ -303,7 +304,12 @@ fn test_affine_bicubic_rgb() {
 fn test_sobel_gradients() {
     fn sobel_gradients(image: &GrayImage) -> GrayImage {
         imageproc::map::map_subpixels(
-            &gradients::sobel_gradients(image),
+            &gradients::gradients(
+                image,
+                Kernel::<i32>::SOBEL_HORIZONTAL_3X3,
+                Kernel::<i32>::SOBEL_VERTICAL_3X3,
+                |p| p,
+            ),
             <u8 as Clamp<u16>>::clamp,
         )
     }

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -306,8 +306,8 @@ fn test_sobel_gradients() {
         imageproc::map::map_subpixels(
             &gradients::gradients(
                 image,
-                Kernel::<i32>::SOBEL_HORIZONTAL_3X3,
-                Kernel::<i32>::SOBEL_VERTICAL_3X3,
+                Kernel::SOBEL_HORIZONTAL_3X3,
+                Kernel::SOBEL_VERTICAL_3X3,
                 |p| p,
             ),
             <u8 as Clamp<u16>>::clamp,


### PR DESCRIPTION
I think I made a mistake in #601 by changing too much at once. This time I've focused on some of the core changes and discarded some others (such as no kernel trait this time).

Summary:
- Moved associated `filter()` method to free-standing `filter()` function
- Added a `filter_clamped()` function which was what `filter3x3()` was doing previously
- Removed `filter3x3()` since `filter_clamped()` is identical and works with any dimensions
- Moved all kernel constants to the `kernel` module as associated constants of `Kernel` rather than free-standing constants
- Removed `sobel_vertical()` and similar functions as they are simply applications of `filter_clamped()` with different kernels which is not very maintainable as the number of different kernels grows.
- Added `FOUR_LAPLACIAN_3X3` and `EIGHT_LAPLACIAN_3X3` kernel constants.