### PR TITLE
Deduplicate the README.md

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,4 @@
-//! An image processing library based on the
-//! [image] crate.
-//!
-//! Note that the image crate contains some image
-//! processing functions (including image resizing) in its
-//! `imageops` module, so check there if you cannot find
-//! a standard image processing function in this crate.
-//!
-//! [image]: https://github.com/image-rs/image
+#![doc = include_str!("../README.md")]
 #![deny(missing_docs)]
 #![cfg_attr(test, feature(test))]
 #![cfg_attr(docsrs, feature(doc_cfg))]


### PR DESCRIPTION
This copies the `README.md` to the top-level library docs.