### PR TITLE
Fix Cargo.toml `rayon` feature and Update Dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,29 +10,28 @@ description = "Image processing operations"
 readme = "README.md"
 repository = "https://github.com/image-rs/imageproc.git"
 homepage = "https://github.com/image-rs/imageproc"
-exclude = [
-    ".github/*",
-    "examples/*",
-    "tests/*"
-]
+exclude = [".github/*", "examples/*", "tests/*"]
 
 [features]
-default = [ "rayon", "image/default" ]
-property-testing = [ "quickcheck" ]
+default = ["rayon", "image/default"]
+property-testing = ["quickcheck"]
 display-window = ["sdl2"]
+rayon = ["dep:rayon", "image/rayon"]
 
 [dependencies]
 ab_glyph = "0.2.23"
 approx = "0.5"
 image = { version = "0.25.0", default-features = false }
-itertools = "0.12"
+itertools = "0.13.0"
 nalgebra = { version = "0.32", default-features = false, features = ["std"] }
 num = "0.4.1"
 rand = "0.8.5"
 rand_distr = "0.4.3"
 rayon = { version = "1.8.0", optional = true }
 quickcheck = { version = "1.0.3", optional = true }
-sdl2 = { version = "0.36", optional = true, default-features = false, features = ["bundled"] }
+sdl2 = { version = "0.36", optional = true, default-features = false, features = [
+	"bundled",
+] }
 katexit = { version = "0.1.4", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
@@ -47,7 +46,7 @@ wasm-bindgen-test = "0.3.38"
 [package.metadata.docs.rs]
 # See https://github.com/image-rs/imageproc/issues/358
 # all-features = true
-features = [ "property-testing", "katexit" ]
+features = ["property-testing", "katexit"]
 
 [profile.release]
 opt-level = 3

--- a/src/morphology.rs
+++ b/src/morphology.rs
@@ -369,7 +369,7 @@ macro_rules! lines {
         $mask
             .elements
             .iter()
-            .group_by(|p| p.y)
+            .chunk_by(|p| p.y)
             .into_iter()
             .map(|(y, line)| (y, line.map(|p| p.x)))
     };


### PR DESCRIPTION
The way the features were defined meant that using `imageproc` with `default-features = false, features = ["rayon"]` would fail to compile as that wouldn't force `image` to use its `rayon` feature. This PR fixes that and updates the cargo dependencies while at it.