### PR TITLE
Add a doc-macro for mut versions of functions.

### DIFF
--- a/src/contrast.rs
+++ b/src/contrast.rs
@@ -181,31 +181,7 @@ pub fn threshold(image: &GrayImage, threshold: u8, threshold_type: ThresholdType
     threshold_mut(&mut out, threshold, threshold_type);
     out
 }
-
-/// Applies a threshold to each pixel in a grayscale image. The action taken depends on `threshold_type` - see [`ThresholdType`].
-///
-/// See [`threshold`] for a list of examples covering each `ThresholdType`.
-/// # Examples
-/// ```
-/// # extern crate image;
-/// # #[macro_use]
-/// # extern crate imageproc;
-/// # fn main() {
-/// use imageproc::contrast::{threshold_mut, ThresholdType};
-///
-/// let mut image = gray_image!(
-///     10, 80, 20;
-///     50, 90, 70);
-///
-/// threshold_mut(&mut image, 50, ThresholdType::Binary);
-///
-/// let result = gray_image!(
-///     0, 255,   0;
-///     0, 255, 255);
-///
-/// assert_pixels_eq!(image, result);
-/// # }
-/// ```
+#[doc=generate_mut_doc_comment!("threshold")]
 pub fn threshold_mut(image: &mut GrayImage, threshold: u8, threshold_type: ThresholdType) {
     match threshold_type {
         ThresholdType::Binary => {

--- a/src/contrast.rs
+++ b/src/contrast.rs
@@ -116,7 +116,8 @@ pub enum ThresholdType {
     ToZeroInverted,
 }
 
-/// Applies a threshold to each pixel in a grayscale image. The action taken depends on `threshold_type` - see [`ThresholdType`].
+/// Applies a threshold to each pixel in a grayscale image. The action taken depends on
+/// `threshold_type` - see [`ThresholdType`].
 ///
 /// # Examples
 /// ```
@@ -212,8 +213,14 @@ pub fn threshold_mut(image: &mut GrayImage, threshold: u8, threshold_type: Thres
     }
 }
 
-/// Equalises the histogram of an 8bpp grayscale image in place. See also
+/// Equalises the histogram of an 8bpp grayscale image. See also
 /// [histogram equalization (wikipedia)](https://en.wikipedia.org/wiki/Histogram_equalization).
+pub fn equalize_histogram(image: &GrayImage) -> GrayImage {
+    let mut out = image.clone();
+    equalize_histogram_mut(&mut out);
+    out
+}
+#[doc=generate_mut_doc_comment!("equalize_histogram")]
 pub fn equalize_histogram_mut(image: &mut GrayImage) {
     let hist = cumulative_histogram(image).channels[0];
     let total = hist[255] as f32;
@@ -233,14 +240,6 @@ pub fn equalize_histogram_mut(image: &mut GrayImage) {
         let fraction = unsafe { *hist.get_unchecked(*p as usize) as f32 / total };
         *p = (f32::min(255f32, 255f32 * fraction)) as u8;
     });
-}
-
-/// Equalises the histogram of an 8bpp grayscale image. See also
-/// [histogram equalization (wikipedia)](https://en.wikipedia.org/wiki/Histogram_equalization).
-pub fn equalize_histogram(image: &GrayImage) -> GrayImage {
-    let mut out = image.clone();
-    equalize_histogram_mut(&mut out);
-    out
 }
 
 /// Stretches the contrast in an image, linearly mapping intensities in `(input_lower, input_upper)` to `(output_lower, output_upper)` and saturating
@@ -294,14 +293,7 @@ pub fn stretch_contrast(
     );
     out
 }
-
-/// Stretches the contrast in an image, linearly mapping intensities in `(input_lower, input_upper)` to `(output_lower, output_upper)` and saturating
-/// values outside this input range.
-///
-/// See the [`stretch_contrast`](fn.stretch_contrast.html) documentation for more.
-///
-/// # Panics
-/// If `input_lower >= input_upper` or `output_lower > output_upper`.
+#[doc=generate_mut_doc_comment!("stretch_contrast")]
 pub fn stretch_contrast_mut(
     image: &mut GrayImage,
     input_min: u8,
@@ -343,8 +335,14 @@ pub fn stretch_contrast_mut(
     map_subpixels_mut(image, f);
 }
 
-/// Adjusts contrast of an 8bpp grayscale image in place so that its
+/// Adjusts contrast of an 8bpp grayscale image so that its
 /// histogram is as close as possible to that of the target image.
+pub fn match_histogram(image: &GrayImage, target: &GrayImage) -> GrayImage {
+    let mut out = image.clone();
+    match_histogram_mut(&mut out, target);
+    out
+}
+#[doc=generate_mut_doc_comment!("match_histogram")]
 pub fn match_histogram_mut(image: &mut GrayImage, target: &GrayImage) {
     let image_histc = cumulative_histogram(image).channels[0];
     let target_histc = cumulative_histogram(target).channels[0];
@@ -353,14 +351,6 @@ pub fn match_histogram_mut(image: &mut GrayImage, target: &GrayImage) {
     for p in image.iter_mut() {
         *p = lut[*p as usize] as u8;
     }
-}
-
-/// Adjusts contrast of an 8bpp grayscale image so that its
-/// histogram is as close as possible to that of the target image.
-pub fn match_histogram(image: &GrayImage, target: &GrayImage) -> GrayImage {
-    let mut out = image.clone();
-    match_histogram_mut(&mut out, target);
-    out
 }
 
 /// `l = histogram_lut(s, t)` is chosen so that `target_histc[l[i]] / sum(target_histc)`

--- a/src/distance_transform.rs
+++ b/src/distance_transform.rs
@@ -93,16 +93,7 @@ pub fn distance_transform(image: &GrayImage, norm: Norm) -> GrayImage {
     distance_transform_mut(&mut out, norm);
     out
 }
-
-/// Updates an image in place so that each pixel contains its distance from a foreground pixel in the original image.
-///
-/// A pixel belongs to the foreground if it has non-zero intensity. As the image has a bit-depth of 8,
-/// distances saturate at 255.
-///
-/// When using `Norm::L2` this function returns the ceiling of the true distances.
-/// Use [`euclidean_squared_distance_transform`] if you need floating point distances.
-///
-/// See [`distance_transform`] for examples.
+#[doc=generate_mut_doc_comment!("distance_transform")]
 pub fn distance_transform_mut(image: &mut GrayImage, norm: Norm) {
     distance_transform_impl(image, norm, DistanceFrom::Foreground);
 }

--- a/src/doc_macros.rs
+++ b/src/doc_macros.rs
@@ -1,0 +1,19 @@
+//! Macros used for generating documentation
+
+/// A macro for generating the doc-comments for mutable versions of various
+/// image processing functions. It takes the name of then non-mut function as an
+/// argument as a string literal.
+///
+/// It uses concat! to generate doc-links to the provided original function name
+/// in string literal form.
+macro_rules! generate_mut_doc_comment {
+    ($name:literal) => {
+        concat!(
+            "An in-place version of [`",
+            $name,
+            "()`].\n\nThis function does the same operation as [`",
+            $name,
+            "()`] but on the `&mut image`\npassed rather than cloning an `&image`. This is faster but you lose the\noriginal image."
+        )
+    };
+}

--- a/src/drawing/bezier.rs
+++ b/src/drawing/bezier.rs
@@ -3,7 +3,7 @@ use crate::drawing::line::draw_line_segment_mut;
 use crate::drawing::Canvas;
 use image::{GenericImage, ImageBuffer};
 
-/// Draws a cubic Bézier curve on a new copy of an image.
+/// Draws a cubic Bézier curve on an image.
 ///
 /// Draws as much of the curve as lies within image bounds.
 #[must_use = "the function does not modify the original image"]
@@ -23,10 +23,7 @@ where
     draw_cubic_bezier_curve_mut(&mut out, start, end, control_a, control_b, color);
     out
 }
-
-/// Draws a cubic Bézier curve on an image in place.
-///
-/// Draws as much of the curve as lies within image bounds.
+#[doc=generate_mut_doc_comment!("draw_cubic_bezier_curve")]
 pub fn draw_cubic_bezier_curve_mut<C>(
     canvas: &mut C,
     start: (f32, f32),

--- a/src/drawing/conics.rs
+++ b/src/drawing/conics.rs
@@ -4,7 +4,7 @@ use crate::drawing::line::draw_line_segment_mut;
 use crate::drawing::Canvas;
 use image::{GenericImage, ImageBuffer};
 
-/// Draws the outline of an ellipse on a new copy of an image.
+/// Draws the outline of an ellipse on an image.
 ///
 /// Draws as much of an ellipse as lies inside the image bounds.
 ///
@@ -30,17 +30,7 @@ where
     draw_hollow_ellipse_mut(&mut out, center, width_radius, height_radius, color);
     out
 }
-
-/// Draws the outline of an ellipse on an image in place.
-///
-/// Draws as much of an ellipse as lies inside the image bounds.
-///
-/// Uses the [Midpoint Ellipse Drawing Algorithm](https://web.archive.org/web/20160128020853/http://tutsheap.com/c/mid-point-ellipse-drawing-algorithm/).
-/// (Modified from Bresenham's algorithm)
-///
-/// The ellipse is axis-aligned and satisfies the following equation:
-///
-/// `(x^2 / width_radius^2) + (y^2 / height_radius^2) = 1`
+#[doc=generate_mut_doc_comment!("draw_hollow_ellipse")]
 pub fn draw_hollow_ellipse_mut<C>(
     canvas: &mut C,
     center: (i32, i32),
@@ -66,7 +56,7 @@ pub fn draw_hollow_ellipse_mut<C>(
     draw_ellipse(draw_quad_pixels, center, width_radius, height_radius);
 }
 
-/// Draws an ellipse and its contents on a new copy of the image.
+/// Draws an ellipse and its contents on an image.
 ///
 /// Draw as much of the ellipse and its contents as lies inside the image bounds.
 ///
@@ -92,17 +82,7 @@ where
     draw_filled_ellipse_mut(&mut out, center, width_radius, height_radius, color);
     out
 }
-
-/// Draws an ellipse and its contents on an image in place.
-///
-/// Draw as much of the ellipse and its contents as lies inside the image bounds.
-///
-/// Uses the [Midpoint Ellipse Drawing Algorithm](https://web.archive.org/web/20160128020853/http://tutsheap.com/c/mid-point-ellipse-drawing-algorithm/).
-/// (Modified from Bresenham's algorithm)
-///
-/// The ellipse is axis-aligned and satisfies the following equation:
-///
-/// `(x^2 / width_radius^2) + (y^2 / height_radius^2) <= 1`
+#[doc=generate_mut_doc_comment!("draw_filled_ellipse")]
 pub fn draw_filled_ellipse_mut<C>(
     canvas: &mut C,
     center: (i32, i32),
@@ -186,7 +166,7 @@ where
     }
 }
 
-/// Draws the outline of a circle on a new copy of an image.
+/// Draws the outline of a circle on an image.
 ///
 /// Draw as much of the circle as lies inside the image bounds.
 #[must_use = "the function does not modify the original image"]
@@ -204,10 +184,7 @@ where
     draw_hollow_circle_mut(&mut out, center, radius, color);
     out
 }
-
-/// Draws the outline of a circle on an image in place.
-///
-/// Draw as much of the circle as lies inside the image bounds.
+#[doc=generate_mut_doc_comment!("draw_hollow_circle")]
 pub fn draw_hollow_circle_mut<C>(canvas: &mut C, center: (i32, i32), radius: i32, color: C::Pixel)
 where
     C: Canvas,
@@ -238,9 +215,25 @@ where
     }
 }
 
-/// Draws a circle and its contents on an image in place.
+/// Draws a circle and its contents on an image.
 ///
 /// Draws as much of a circle and its contents as lies inside the image bounds.
+#[must_use = "the function does not modify the original image"]
+pub fn draw_filled_circle<I>(
+    image: &I,
+    center: (i32, i32),
+    radius: i32,
+    color: I::Pixel,
+) -> Image<I::Pixel>
+where
+    I: GenericImage,
+{
+    let mut out = ImageBuffer::new(image.width(), image.height());
+    out.copy_from(image, 0, 0).unwrap();
+    draw_filled_circle_mut(&mut out, center, radius, color);
+    out
+}
+#[doc=generate_mut_doc_comment!("draw_filled_circle")]
 pub fn draw_filled_circle_mut<C>(canvas: &mut C, center: (i32, i32), radius: i32, color: C::Pixel)
 where
     C: Canvas,
@@ -285,25 +278,6 @@ where
             p += 2 * (x - y) + 1;
         }
     }
-}
-
-/// Draws a circle and its contents on a new copy of the image.
-///
-/// Draws as much of a circle and its contents as lies inside the image bounds.
-#[must_use = "the function does not modify the original image"]
-pub fn draw_filled_circle<I>(
-    image: &I,
-    center: (i32, i32),
-    radius: i32,
-    color: I::Pixel,
-) -> Image<I::Pixel>
-where
-    I: GenericImage,
-{
-    let mut out = ImageBuffer::new(image.width(), image.height());
-    out.copy_from(image, 0, 0).unwrap();
-    draw_filled_circle_mut(&mut out, center, radius, color);
-    out
 }
 
 #[cfg(test)]

--- a/src/drawing/cross.rs
+++ b/src/drawing/cross.rs
@@ -2,9 +2,20 @@ use crate::definitions::Image;
 use crate::drawing::Canvas;
 use image::{GenericImage, ImageBuffer};
 
-/// Draws a colored cross on an image in place.
+/// Draws a colored cross on an image.
 ///
 /// Handles coordinates outside image bounds.
+#[must_use = "the function does not modify the original image"]
+pub fn draw_cross<I>(image: &I, color: I::Pixel, x: i32, y: i32) -> Image<I::Pixel>
+where
+    I: GenericImage,
+{
+    let mut out = ImageBuffer::new(image.width(), image.height());
+    out.copy_from(image, 0, 0).unwrap();
+    draw_cross_mut(&mut out, color, x, y);
+    out
+}
+#[doc=generate_mut_doc_comment!("draw_cross")]
 #[rustfmt::skip]
 pub fn draw_cross_mut<C>(canvas: &mut C, color: C::Pixel, x: i32, y: i32)
 where
@@ -33,20 +44,6 @@ where
             }
         }
     }
-}
-
-/// Draws a colored cross on a new copy of an image.
-///
-/// Handles coordinates outside image bounds.
-#[must_use = "the function does not modify the original image"]
-pub fn draw_cross<I>(image: &I, color: I::Pixel, x: i32, y: i32) -> Image<I::Pixel>
-where
-    I: GenericImage,
-{
-    let mut out = ImageBuffer::new(image.width(), image.height());
-    out.copy_from(image, 0, 0).unwrap();
-    draw_cross_mut(&mut out, color, x, y);
-    out
 }
 
 #[cfg(test)]

--- a/src/drawing/line.rs
+++ b/src/drawing/line.rs
@@ -159,7 +159,7 @@ impl<'a, P: Pixel> Iterator for BresenhamLinePixelIterMut<'a, P> {
     }
 }
 
-/// Draws a line segment on a new copy of an image.
+/// Draws a line segment on an image.
 ///
 /// Draws as much of the line segment between start and end as lies inside the image bounds.
 ///
@@ -179,12 +179,7 @@ where
     draw_line_segment_mut(&mut out, start, end, color);
     out
 }
-
-/// Draws a line segment on an image in place.
-///
-/// Draws as much of the line segment between start and end as lies inside the image bounds.
-///
-/// Uses [Bresenham's line drawing algorithm](https://en.wikipedia.org/wiki/Bresenham%27s_line_algorithm).
+#[doc=generate_mut_doc_comment!("draw_line_segment")]
 pub fn draw_line_segment_mut<C>(canvas: &mut C, start: (f32, f32), end: (f32, f32), color: C::Pixel)
 where
     C: Canvas,
@@ -204,7 +199,7 @@ where
     }
 }
 
-/// Draws an antialised line segment on a new copy of an image.
+/// Draws an antialised line segment on an image.
 ///
 /// Draws as much of the line segment between `start` and `end` as lies inside the image bounds.
 ///
@@ -230,15 +225,7 @@ where
     draw_antialiased_line_segment_mut(&mut out, start, end, color, blend);
     out
 }
-
-/// Draws an antialised line segment on an image in place.
-///
-/// Draws as much of the line segment between `start` and `end` as lies inside the image bounds.
-///
-/// The parameters of blend are (line color, original color, line weight).
-/// Consider using [`interpolate`](fn.interpolate.html) for blend.
-///
-/// Uses [Xu's line drawing algorithm](https://en.wikipedia.org/wiki/Xiaolin_Wu%27s_line_algorithm).
+#[doc=generate_mut_doc_comment!("draw_antialiased_line_segment")]
 pub fn draw_antialiased_line_segment_mut<I, B>(
     image: &mut I,
     start: (i32, i32),

--- a/src/drawing/mod.rs
+++ b/src/drawing/mod.rs
@@ -1,7 +1,4 @@
 //! Helpers for drawing basic shapes on images.
-//!
-//! Every `draw_` function comes in two variants: one creates a new copy of the input image, one modifies the image in place.
-//! The latter is more memory efficient, but you lose the original image.
 
 mod bezier;
 pub use self::bezier::{draw_cubic_bezier_curve, draw_cubic_bezier_curve_mut};

--- a/src/drawing/rect.rs
+++ b/src/drawing/rect.rs
@@ -5,7 +5,7 @@ use crate::rect::Rect;
 use image::{GenericImage, ImageBuffer};
 use std::f32;
 
-/// Draws the outline of a rectangle on a new copy of an image.
+/// Draws the outline of a rectangle on an image.
 ///
 /// Draws as much of the boundary of the rectangle as lies inside the image bounds.
 #[must_use = "the function does not modify the original image"]
@@ -18,10 +18,7 @@ where
     draw_hollow_rect_mut(&mut out, rect, color);
     out
 }
-
-/// Draws the outline of a rectangle on an image in place.
-///
-/// Draws as much of the boundary of the rectangle as lies inside the image bounds.
+#[doc=generate_mut_doc_comment!("draw_hollow_rect")]
 pub fn draw_hollow_rect_mut<C>(canvas: &mut C, rect: Rect, color: C::Pixel)
 where
     C: Canvas,
@@ -37,7 +34,7 @@ where
     draw_line_segment_mut(canvas, (right, top), (right, bottom), color);
 }
 
-/// Draws a rectangle and its contents on a new copy of an image.
+/// Draws a rectangle and its contents on an image.
 ///
 /// Draws as much of the rectangle and its contents as lies inside the image bounds.
 #[must_use = "the function does not modify the original image"]
@@ -50,10 +47,7 @@ where
     draw_filled_rect_mut(&mut out, rect, color);
     out
 }
-
-/// Draws a rectangle and its contents on an image in place.
-///
-/// Draws as much of the rectangle and its contents as lies inside the image bounds.
+#[doc=generate_mut_doc_comment!("draw_filled_rect")]
 pub fn draw_filled_rect_mut<C>(canvas: &mut C, rect: Rect, color: C::Pixel)
 where
     C: Canvas,

--- a/src/drawing/text.rs
+++ b/src/drawing/text.rs
@@ -43,11 +43,31 @@ pub fn text_size(scale: impl Into<PxScale> + Copy, font: &impl Font, text: &str)
     layout_glyphs(scale, font, text, |_, _| {})
 }
 
-/// Draws colored text on an image in place.
+/// Draws colored text on an image.
 ///
 /// `scale` is augmented font scaling on both the x and y axis (in pixels).
 ///
 /// Note that this function *does not* support newlines, you must do this manually.
+#[must_use = "the function does not modify the original image"]
+pub fn draw_text<I>(
+    image: &I,
+    color: I::Pixel,
+    x: i32,
+    y: i32,
+    scale: impl Into<PxScale> + Copy,
+    font: &impl Font,
+    text: &str,
+) -> Image<I::Pixel>
+where
+    I: GenericImage,
+    <I::Pixel as Pixel>::Subpixel: Into<f32> + Clamp<f32>,
+{
+    let mut out = ImageBuffer::new(image.width(), image.height());
+    out.copy_from(image, 0, 0).unwrap();
+    draw_text_mut(&mut out, color, x, y, scale, font, text);
+    out
+}
+#[doc=generate_mut_doc_comment!("draw_text")]
 pub fn draw_text_mut<C>(
     canvas: &mut C,
     color: C::Pixel,
@@ -78,29 +98,4 @@ pub fn draw_text_mut<C>(
             }
         })
     });
-}
-
-/// Draws colored text on a new copy of an image.
-///
-/// `scale` is augmented font scaling on both the x and y axis (in pixels).
-///
-/// Note that this function *does not* support newlines, you must do this manually.
-#[must_use = "the function does not modify the original image"]
-pub fn draw_text<I>(
-    image: &I,
-    color: I::Pixel,
-    x: i32,
-    y: i32,
-    scale: impl Into<PxScale> + Copy,
-    font: &impl Font,
-    text: &str,
-) -> Image<I::Pixel>
-where
-    I: GenericImage,
-    <I::Pixel as Pixel>::Subpixel: Into<f32> + Clamp<f32>,
-{
-    let mut out = ImageBuffer::new(image.width(), image.height());
-    out.copy_from(image, 0, 0).unwrap();
-    draw_text_mut(&mut out, color, x, y, scale, font, text);
-    out
 }

--- a/src/haar.rs
+++ b/src/haar.rs
@@ -391,9 +391,7 @@ where
     draw_haar_feature_mut(&mut out, feature);
     out
 }
-
-/// Draws the given Haar-like feature on an image in place, drawing pixels
-/// with a positive sign white and those with a negative sign black.
+#[doc=generate_mut_doc_comment!("draw_haar_feature")]
 pub fn draw_haar_feature_mut<I>(image: &mut I, feature: HaarFeature)
 where
     I: GenericImage,

--- a/src/hough.rs
+++ b/src/hough.rs
@@ -104,10 +104,7 @@ where
     draw_polar_lines_mut(&mut out, lines, color);
     out
 }
-
-/// Draws each element of `lines` on `image` in the provided `color`.
-///
-/// See ./examples/hough.rs for example usage.
+#[doc=generate_mut_doc_comment!("draw_polar_lines")]
 pub fn draw_polar_lines_mut<P>(image: &mut Image<P>, lines: &[PolarLine], color: P)
 where
     P: Pixel,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,8 @@ mod proptest_utils;
 
 #[macro_use]
 pub mod utils;
+#[macro_use]
+pub mod doc_macros;
 pub mod binary_descriptors;
 pub mod contours;
 pub mod contrast;

--- a/src/morphology.rs
+++ b/src/morphology.rs
@@ -73,12 +73,7 @@ pub fn dilate(image: &GrayImage, norm: Norm, k: u8) -> GrayImage {
     dilate_mut(&mut out, norm, k);
     out
 }
-
-/// Sets all pixels within distance `k` of a foreground pixel to white.
-///
-/// A pixel is treated as belonging to the foreground if it has non-zero intensity.
-///
-/// See the [`dilate`](fn.dilate.html) documentation for examples.
+#[doc=generate_mut_doc_comment!("dilate")]
 pub fn dilate_mut(image: &mut GrayImage, norm: Norm, k: u8) {
     distance_transform_mut(image, norm);
     for p in image.iter_mut() {
@@ -169,12 +164,7 @@ pub fn erode(image: &GrayImage, norm: Norm, k: u8) -> GrayImage {
     erode_mut(&mut out, norm, k);
     out
 }
-
-/// Sets all pixels within distance `k` of a background pixel to black.
-///
-/// A pixel is treated as belonging to the foreground if it has non-zero intensity.
-///
-/// See the [`erode`](fn.erode.html) documentation for examples.
+#[doc=generate_mut_doc_comment!("erode")]
 pub fn erode_mut(image: &mut GrayImage, norm: Norm, k: u8) {
     distance_transform_impl(image, norm, DistanceFrom::Background);
     for p in image.iter_mut() {
@@ -238,12 +228,7 @@ pub fn open(image: &GrayImage, norm: Norm, k: u8) -> GrayImage {
     open_mut(&mut out, norm, k);
     out
 }
-
-/// Erosion followed by dilation.
-///
-/// See the [`open`](fn.open.html) documentation for examples,
-/// and the [`erode`](fn.erode.html) and [`dilate`](fn.dilate.html)
-/// documentation for definitions of dilation and erosion.
+#[doc=generate_mut_doc_comment!("open")]
 pub fn open_mut(image: &mut GrayImage, norm: Norm, k: u8) {
     erode_mut(image, norm, k);
     dilate_mut(image, norm, k);
@@ -343,12 +328,7 @@ pub fn close(image: &GrayImage, norm: Norm, k: u8) -> GrayImage {
     close_mut(&mut out, norm, k);
     out
 }
-
-/// Dilation followed by erosion.
-///
-/// See the [`close`](fn.close.html) documentation for examples,
-/// and the [`erode`](fn.erode.html) and [`dilate`](fn.dilate.html)
-/// documentation for definitions of dilation and erosion.
+#[doc=generate_mut_doc_comment!("close")]
 pub fn close_mut(image: &mut GrayImage, norm: Norm, k: u8) {
     dilate_mut(image, norm, k);
     erode_mut(image, norm, k);

--- a/src/noise.rs
+++ b/src/noise.rs
@@ -16,9 +16,7 @@ where
     gaussian_noise_mut(&mut out, mean, stddev, seed);
     out
 }
-
-/// Adds independent additive Gaussian noise to all channels
-/// of an image in place, with the given mean and standard deviation.
+#[doc=generate_mut_doc_comment!("gaussian_noise")]
 pub fn gaussian_noise_mut<P>(image: &mut Image<P>, mean: f64, stddev: f64, seed: u64)
 where
     P: Pixel,
@@ -45,9 +43,7 @@ where
     salt_and_pepper_noise_mut(&mut out, rate, seed);
     out
 }
-
-/// Converts pixels to black or white in place at the given `rate` (between 0.0 and 1.0).
-/// Black and white occur with equal probability.
+#[doc=generate_mut_doc_comment!("salt_and_pepper_noise")]
 pub fn salt_and_pepper_noise_mut<P>(image: &mut Image<P>, rate: f64, seed: u64)
 where
     P: Pixel + HasBlack + HasWhite,


### PR DESCRIPTION
As discussed in #622.

As it turned out the `imageproc::map` functions were the only functions not able to be de-duplicated using a doc-comment generating macro as the image bounds are completely different per function so complete separate implementations (`Fn(P) -> P` vs `Fn(P) -> Q).

But overall I'm very happy with the amount of de-duplication achieved which should make things much more standardized and easier to maintain and extend.

I also standardized the non-mut functions being above the mut function in the source code with no empty-line between them for consistency.