### PR TITLE
Remove noisy `ImageBuffer` type

### DIFF
--- a/examples/blend.rs
+++ b/examples/blend.rs
@@ -1,7 +1,7 @@
 //! Demonstrates the current incorrect handling of gamma for RGB images
 
-use image::{ImageBuffer, Rgb};
-use imageproc::pixelops::interpolate;
+use image::Rgb;
+use imageproc::{definitions::Image, pixelops::interpolate};
 
 fn main() {
     let red = Rgb::<u8>([255, 0, 0]);
@@ -12,7 +12,7 @@ fn main() {
 
     let naive_blend = |x| interpolate(red, green, left_weight(x));
 
-    let mut naive_image = ImageBuffer::new(800, 400);
+    let mut naive_image = Image::new(800, 400);
     for y in 0..naive_image.height() {
         for x in 0..naive_image.width() {
             naive_image.put_pixel(x, y, naive_blend(x));
@@ -39,7 +39,7 @@ fn main() {
         ])
     };
 
-    let mut gamma_image = ImageBuffer::new(800, 400);
+    let mut gamma_image = Image::new(800, 400);
     for y in 0..gamma_image.height() {
         for x in 0..gamma_image.width() {
             gamma_image.put_pixel(x, y, gamma_blend(x));

--- a/examples/hog.rs
+++ b/examples/hog.rs
@@ -1,6 +1,7 @@
 //! Demonstrates computing and visualising HoG gradients.
 
-use image::{open, ImageBuffer};
+use image::open;
+use imageproc::definitions::Image;
 use imageproc::hog::*;
 use std::env;
 use std::path::Path;
@@ -32,7 +33,7 @@ fn create_hog_image(input: &Path, signed: bool) {
 
     // Crop image to a suitable size
     let (cropped_width, cropped_height) = (10 * (width / 10), 10 * (height / 10));
-    let mut cropped = ImageBuffer::new(cropped_width, cropped_height);
+    let mut cropped = Image::new(cropped_width, cropped_height);
     for y in 0..cropped_height {
         for x in 0..cropped_width {
             cropped.put_pixel(x, y, *image.get_pixel(x, y));

--- a/src/binary_descriptors/brief.rs
+++ b/src/binary_descriptors/brief.rs
@@ -67,12 +67,7 @@ pub struct TestPair {
     pub p1: Point<u32>,
 }
 
-fn local_pixel_average(
-    integral_image: &Image<Luma<u32>>,
-    x: u32,
-    y: u32,
-    radius: u32,
-) -> u8 {
+fn local_pixel_average(integral_image: &Image<Luma<u32>>, x: u32, y: u32, radius: u32) -> u8 {
     if radius == 0 {
         return 0;
     }

--- a/src/binary_descriptors/brief.rs
+++ b/src/binary_descriptors/brief.rs
@@ -2,10 +2,10 @@
 //! described in [Calonder, et. al. (2010)].
 ///
 /// [Calonder, et. al. (2010)]: https://www.cs.ubc.ca/~lowe/525/papers/calonder_eccv10.pdf
-use image::{GenericImageView, GrayImage, ImageBuffer, Luma};
+use image::{GenericImageView, GrayImage, Luma};
 use rand_distr::{Distribution, Normal};
 
-use crate::{corners::Corner, integral_image::integral_image, point::Point};
+use crate::{corners::Corner, definitions::Image, integral_image::integral_image, point::Point};
 
 use super::{
     constants::{BRIEF_PATCH_DIAMETER, BRIEF_PATCH_RADIUS},
@@ -68,7 +68,7 @@ pub struct TestPair {
 }
 
 fn local_pixel_average(
-    integral_image: &ImageBuffer<Luma<u32>, Vec<u32>>,
+    integral_image: &Image<Luma<u32>>,
     x: u32,
     y: u32,
     radius: u32,
@@ -114,7 +114,7 @@ fn local_pixel_average(
 }
 
 pub(crate) fn brief_impl(
-    integral_image: &ImageBuffer<Luma<u32>, Vec<u32>>,
+    integral_image: &Image<Luma<u32>>,
     keypoints: &[Point<u32>],
     test_pairs: &[TestPair],
     length: usize,
@@ -318,7 +318,7 @@ mod tests {
               5, 237, 254, 171, 172, 165,  50,  39;
              92,  31, 238,  88,  44,  67, 140, 255
         );
-        let integral_image: ImageBuffer<Luma<u32>, Vec<u32>> = integral_image(&image);
+        let integral_image: Image<Luma<u32>> = integral_image(&image);
         assert_eq!(local_pixel_average(&integral_image, 3, 3, 2), 117);
     }
 }

--- a/src/contrast.rs
+++ b/src/contrast.rs
@@ -2,7 +2,7 @@
 
 use std::cmp::{max, min};
 
-use image::{GrayImage, ImageBuffer, Luma};
+use image::{GrayImage, Luma};
 #[cfg(feature = "rayon")]
 use rayon::prelude::*;
 
@@ -19,7 +19,7 @@ use crate::stats::{cumulative_histogram, histogram};
 pub fn adaptive_threshold(image: &GrayImage, block_radius: u32) -> GrayImage {
     assert!(block_radius > 0);
     let integral = integral_image::<_, u32>(image);
-    let mut out = ImageBuffer::from_pixel(image.width(), image.height(), Luma::black());
+    let mut out = GrayImage::from_pixel(image.width(), image.height(), Luma::black());
 
     for y in 0..image.height() {
         for x in 0..image.width() {

--- a/src/distance_transform.rs
+++ b/src/distance_transform.rs
@@ -115,8 +115,7 @@ pub(crate) fn distance_transform_impl(image: &mut GrayImage, norm: Norm, from: D
                     .iter_mut()
                     .for_each(|p| *p = if *p == 0 { 1 } else { 0 }),
             }
-            let float_dist: Image<Luma<f64>> =
-                euclidean_squared_distance_transform(image);
+            let float_dist: Image<Luma<f64>> = euclidean_squared_distance_transform(image);
             image
                 .iter_mut()
                 .zip(float_dist.iter())

--- a/src/distance_transform.rs
+++ b/src/distance_transform.rs
@@ -2,7 +2,7 @@
 //! image from the nearest pixel of interest.
 
 use crate::definitions::Image;
-use image::{GenericImage, GenericImageView, GrayImage, ImageBuffer, Luma};
+use image::{GenericImage, GenericImageView, GrayImage, Luma};
 use std::cmp::min;
 
 /// How to measure distance between coordinates.
@@ -115,7 +115,7 @@ pub(crate) fn distance_transform_impl(image: &mut GrayImage, norm: Norm, from: D
                     .iter_mut()
                     .for_each(|p| *p = if *p == 0 { 1 } else { 0 }),
             }
-            let float_dist: ImageBuffer<Luma<f64>, Vec<f64>> =
+            let float_dist: Image<Luma<f64>> =
                 euclidean_squared_distance_transform(image);
             image
                 .iter_mut()
@@ -222,7 +222,7 @@ unsafe fn check(
 /// [Distance Transforms of Sampled Functions]: https://www.cs.cornell.edu/~dph/papers/dt.pdf
 pub fn euclidean_squared_distance_transform(image: &Image<Luma<u8>>) -> Image<Luma<f64>> {
     let (width, height) = image.dimensions();
-    let mut result = ImageBuffer::new(width, height);
+    let mut result = Image::new(width, height);
     let mut column_envelope = LowerEnvelope::new(height as usize);
 
     // Compute 1d transforms of each column

--- a/src/drawing/bezier.rs
+++ b/src/drawing/bezier.rs
@@ -1,7 +1,7 @@
 use crate::definitions::Image;
 use crate::drawing::line::draw_line_segment_mut;
 use crate::drawing::Canvas;
-use image::{GenericImage};
+use image::GenericImage;
 
 /// Draws a cubic Bézier curve on an image.
 ///

--- a/src/drawing/bezier.rs
+++ b/src/drawing/bezier.rs
@@ -1,7 +1,7 @@
 use crate::definitions::Image;
 use crate::drawing::line::draw_line_segment_mut;
 use crate::drawing::Canvas;
-use image::{GenericImage, ImageBuffer};
+use image::{GenericImage};
 
 /// Draws a cubic Bézier curve on an image.
 ///
@@ -18,7 +18,7 @@ pub fn draw_cubic_bezier_curve<I>(
 where
     I: GenericImage,
 {
-    let mut out = ImageBuffer::new(image.width(), image.height());
+    let mut out = Image::new(image.width(), image.height());
     out.copy_from(image, 0, 0).unwrap();
     draw_cubic_bezier_curve_mut(&mut out, start, end, control_a, control_b, color);
     out

--- a/src/drawing/conics.rs
+++ b/src/drawing/conics.rs
@@ -2,7 +2,7 @@ use crate::definitions::Image;
 use crate::drawing::draw_if_in_bounds;
 use crate::drawing::line::draw_line_segment_mut;
 use crate::drawing::Canvas;
-use image::{GenericImage, ImageBuffer};
+use image::{GenericImage};
 
 /// Draws the outline of an ellipse on an image.
 ///
@@ -25,7 +25,7 @@ pub fn draw_hollow_ellipse<I>(
 where
     I: GenericImage,
 {
-    let mut out = ImageBuffer::new(image.width(), image.height());
+    let mut out = Image::new(image.width(), image.height());
     out.copy_from(image, 0, 0).unwrap();
     draw_hollow_ellipse_mut(&mut out, center, width_radius, height_radius, color);
     out
@@ -77,7 +77,7 @@ pub fn draw_filled_ellipse<I>(
 where
     I: GenericImage,
 {
-    let mut out = ImageBuffer::new(image.width(), image.height());
+    let mut out = Image::new(image.width(), image.height());
     out.copy_from(image, 0, 0).unwrap();
     draw_filled_ellipse_mut(&mut out, center, width_radius, height_radius, color);
     out
@@ -179,7 +179,7 @@ pub fn draw_hollow_circle<I>(
 where
     I: GenericImage,
 {
-    let mut out = ImageBuffer::new(image.width(), image.height());
+    let mut out = Image::new(image.width(), image.height());
     out.copy_from(image, 0, 0).unwrap();
     draw_hollow_circle_mut(&mut out, center, radius, color);
     out
@@ -228,7 +228,7 @@ pub fn draw_filled_circle<I>(
 where
     I: GenericImage,
 {
-    let mut out = ImageBuffer::new(image.width(), image.height());
+    let mut out = Image::new(image.width(), image.height());
     out.copy_from(image, 0, 0).unwrap();
     draw_filled_circle_mut(&mut out, center, radius, color);
     out

--- a/src/drawing/conics.rs
+++ b/src/drawing/conics.rs
@@ -2,7 +2,7 @@ use crate::definitions::Image;
 use crate::drawing::draw_if_in_bounds;
 use crate::drawing::line::draw_line_segment_mut;
 use crate::drawing::Canvas;
-use image::{GenericImage};
+use image::GenericImage;
 
 /// Draws the outline of an ellipse on an image.
 ///

--- a/src/drawing/cross.rs
+++ b/src/drawing/cross.rs
@@ -1,6 +1,6 @@
 use crate::definitions::Image;
 use crate::drawing::Canvas;
-use image::{GenericImage, ImageBuffer};
+use image::GenericImage;
 
 /// Draws a colored cross on an image.
 ///
@@ -10,7 +10,7 @@ pub fn draw_cross<I>(image: &I, color: I::Pixel, x: i32, y: i32) -> Image<I::Pix
 where
     I: GenericImage,
 {
-    let mut out = ImageBuffer::new(image.width(), image.height());
+    let mut out = Image::new(image.width(), image.height());
     out.copy_from(image, 0, 0).unwrap();
     draw_cross_mut(&mut out, color, x, y);
     out

--- a/src/drawing/line.rs
+++ b/src/drawing/line.rs
@@ -1,6 +1,6 @@
 use crate::definitions::Image;
 use crate::drawing::Canvas;
-use image::{GenericImage, ImageBuffer, Pixel};
+use image::{GenericImage, Pixel};
 use std::mem::{swap, transmute};
 
 /// Iterates over the coordinates in a line segment using
@@ -174,7 +174,7 @@ pub fn draw_line_segment<I>(
 where
     I: GenericImage,
 {
-    let mut out = ImageBuffer::new(image.width(), image.height());
+    let mut out = Image::new(image.width(), image.height());
     out.copy_from(image, 0, 0).unwrap();
     draw_line_segment_mut(&mut out, start, end, color);
     out
@@ -220,7 +220,7 @@ where
 
     B: Fn(I::Pixel, I::Pixel, f32) -> I::Pixel,
 {
-    let mut out = ImageBuffer::new(image.width(), image.height());
+    let mut out = Image::new(image.width(), image.height());
     out.copy_from(image, 0, 0).unwrap();
     draw_antialiased_line_segment_mut(&mut out, start, end, color, blend);
     out

--- a/src/drawing/polygon.rs
+++ b/src/drawing/polygon.rs
@@ -2,7 +2,7 @@ use crate::definitions::Image;
 use crate::drawing::line::{draw_antialiased_line_segment_mut, draw_line_segment_mut};
 use crate::drawing::Canvas;
 use crate::point::Point;
-use image::{GenericImage, ImageBuffer};
+use image::{GenericImage};
 use std::cmp::{max, min};
 
 /// Draws a polygon and its contents on an image.
@@ -88,7 +88,7 @@ pub fn draw_hollow_polygon<I>(
 where
     I: GenericImage,
 {
-    let mut out = ImageBuffer::new(image.width(), image.height());
+    let mut out = Image::new(image.width(), image.height());
     out.copy_from(image, 0, 0).unwrap();
     draw_hollow_polygon_mut(&mut out, poly, color);
     out
@@ -138,7 +138,7 @@ where
     I: GenericImage,
     L: Fn(&mut Image<I::Pixel>, (f32, f32), (f32, f32), I::Pixel),
 {
-    let mut out = ImageBuffer::new(image.width(), image.height());
+    let mut out = Image::new(image.width(), image.height());
     out.copy_from(image, 0, 0).unwrap();
     draw_polygon_with_mut(&mut out, poly, color, plotter);
     out

--- a/src/drawing/polygon.rs
+++ b/src/drawing/polygon.rs
@@ -2,7 +2,7 @@ use crate::definitions::Image;
 use crate::drawing::line::{draw_antialiased_line_segment_mut, draw_line_segment_mut};
 use crate::drawing::Canvas;
 use crate::point::Point;
-use image::{GenericImage};
+use image::GenericImage;
 use std::cmp::{max, min};
 
 /// Draws a polygon and its contents on an image.

--- a/src/drawing/rect.rs
+++ b/src/drawing/rect.rs
@@ -2,7 +2,7 @@ use crate::definitions::Image;
 use crate::drawing::line::draw_line_segment_mut;
 use crate::drawing::Canvas;
 use crate::rect::Rect;
-use image::{GenericImage, ImageBuffer};
+use image::{GenericImage};
 use std::f32;
 
 /// Draws the outline of a rectangle on an image.
@@ -13,7 +13,7 @@ pub fn draw_hollow_rect<I>(image: &I, rect: Rect, color: I::Pixel) -> Image<I::P
 where
     I: GenericImage,
 {
-    let mut out = ImageBuffer::new(image.width(), image.height());
+    let mut out = Image::new(image.width(), image.height());
     out.copy_from(image, 0, 0).unwrap();
     draw_hollow_rect_mut(&mut out, rect, color);
     out
@@ -42,7 +42,7 @@ pub fn draw_filled_rect<I>(image: &I, rect: Rect, color: I::Pixel) -> Image<I::P
 where
     I: GenericImage,
 {
-    let mut out = ImageBuffer::new(image.width(), image.height());
+    let mut out = Image::new(image.width(), image.height());
     out.copy_from(image, 0, 0).unwrap();
     draw_filled_rect_mut(&mut out, rect, color);
     out

--- a/src/drawing/rect.rs
+++ b/src/drawing/rect.rs
@@ -2,7 +2,7 @@ use crate::definitions::Image;
 use crate::drawing::line::draw_line_segment_mut;
 use crate::drawing::Canvas;
 use crate::rect::Rect;
-use image::{GenericImage};
+use image::GenericImage;
 use std::f32;
 
 /// Draws the outline of a rectangle on an image.

--- a/src/drawing/text.rs
+++ b/src/drawing/text.rs
@@ -1,4 +1,4 @@
-use image::{GenericImage, ImageBuffer, Pixel};
+use image::{GenericImage, Pixel};
 use std::f32;
 
 use crate::definitions::{Clamp, Image};
@@ -62,7 +62,7 @@ where
     I: GenericImage,
     <I::Pixel as Pixel>::Subpixel: Into<f32> + Clamp<f32>,
 {
-    let mut out = ImageBuffer::new(image.width(), image.height());
+    let mut out = Image::new(image.width(), image.height());
     out.copy_from(image, 0, 0).unwrap();
     draw_text_mut(&mut out, color, x, y, scale, font, text);
     out

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -914,8 +914,7 @@ mod benches {
         ], 3, 3);
 
         b.iter(|| {
-            let filtered: Image<Luma<i16>> =
-                filter_clamped::<_, _, i16>(&image, kernel);
+            let filtered: Image<Luma<i16>> = filter_clamped::<_, _, i16>(&image, kernel);
             black_box(filtered);
         });
     }

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -8,7 +8,7 @@ pub use self::median::median_filter;
 mod sharpen;
 pub use self::sharpen::*;
 
-use image::{GenericImage, GenericImageView, GrayImage, ImageBuffer, Luma, Pixel, Primitive};
+use image::{GenericImage, GenericImageView, GrayImage, Luma, Pixel, Primitive};
 
 use crate::definitions::{Clamp, Image};
 use crate::integral_image::{column_running_sum, row_running_sum};
@@ -32,7 +32,7 @@ use std::f32;
 #[must_use = "the function does not modify the original image"]
 pub fn box_filter(image: &GrayImage, x_radius: u32, y_radius: u32) -> Image<Luma<u8>> {
     let (width, height) = image.dimensions();
-    let mut out = ImageBuffer::new(width, height);
+    let mut out = Image::new(width, height);
     if width == 0 || height == 0 {
         return out;
     }
@@ -447,7 +447,7 @@ mod tests {
     use super::*;
     use crate::definitions::{Clamp, Image};
     use crate::utils::gray_bench_image;
-    use image::{GrayImage, ImageBuffer, Luma};
+    use image::{GrayImage, Luma};
     use std::cmp::{max, min};
     use test::black_box;
 
@@ -773,14 +773,14 @@ mod tests {
 
     #[test]
     fn test_gaussian_on_u8_white_idempotent() {
-        let image = ImageBuffer::<Luma<u8>, Vec<u8>>::from_pixel(12, 12, Luma([255]));
+        let image = Image::<Luma<u8>>::from_pixel(12, 12, Luma([255]));
         let image2 = gaussian_blur_f32(&image, 6f32);
         assert_pixels_eq_within!(image2, image, 0);
     }
 
     #[test]
     fn test_gaussian_on_f32_white_idempotent() {
-        let image = ImageBuffer::<Luma<f32>, Vec<f32>>::from_pixel(12, 12, Luma([1.0]));
+        let image = Image::<Luma<f32>>::from_pixel(12, 12, Luma([1.0]));
         let image2 = gaussian_blur_f32(&image, 6f32);
         assert_pixels_eq_within!(image2, image, 1e-6);
     }
@@ -860,7 +860,7 @@ mod benches {
     use crate::definitions::Image;
     use crate::utils::{gray_bench_image, rgb_bench_image};
     use image::imageops::blur;
-    use image::{GenericImage, ImageBuffer, Luma, Rgb};
+    use image::{GenericImage, Luma, Rgb};
     use test::{black_box, Bencher};
 
     #[bench]
@@ -914,7 +914,7 @@ mod benches {
         ], 3, 3);
 
         b.iter(|| {
-            let filtered: ImageBuffer<Luma<i16>, Vec<i16>> =
+            let filtered: Image<Luma<i16>> =
                 filter_clamped::<_, _, i16>(&image, kernel);
             black_box(filtered);
         });

--- a/src/geometric_transformations.rs
+++ b/src/geometric_transformations.rs
@@ -2,7 +2,7 @@
 //! projective transformations.
 
 use crate::definitions::{Clamp, Image};
-use image::{GenericImageView, ImageBuffer, Pixel};
+use image::{GenericImageView, Pixel};
 #[cfg(feature = "rayon")]
 use rayon::prelude::*;
 use std::{cmp, ops::Mul};
@@ -330,7 +330,7 @@ where
     let (tx, ty) = t;
     let (w, h) = (width as i32, height as i32);
     let num_channels = P::CHANNEL_COUNT as usize;
-    let mut out = ImageBuffer::new(width, height);
+    let mut out = Image::new(width, height);
 
     for y in 0..height {
         let y_in = cmp::max(0, cmp::min(y as i32 - ty, h - 1));
@@ -385,7 +385,7 @@ where
     <P as Pixel>::Subpixel: Into<f32> + Clamp<f32>,
 {
     let (width, height) = image.dimensions();
-    let mut out = ImageBuffer::new(width, height);
+    let mut out = Image::new(width, height);
     warp_into(image, projection, interpolation, default, &mut out);
     out
 }
@@ -457,7 +457,7 @@ where
     <P as Pixel>::Subpixel: Into<f32> + Clamp<f32>,
 {
     let (width, height) = image.dimensions();
-    let mut out = ImageBuffer::new(width, height);
+    let mut out = Image::new(width, height);
     warp_into_with(image, mapping, interpolation, default, &mut out);
     out
 }
@@ -1170,7 +1170,7 @@ mod benches {
 
         b.iter(|| {
             let (width, height) = image.dimensions();
-            let mut out = ImageBuffer::new(width, height);
+            let mut out = Image::new(width, height);
             warp_into_with(
                 &image,
                 |x, y| (x - 30.0, y - 30.0),

--- a/src/gradients.rs
+++ b/src/gradients.rs
@@ -332,12 +332,12 @@ mod tests {
     use crate::filter::filter_clamped;
 
     use super::*;
-    use image::{ImageBuffer, Luma};
+    use image::Luma;
 
     #[test]
     fn test_gradients_constant_image_sobel() {
-        let image = ImageBuffer::from_pixel(5, 5, Luma([15u8]));
-        let expected = ImageBuffer::from_pixel(5, 5, Luma([0u16]));
+        let image = Image::from_pixel(5, 5, Luma([15u8]));
+        let expected = Image::from_pixel(5, 5, Luma([0u16]));
 
         assert_pixels_eq!(
             gradients(
@@ -351,8 +351,8 @@ mod tests {
     }
     #[test]
     fn test_gradients_constant_image_scharr() {
-        let image = ImageBuffer::from_pixel(5, 5, Luma([15u8]));
-        let expected = ImageBuffer::from_pixel(5, 5, Luma([0u16]));
+        let image = Image::from_pixel(5, 5, Luma([15u8]));
+        let expected = Image::from_pixel(5, 5, Luma([0u16]));
 
         assert_pixels_eq!(
             gradients(
@@ -366,8 +366,8 @@ mod tests {
     }
     #[test]
     fn test_gradients_constant_image_prewitt() {
-        let image = ImageBuffer::from_pixel(5, 5, Luma([15u8]));
-        let expected = ImageBuffer::from_pixel(5, 5, Luma([0u16]));
+        let image = Image::from_pixel(5, 5, Luma([15u8]));
+        let expected = Image::from_pixel(5, 5, Luma([0u16]));
 
         assert_pixels_eq!(
             gradients(
@@ -381,8 +381,8 @@ mod tests {
     }
     #[test]
     fn test_gradients_constant_image_roberts() {
-        let image = ImageBuffer::from_pixel(5, 5, Luma([15u8]));
-        let expected = ImageBuffer::from_pixel(5, 5, Luma([0u16]));
+        let image = Image::from_pixel(5, 5, Luma([15u8]));
+        let expected = Image::from_pixel(5, 5, Luma([0u16]));
 
         assert_pixels_eq!(
             gradients(

--- a/src/haar.rs
+++ b/src/haar.rs
@@ -3,7 +3,7 @@
 //! [Haar-like features]: https://en.wikipedia.org/wiki/Haar-like_features
 
 use crate::definitions::{HasBlack, HasWhite, Image};
-use image::{GenericImage, GenericImageView, ImageBuffer, Luma};
+use image::{GenericImage, GenericImageView, Luma};
 use itertools::Itertools;
 use std::marker::PhantomData;
 use std::ops::Range;
@@ -386,7 +386,7 @@ where
     I: GenericImage,
     I::Pixel: HasBlack + HasWhite,
 {
-    let mut out = ImageBuffer::new(image.width(), image.height());
+    let mut out = Image::new(image.width(), image.height());
     out.copy_from(image, 0, 0).unwrap();
     draw_haar_feature_mut(&mut out, feature);
     out

--- a/src/hog.rs
+++ b/src/hog.rs
@@ -5,7 +5,7 @@ use crate::definitions::{Clamp, Image};
 use crate::filter::filter_clamped;
 use crate::kernel::{self};
 use crate::math::l2_norm;
-use image::{GenericImage, GrayImage, ImageBuffer, Luma};
+use image::{GenericImage, GrayImage, Luma};
 use num::Zero;
 use std::f32;
 
@@ -373,7 +373,7 @@ impl Interpolation {
 pub fn render_hist_grid(star_side: u32, grid: &View3d<'_, f32>, signed: bool) -> Image<Luma<u8>> {
     let width = grid.lengths[1] as u32 * star_side;
     let height = grid.lengths[2] as u32 * star_side;
-    let mut out = ImageBuffer::new(width, height);
+    let mut out = Image::new(width, height);
 
     for y in 0..grid.lengths[2] {
         let y_window = y as u32 * star_side;

--- a/src/hough.rs
+++ b/src/hough.rs
@@ -5,7 +5,7 @@
 use crate::definitions::Image;
 use crate::drawing::draw_line_segment_mut;
 use crate::suppress::suppress_non_maximum;
-use image::{GenericImage, GenericImageView, GrayImage, ImageBuffer, Luma, Pixel};
+use image::{GenericImage, GenericImageView, GrayImage, Luma, Pixel};
 use std::f32;
 
 /// A detected line, in polar coordinates.
@@ -45,7 +45,7 @@ pub fn detect_lines(image: &GrayImage, options: LineDetectionOptions) -> Vec<Pol
     // Measure angles in degrees, and use bins of width 1 pixel and height 1 degree.
     // We use the convention that distances are positive for angles in (0, 180] and
     // negative for angles in [180, 360).
-    let mut acc: ImageBuffer<Luma<u32>, Vec<u32>> = ImageBuffer::new(2 * rmax as u32 + 1, 180u32);
+    let mut acc: Image<Luma<u32>> = Image::new(2 * rmax as u32 + 1, 180u32);
 
     // Precalculate values of (cos(m), sin(m))
     let lut: Vec<(f32, f32)> = (0..180u32)
@@ -538,7 +538,7 @@ mod tests {
 #[cfg(test)]
 mod benches {
     use super::*;
-    use image::{GrayImage, ImageBuffer, Luma};
+    use image::{GrayImage, Luma};
     use test::{black_box, Bencher};
 
     macro_rules! bench_detect_lines {
@@ -572,7 +572,7 @@ mod benches {
     bench_detect_lines!(bench_detect_line_neg10_120, -10.0, 120);
 
     fn chessboard(width: u32, height: u32) -> GrayImage {
-        ImageBuffer::from_fn(width, height, |x, y| {
+        GrayImage::from_fn(width, height, |x, y| {
             if (x + y) % 2 == 0 {
                 Luma([255u8])
             } else {

--- a/src/integral_image.rs
+++ b/src/integral_image.rs
@@ -467,7 +467,7 @@ mod tests {
     use crate::definitions::Image;
     use crate::property_testing::GrayTestImage;
     use crate::utils::pixel_diff_summary;
-    use image::{GenericImage, ImageBuffer, Luma};
+    use image::{GenericImage, Luma};
     use quickcheck::{quickcheck, TestResult};
 
     #[test]
@@ -561,7 +561,7 @@ mod tests {
     {
         let (in_width, in_height) = image.dimensions();
         let (out_width, out_height) = (in_width + 1, in_height + 1);
-        let mut out = ImageBuffer::from_pixel(out_width, out_height, Luma([0u32]));
+        let mut out = Image::from_pixel(out_width, out_height, Luma([0u32]));
 
         for y in 1..out_height {
             for x in 0..out_width {

--- a/src/map.rs
+++ b/src/map.rs
@@ -1,6 +1,6 @@
 //! Functions for mapping over pixels, colors or subpixels of images.
 
-use image::{GenericImage, ImageBuffer, Luma, LumaA, Pixel, Primitive, Rgb, Rgba};
+use image::{GenericImage, Luma, LumaA, Pixel, Primitive, Rgb, Rgba};
 
 use crate::definitions::Image;
 
@@ -82,7 +82,7 @@ where
     F: Fn(P::Subpixel) -> S,
 {
     let (width, height) = image.dimensions();
-    let mut out: ImageBuffer<ChannelMap<P, S>, Vec<S>> = ImageBuffer::new(width, height);
+    let mut out: Image<ChannelMap<P, S>> = Image::new(width, height);
 
     for y in 0..height {
         for x in 0..width {
@@ -179,7 +179,7 @@ where
     F: Fn(P) -> Q,
 {
     let (width, height) = image.dimensions();
-    let mut out: ImageBuffer<Q, Vec<Q::Subpixel>> = ImageBuffer::new(width, height);
+    let mut out: Image<Q> = Image::new(width, height);
 
     for y in 0..height {
         for x in 0..width {
@@ -282,7 +282,7 @@ where
     assert_eq!(image1.dimensions(), image2.dimensions());
 
     let (width, height) = image1.dimensions();
-    let mut out: ImageBuffer<R, Vec<R::Subpixel>> = ImageBuffer::new(width, height);
+    let mut out: Image<R> = Image::new(width, height);
 
     for y in 0..height {
         for x in 0..width {
@@ -331,7 +331,7 @@ where
     F: Fn(u32, u32, P) -> Q,
 {
     let (width, height) = image.dimensions();
-    let mut out: ImageBuffer<Q, Vec<Q::Subpixel>> = ImageBuffer::new(width, height);
+    let mut out: Image<Q> = Image::new(width, height);
 
     for y in 0..height {
         for x in 0..width {

--- a/src/property_testing.rs
+++ b/src/property_testing.rs
@@ -4,7 +4,7 @@
 //! [quickcheck]: https://github.com/BurntSushi/quickcheck
 
 use crate::definitions::Image;
-use image::{GenericImage, ImageBuffer, Luma, Pixel, Primitive, Rgb};
+use image::{GenericImage, Luma, Pixel, Primitive, Rgb};
 use quickcheck::{Arbitrary, Gen};
 use rand_distr::{Distribution, Standard};
 use std::fmt;
@@ -25,7 +25,7 @@ where
 {
     fn arbitrary(g: &mut Gen) -> Self {
         let (width, height) = small_image_dimensions(g);
-        let mut image = ImageBuffer::new(width, height);
+        let mut image = Image::new(width, height);
         for y in 0..height {
             for x in 0..width {
                 let pix: T = ArbitraryPixel::arbitrary(g);
@@ -77,7 +77,7 @@ fn copy_sub<I>(image: &I, x: u32, y: u32, width: u32, height: u32) -> Image<I::P
 where
     I: GenericImage,
 {
-    let mut out = ImageBuffer::new(width, height);
+    let mut out = Image::new(width, height);
     for dy in 0..height {
         let oy = y + dy;
         for dx in 0..width {

--- a/src/region_labelling.rs
+++ b/src/region_labelling.rs
@@ -2,7 +2,7 @@
 
 use std::cmp;
 
-use image::{GenericImage, GenericImageView, ImageBuffer, Luma};
+use image::{GenericImage, GenericImageView, Luma};
 
 use crate::definitions::Image;
 use crate::union_find::DisjointSetForest;
@@ -134,7 +134,7 @@ where
         panic!("Images with 2^32 or more pixels are not supported");
     }
 
-    let mut out = ImageBuffer::new(width, height);
+    let mut out = Image::new(width, height);
 
     // TODO: add macro to abandon early if either dimension is zero
     if width == 0 || height == 0 {
@@ -247,7 +247,7 @@ where
 mod tests {
     extern crate wasm_bindgen_test;
 
-    use image::{GrayImage, ImageBuffer, Luma};
+    use image::{GrayImage, Luma};
     #[cfg(target_arch = "wasm32")]
     use wasm_bindgen_test::*;
 
@@ -278,7 +278,7 @@ mod tests {
     // One huge component with eight-way connectivity, loads of
     // isolated components with four-way connectivity.
     pub(super) fn chessboard(width: u32, height: u32) -> GrayImage {
-        ImageBuffer::from_fn(width, height, |x, y| {
+        GrayImage::from_fn(width, height, |x, y| {
             if (x + y) % 2 == 0 {
                 Luma([255u8])
             } else {

--- a/src/suppress.rs
+++ b/src/suppress.rs
@@ -177,7 +177,7 @@ mod tests {
     use crate::definitions::{Image, Position, Score};
     use crate::property_testing::GrayTestImage;
     use crate::utils::pixel_diff_summary;
-    use image::{GenericImage, GrayImage,  Luma, Primitive};
+    use image::{GenericImage, GrayImage, Luma, Primitive};
     use quickcheck::{quickcheck, TestResult};
     use std::cmp;
 
@@ -345,8 +345,8 @@ mod tests {
 #[cfg(test)]
 mod benches {
     use super::{local_maxima, suppress_non_maximum, tests::T};
-    use crate::noise::gaussian_noise_mut;
     use crate::definitions::Image;
+    use crate::noise::gaussian_noise_mut;
     use image::{GrayImage, Luma};
     use test::Bencher;
 

--- a/src/suppress.rs
+++ b/src/suppress.rs
@@ -1,19 +1,19 @@
 //! Functions for suppressing non-maximal values.
 
-use crate::definitions::{Position, Score};
-use image::{GenericImage, ImageBuffer, Luma, Primitive};
+use crate::definitions::{Image, Position, Score};
+use image::{GenericImage, Luma, Primitive};
 use std::cmp;
 
 /// Returned image has zeroes for all inputs pixels which do not have the greatest
 /// intensity in the (2 * radius + 1) square block centred on them.
 /// Ties are resolved lexicographically.
-pub fn suppress_non_maximum<I, C>(image: &I, radius: u32) -> ImageBuffer<Luma<C>, Vec<C>>
+pub fn suppress_non_maximum<I, C>(image: &I, radius: u32) -> Image<Luma<C>>
 where
     I: GenericImage<Pixel = Luma<C>>,
     C: Primitive + Ord,
 {
     let (width, height) = image.dimensions();
-    let mut out: ImageBuffer<Luma<C>, Vec<C>> = ImageBuffer::new(width, height);
+    let mut out: Image<Luma<C>> = Image::new(width, height);
     if width == 0 || height == 0 {
         return out;
     }
@@ -174,10 +174,10 @@ where
 #[cfg(test)]
 mod tests {
     use super::{local_maxima, suppress_non_maximum};
-    use crate::definitions::{Position, Score};
+    use crate::definitions::{Image, Position, Score};
     use crate::property_testing::GrayTestImage;
     use crate::utils::pixel_diff_summary;
-    use image::{GenericImage, GrayImage, ImageBuffer, Luma, Primitive};
+    use image::{GenericImage, GrayImage,  Luma, Primitive};
     use quickcheck::{quickcheck, TestResult};
     use std::cmp;
 
@@ -274,13 +274,13 @@ mod tests {
 
     /// Reference implementation of suppress_non_maximum. Used to validate
     /// the (presumably faster) actual implementation.
-    fn suppress_non_maximum_reference<I, C>(image: &I, radius: u32) -> ImageBuffer<Luma<C>, Vec<C>>
+    fn suppress_non_maximum_reference<I, C>(image: &I, radius: u32) -> Image<Luma<C>>
     where
         I: GenericImage<Pixel = Luma<C>>,
         C: Primitive + Ord,
     {
         let (width, height) = image.dimensions();
-        let mut out = ImageBuffer::new(width, height);
+        let mut out = Image::new(width, height);
         out.copy_from(image, 0, 0).unwrap();
 
         let iradius = radius as i32;
@@ -346,7 +346,8 @@ mod tests {
 mod benches {
     use super::{local_maxima, suppress_non_maximum, tests::T};
     use crate::noise::gaussian_noise_mut;
-    use image::{GrayImage, ImageBuffer, Luma};
+    use crate::definitions::Image;
+    use image::{GrayImage, Luma};
     use test::Bencher;
 
     #[bench]
@@ -376,7 +377,7 @@ mod benches {
     fn bench_suppress_non_maximum_increasing_gradient(b: &mut Bencher) {
         // Increasing gradient in both directions. This can be a worst-case for
         // early-abort strategies.
-        let img = ImageBuffer::from_fn(40, 20, |x, y| Luma([(x + y) as u8]));
+        let img = Image::from_fn(40, 20, |x, y| Luma([(x + y) as u8]));
         b.iter(|| suppress_non_maximum(&img, 7));
     }
 
@@ -384,7 +385,7 @@ mod benches {
     fn bench_suppress_non_maximum_decreasing_gradient(b: &mut Bencher) {
         let width = 40u32;
         let height = 20u32;
-        let img = ImageBuffer::from_fn(width, height, |x, y| {
+        let img = Image::from_fn(width, height, |x, y| {
             Luma([((width - x) + (height - y)) as u8])
         });
         b.iter(|| suppress_non_maximum(&img, 7));
@@ -392,21 +393,21 @@ mod benches {
 
     #[bench]
     fn bench_suppress_non_maximum_noise_7(b: &mut Bencher) {
-        let mut img: GrayImage = ImageBuffer::new(40, 20);
+        let mut img: GrayImage = GrayImage::new(40, 20);
         gaussian_noise_mut(&mut img, 128f64, 30f64, 1);
         b.iter(|| suppress_non_maximum(&img, 7));
     }
 
     #[bench]
     fn bench_suppress_non_maximum_noise_3(b: &mut Bencher) {
-        let mut img: GrayImage = ImageBuffer::new(40, 20);
+        let mut img: GrayImage = GrayImage::new(40, 20);
         gaussian_noise_mut(&mut img, 128f64, 30f64, 1);
         b.iter(|| suppress_non_maximum(&img, 3));
     }
 
     #[bench]
     fn bench_suppress_non_maximum_noise_1(b: &mut Bencher) {
-        let mut img: GrayImage = ImageBuffer::new(40, 20);
+        let mut img: GrayImage = GrayImage::new(40, 20);
         gaussian_noise_mut(&mut img, 128f64, 30f64, 1);
         b.iter(|| suppress_non_maximum(&img, 1));
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -88,8 +88,10 @@ macro_rules! gray_image {
         // Empty image with the given channel type
     (type: $channel_type:ty) => {
         {
-            use image::{ImageBuffer, Luma};
-            ImageBuffer::<Luma<$channel_type>, Vec<$channel_type>>::new(0, 0)
+            use image::Luma;
+            use $crate::definitions::Image;
+
+            Image::<Luma<$channel_type>>::new(0, 0)
         }
     };
     // Non-empty image of default channel type u8
@@ -99,7 +101,8 @@ macro_rules! gray_image {
     // Non-empty image of given channel type
     (type: $channel_type:ty, $( $( $x: expr ),*);*) => {
         {
-            use image::{ImageBuffer, Luma};
+            use image::Luma;
+            use $crate::definitions::Image;
 
             let nested_array = [ $( [ $($x),* ] ),* ];
             let height = nested_array.len() as u32;
@@ -110,7 +113,7 @@ macro_rules! gray_image {
                 .cloned()
                 .collect();
 
-            ImageBuffer::<Luma<$channel_type>, Vec<$channel_type>>::from_raw(width, height, flat_array)
+            Image::<Luma<$channel_type>>::from_raw(width, height, flat_array)
                 .unwrap()
         }
     }
@@ -190,8 +193,10 @@ macro_rules! rgb_image {
     // Empty image with the given channel type
     (type: $channel_type:ty) => {
         {
-            use image::{ImageBuffer, Rgb};
-            ImageBuffer::<Rgb<$channel_type>, Vec<$channel_type>>::new(0, 0)
+            use image::Rgb;
+            use $crate::definitions::Image;
+
+            Image::<Rgb<$channel_type>>::new(0, 0)
         }
     };
     // Non-empty image of default channel type u8
@@ -201,7 +206,9 @@ macro_rules! rgb_image {
     // Non-empty image of given channel type
     (type: $channel_type:ty, $( $( [$r: expr, $g: expr, $b: expr]),*);*) => {
         {
-            use image::{ImageBuffer, Rgb};
+            use image::Rgb;
+            use $crate::definitions::Image;
+
             let nested_array = [$( [ $([$r, $g, $b]),*]),*];
             let height = nested_array.len() as u32;
             let width = nested_array[0].len() as u32;
@@ -211,7 +218,7 @@ macro_rules! rgb_image {
                 .cloned()
                 .collect();
 
-            ImageBuffer::<Rgb<$channel_type>, Vec<$channel_type>>::from_raw(width, height, flat_array)
+            Image::<Rgb<$channel_type>>::from_raw(width, height, flat_array)
                 .unwrap()
         }
     }
@@ -291,8 +298,10 @@ macro_rules! rgba_image {
     // Empty image with the given channel type
     (type: $channel_type:ty) => {
         {
-            use image::{ImageBuffer, Rgba};
-            ImageBuffer::<Rgba<$channel_type>, Vec<$channel_type>>::new(0, 0)
+            use image::Rgba;
+            use $crate::definitions::Image;
+
+            Image::<Rgba<$channel_type>>::new(0, 0)
         }
     };
     // Non-empty image of default channel type u8
@@ -302,7 +311,9 @@ macro_rules! rgba_image {
     // Non-empty image of given channel type
     (type: $channel_type:ty, $( $( [$r: expr, $g: expr, $b: expr, $a: expr]),*);*) => {
         {
-            use image::{ImageBuffer, Rgba};
+            use image::Rgba;
+            use $crate::definitions::Image;
+
             let nested_array = [$( [ $([$r, $g, $b, $a]),*]),*];
             let height = nested_array.len() as u32;
             let width = nested_array[0].len() as u32;
@@ -312,7 +323,7 @@ macro_rules! rgba_image {
                 .cloned()
                 .collect();
 
-            ImageBuffer::<Rgba<$channel_type>, Vec<$channel_type>>::from_raw(width, height, flat_array)
+            Image::<Rgba<$channel_type>>::from_raw(width, height, flat_array)
                 .unwrap()
         }
     }

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -18,11 +18,12 @@ extern crate imageproc;
 use std::{env, f32, path::Path};
 
 use image::{
-    DynamicImage, GrayImage, ImageBuffer, Luma, Pixel, PixelWithColorType, Rgb, RgbImage, Rgba,
+    DynamicImage, GrayImage, Luma, Pixel, PixelWithColorType, Rgb, RgbImage, Rgba,
     RgbaImage,
 };
 
 use imageproc::contrast::ThresholdType;
+use imageproc::definitions::Image;
 use imageproc::filter::bilateral::GaussianEuclideanColorDistance;
 use imageproc::filter::bilateral_filter;
 use imageproc::kernel::{self};
@@ -73,8 +74,8 @@ impl FromDynamic for RgbaImage {
 fn compare_to_truth<P, F>(input_file_name: &str, truth_file_name: &str, op: F)
 where
     P: Pixel<Subpixel = u8> + PixelWithColorType,
-    ImageBuffer<P, Vec<u8>>: FromDynamic,
-    F: Fn(&ImageBuffer<P, Vec<u8>>) -> ImageBuffer<P, Vec<u8>>,
+    Image<P>: FromDynamic,
+    F: Fn(&Image<P>) -> Image<P>,
 {
     compare_to_truth_with_tolerance(input_file_name, truth_file_name, op, 0u8);
 }
@@ -88,10 +89,10 @@ fn compare_to_truth_with_tolerance<P, F>(
     tol: u8,
 ) where
     P: Pixel<Subpixel = u8> + PixelWithColorType,
-    ImageBuffer<P, Vec<u8>>: FromDynamic,
-    F: Fn(&ImageBuffer<P, Vec<u8>>) -> ImageBuffer<P, Vec<u8>>,
+    Image<P>: FromDynamic,
+    F: Fn(&Image<P>) -> Image<P>,
 {
-    let input = ImageBuffer::<P, Vec<u8>>::from_dynamic(&load_image_or_panic(
+    let input = Image::<P>::from_dynamic(&load_image_or_panic(
         Path::new(INPUT_DIR).join(input_file_name),
     ));
     let actual = op(&input);
@@ -99,29 +100,26 @@ fn compare_to_truth_with_tolerance<P, F>(
 }
 
 /// Checks that an image matches a 'truth' image.
-fn compare_to_truth_image<P>(actual: &ImageBuffer<P, Vec<u8>>, truth_file_name: &str)
+fn compare_to_truth_image<P>(actual: &Image<P>, truth_file_name: &str)
 where
     P: Pixel<Subpixel = u8> + PixelWithColorType,
-    ImageBuffer<P, Vec<u8>>: FromDynamic,
+    Image<P>: FromDynamic,
 {
     compare_to_truth_image_with_tolerance(actual, truth_file_name, 0u8);
 }
 
 /// Checks that an image matches a 'truth' image to within a given per-pixel tolerance.
-fn compare_to_truth_image_with_tolerance<P>(
-    actual: &ImageBuffer<P, Vec<u8>>,
-    truth_file_name: &str,
-    tol: u8,
-) where
+fn compare_to_truth_image_with_tolerance<P>(actual: &Image<P>, truth_file_name: &str, tol: u8)
+where
     P: Pixel<Subpixel = u8> + PixelWithColorType,
-    ImageBuffer<P, Vec<u8>>: FromDynamic,
+    Image<P>: FromDynamic,
 {
     if should_regenerate() {
         actual
             .save(Path::new(TRUTH_DIR).join(truth_file_name))
             .unwrap();
     } else {
-        let truth = ImageBuffer::<P, Vec<u8>>::from_dynamic(&load_image_or_panic(
+        let truth = Image::<P>::from_dynamic(&load_image_or_panic(
             Path::new(TRUTH_DIR).join(truth_file_name),
         ));
         assert_pixels_eq_within!(*actual, truth, tol);

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -18,8 +18,7 @@ extern crate imageproc;
 use std::{env, f32, path::Path};
 
 use image::{
-    DynamicImage, GrayImage, Luma, Pixel, PixelWithColorType, Rgb, RgbImage, Rgba,
-    RgbaImage,
+    DynamicImage, GrayImage, Luma, Pixel, PixelWithColorType, Rgb, RgbImage, Rgba, RgbaImage,
 };
 
 use imageproc::contrast::ThresholdType;


### PR DESCRIPTION
This PR replaces the `ImageBuffer` type with more relevant `Image` and `GrayImage` types as appropriate.

A lot of the time functions return `Image<P>` anyway so using `Image` inside the function makes more sense to me. Also a lot of the time `ImageBuffer<P, Vec<P>>` is used explicitly which is repetitive and noisy compared to simply `Image<P>`.

The only exception to this is doc-examples which I avoided since it may teach users to rely on the `imageproc::definitions::Image` type synonym which I wasn't sure about. However, I'd be happy to also switch these to use `Image` as well if you think that'd be ok.