### PR TITLE
Add `delta` parameter to `adaptive_threshold`

### DIFF
--- a/src/contrast.rs
+++ b/src/contrast.rs
@@ -13,7 +13,7 @@ use crate::stats::{cumulative_histogram, histogram};
 
 /// Applies an adaptive threshold to an image.
 ///
-/// Equivalent to `adaptive_threshold_with_delta` with delta=0.
+/// Equivalent to [`adaptive_threshold_with_delta()`] with delta=0.
 pub fn adaptive_threshold(image: &GrayImage, block_radius: u32) -> GrayImage {
     adaptive_threshold_with_delta(image, block_radius, 0)
 }

--- a/src/contrast.rs
+++ b/src/contrast.rs
@@ -463,6 +463,23 @@ mod tests {
     }
 
     #[test]
+    fn test_adaptive_thesholding_with_delta() {
+        let mut image = GrayImage::from_pixel(3, 3, Luma([100u8]));
+        image.put_pixel(2, 2, Luma::black());
+
+        //big delta should make the theshold for the black pixel small enough to be white
+        let binary = adaptive_threshold_with_delta(&image, 1, 100);
+        let expected = GrayImage::from_pixel(3, 3, Luma::white());
+        assert_pixels_eq!(binary, expected);
+
+        //smaller delta should make the theshold the pixel to be black
+        let binary = adaptive_threshold_with_delta(&image, 1, 50);
+        let mut expected = GrayImage::from_pixel(3, 3, Luma::white());
+        expected.put_pixel(2, 2, Luma::black());
+        assert_pixels_eq!(binary, expected);
+    }
+
+    #[test]
     fn test_histogram_lut_source_and_target_equal() {
         let mut histc = [0u32; 256];
         for i in 1..histc.len() {

--- a/src/contrast.rs
+++ b/src/contrast.rs
@@ -13,9 +13,7 @@ use crate::stats::{cumulative_histogram, histogram};
 
 /// Applies an adaptive threshold to an image.
 ///
-/// This algorithm compares each pixel's brightness with the average brightness of the pixels
-/// in the (2 * `block_radius` + 1) square block centered on it. If the pixel is at least as bright
-/// as the threshold then it will have a value of 255 in the output image, otherwise 0.
+/// Equivalent to `adaptive_threshold_with_delta` with delta=0.
 pub fn adaptive_threshold(image: &GrayImage, block_radius: u32) -> GrayImage {
     adaptive_threshold_with_delta(image, block_radius, 0)
 }

--- a/src/contrast.rs
+++ b/src/contrast.rs
@@ -17,6 +17,19 @@ use crate::stats::{cumulative_histogram, histogram};
 /// in the (2 * `block_radius` + 1) square block centered on it. If the pixel is at least as bright
 /// as the threshold then it will have a value of 255 in the output image, otherwise 0.
 pub fn adaptive_threshold(image: &GrayImage, block_radius: u32) -> GrayImage {
+    adaptive_threshold_with_delta(image, block_radius, 0)
+}
+
+/// Applies an adaptive threshold to an image, also accepting a delta parameter.
+///
+/// This algorithm compares each pixel's brightness with the average brightness of the pixels
+/// in the (2 * `block_radius` + 1) square block centered on it minus delta. If the pixel is at least as bright
+/// as the threshold then it will have a value of 255 in the output image, otherwise 0.
+pub fn adaptive_threshold_with_delta(
+    image: &GrayImage,
+    block_radius: u32,
+    delta: i32,
+) -> GrayImage {
     assert!(block_radius > 0);
     let integral = integral_image::<_, u32>(image);
     let mut out = ImageBuffer::from_pixel(image.width(), image.height(), Luma::black());
@@ -38,7 +51,7 @@ pub fn adaptive_threshold(image: &GrayImage, block_radius: u32) -> GrayImage {
             let w = (y_high - y_low + 1) * (x_high - x_low + 1);
             let mean = sum_image_pixels(&integral, x_low, y_low, x_high, y_high)[0] / w;
 
-            if current_pixel[0] as u32 >= mean as u32 {
+            if current_pixel[0] as i32 >= mean as i32 - delta {
                 out.put_pixel(x, y, Luma::white());
             }
         }

--- a/src/edges.rs
+++ b/src/edges.rs
@@ -14,11 +14,11 @@ use std::f32;
 /// # Params
 ///
 /// - `low_threshold`: Low threshold for the hysteresis procedure.
-/// Edges with a strength higher than the low threshold will appear
-/// in the output image, if there are strong edges nearby.
+///   Edges with a strength higher than the low threshold will appear
+///   in the output image, if there are strong edges nearby.
 /// - `high_threshold`: High threshold for the hysteresis procedure.
-/// Edges with a strength higher than the high threshold will always
-/// appear as edges in the output image.
+///   Edges with a strength higher than the high threshold will always
+///   appear as edges in the output image.
 ///
 /// The greatest possible edge strength (and so largest sensible threshold)
 /// is`sqrt(5) * 2 * 255`, or approximately 1140.39.

--- a/src/template_matching.rs
+++ b/src/template_matching.rs
@@ -120,7 +120,7 @@ pub fn match_template_parallel(
 /// # Panics
 ///
 /// - If either dimension of `template` is not strictly less than the corresponding dimension
-/// of `image`.
+///   of `image`.
 /// - If `template.dimensions() != mask.dimensions()`.
 pub fn match_template_with_mask(
     image: &GrayImage,

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -369,7 +369,7 @@ fn test_gaussian_blur_stdev_10() {
 fn test_adaptive_threshold() {
     use imageproc::contrast::adaptive_threshold;
     compare_to_truth("zebra.png", "zebra_adaptive_threshold.png", |image| {
-        adaptive_threshold(image, 41)
+        adaptive_threshold(image, 41, 0)
     });
 }
 


### PR DESCRIPTION
For #532 
The opencv implementation seems to take the delta as float and rounds it differently based on if the thresholding is inverted or not, we don't have an inverted mode for this so passing delta as `i32` should be fine.