### PR TITLE
Removed allocation from `filter_pixel()`

### DIFF
--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -109,8 +109,6 @@ where
     F: Fn(K) -> Q::Subpixel,
     K: num::Num + Copy + From<P::Subpixel>,
 {
-    //TODO refactor this to use the `crate::maps` functions once that lands
-
     let (width, height) = image.dimensions();
 
     let mut out = Image::<Q>::new(width, height);
@@ -134,8 +132,6 @@ where
     F: Fn(K) -> Q::Subpixel + Send + Sync,
     K: Num + Copy + From<P::Subpixel> + Sync,
 {
-    //TODO refactor this to use the `crate::maps` functions once that lands
-
     use rayon::iter::IndexedParallelIterator;
     use rayon::iter::ParallelIterator;
 

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -2,19 +2,13 @@
 
 /// An borrowed 2D kernel, used to filter images via convolution.
 #[derive(Debug, Copy, Clone)]
-pub struct Kernel<'a, K>
-where
-    K: Copy,
-{
+pub struct Kernel<'a, K> {
     pub(crate) data: &'a [K],
     pub(crate) width: u32,
     pub(crate) height: u32,
 }
 
-impl<'a, K> Kernel<'a, K>
-where
-    K: Copy,
-{
+impl<'a, K> Kernel<'a, K> {
     /// Construct a kernel from a slice and its dimensions. The input slice is
     /// in row-major order.
     ///
@@ -35,28 +29,10 @@ where
     ///
     /// # Panics
     ///
-    /// If the `y * kernel.width + x` is outside of the kernel data.
+    /// If the `x` or `y` is outside of the width or height of the kernel.
     #[inline]
-    pub fn get(&self, x: u32, y: u32) -> K {
-        debug_assert!(x < self.width);
-        debug_assert!(y < self.height);
-        let at = usize::try_from(y * self.width + x).unwrap();
-        self.data[at]
-    }
-
-    /// Get the value in the kernel at the given `x` and `y` position, without
-    /// doing bounds checking.
-    ///
-    /// # Safety
-    /// The caller must ensure that `y * self.width + x` is in bounds of the
-    /// kernel data.
-    #[inline]
-    pub unsafe fn get_unchecked(&self, x: u32, y: u32) -> K {
-        debug_assert!(x < self.width);
-        debug_assert!(y < self.height);
-        let at = usize::try_from(y * self.width + x).unwrap();
-        debug_assert!(at < self.data.len());
-        *self.data.get_unchecked(at)
+    pub fn at(&self, x: u32, y: u32) -> &K {
+        &self.data[(y * self.width + x) as usize]
     }
 }
 


### PR DESCRIPTION
Achieved via always computing with 4 channels using an array of length 4 since const generic expressions are unstable.