### PR TITLE
Update all doc-links to use shorthand syntax

### DIFF
--- a/src/drawing/canvas.rs
+++ b/src/drawing/canvas.rs
@@ -8,7 +8,7 @@ use image::{GenericImage, GenericImageView, Pixel};
 /// the behaviour of `draw_pixel` being equivalent to calling
 /// `set_pixel` with the same arguments.
 ///
-/// See [`Blend`](struct.Blend.html) for another example implementation
+/// See [`Blend`] for another example implementation
 /// of this trait - its implementation of `draw_pixel` alpha-blends
 /// the input value with the pixel's current value.
 ///
@@ -94,7 +94,7 @@ where
 
 /// A canvas that blends pixels when drawing.
 ///
-/// See the documentation for [`Canvas`](trait.Canvas.html)
+/// See the documentation for [`Canvas`]
 /// for an example using this type.
 pub struct Blend<I>(pub I);
 

--- a/src/drawing/line.rs
+++ b/src/drawing/line.rs
@@ -17,7 +17,7 @@ pub struct BresenhamLineIter {
 }
 
 impl BresenhamLineIter {
-    /// Creates a [`BresenhamLineIter`](struct.BresenhamLineIter.html) which will iterate over the integer coordinates
+    /// Creates a [`BresenhamLineIter`] which will iterate over the integer coordinates
     /// between `start` and `end`.
     pub fn new(start: (f32, f32), end: (f32, f32)) -> BresenhamLineIter {
         let (mut x0, mut y0) = (start.0, start.1);
@@ -92,7 +92,7 @@ pub struct BresenhamLinePixelIter<'a, P: Pixel> {
 }
 
 impl<'a, P: Pixel> BresenhamLinePixelIter<'a, P> {
-    /// Creates a [`BresenhamLinePixelIter`](struct.BresenhamLinePixelIter.html) which will iterate over
+    /// Creates a [`BresenhamLinePixelIter`] which will iterate over
     /// the image pixels with coordinates between `start` and `end`.
     pub fn new(
         image: &Image<P>,
@@ -126,7 +126,7 @@ pub struct BresenhamLinePixelIterMut<'a, P: Pixel> {
 }
 
 impl<'a, P: Pixel> BresenhamLinePixelIterMut<'a, P> {
-    /// Creates a [`BresenhamLinePixelIterMut`](struct.BresenhamLinePixelIterMut.html) which will iterate over
+    /// Creates a [`BresenhamLinePixelIterMut`] which will iterate over
     /// the image pixels with coordinates between `start` and `end`.
     pub fn new(
         image: &mut Image<P>,
@@ -204,7 +204,7 @@ where
 /// Draws as much of the line segment between `start` and `end` as lies inside the image bounds.
 ///
 /// The parameters of blend are (line color, original color, line weight).
-/// Consider using [`interpolate`](fn.interpolate.html) for blend.
+/// Consider using [`interpolate()`](crate::pixelops::interpolate) for blend.
 ///
 /// Uses [Xu's line drawing algorithm](https://en.wikipedia.org/wiki/Xiaolin_Wu%27s_line_algorithm).
 #[must_use = "the function does not modify the original image"]

--- a/src/drawing/polygon.rs
+++ b/src/drawing/polygon.rs
@@ -31,7 +31,7 @@ where
 /// An implicit edge is added from the last to the first point in the slice.
 ///
 /// The parameters of blend are (line color, original color, line weight).
-/// Consider using [`interpolate`](fn.interpolate.html) for blend.
+/// Consider using [`interpolate()`](crate::pixelops::interpolate) for blend.
 pub fn draw_antialiased_polygon<I, B>(
     image: &I,
     poly: &[Point<i32>],

--- a/src/geometric_transformations.rs
+++ b/src/geometric_transformations.rs
@@ -532,7 +532,7 @@ where
 
 /// Applies a projective transformation to an image, writing to a provided output.
 ///
-/// See the [`warp`](fn.warp.html) documentation for more information.
+/// See the [`warp()`] documentation for more information.
 pub fn warp_into<P>(
     image: &Image<P>,
     projection: &Projection,
@@ -605,7 +605,7 @@ where
 /// Warps an image using the provided function to define the pre-image of each output pixel,
 /// writing into a preallocated output.
 ///
-/// See the [`warp_with`](fn.warp_with.html) documentation for more information.
+/// See the [`warp_with()`] documentation for more information.
 pub fn warp_into_with<P, F>(
     image: &Image<P>,
     mapping: F,

--- a/src/gradients.rs
+++ b/src/gradients.rs
@@ -2,7 +2,10 @@
 
 use crate::definitions::{HasBlack, Image};
 use crate::filter::filter_clamped;
-use crate::kernel::{self, Kernel, PREWITT_HORIZONTAL_3X3, PREWITT_VERTICAL_3X3, SCHARR_HORIZONTAL_3X3, SCHARR_VERTICAL_3X3, SOBEL_HORIZONTAL_3X3, SOBEL_VERTICAL_3X3};
+use crate::kernel::{
+    self, Kernel, PREWITT_HORIZONTAL_3X3, PREWITT_VERTICAL_3X3, SCHARR_HORIZONTAL_3X3,
+    SCHARR_VERTICAL_3X3, SOBEL_HORIZONTAL_3X3, SOBEL_VERTICAL_3X3,
+};
 use crate::map::{ChannelMap, WithChannel};
 use image::{GenericImage, GenericImageView, GrayImage, Luma, Pixel};
 use itertools::multizip;

--- a/src/gradients.rs
+++ b/src/gradients.rs
@@ -2,7 +2,7 @@
 
 use crate::definitions::{HasBlack, Image};
 use crate::filter::filter_clamped;
-use crate::kernel::{self, Kernel};
+use crate::kernel::{self, Kernel, PREWITT_HORIZONTAL_3X3, PREWITT_VERTICAL_3X3, SCHARR_HORIZONTAL_3X3, SCHARR_VERTICAL_3X3, SOBEL_HORIZONTAL_3X3, SOBEL_VERTICAL_3X3};
 use crate::map::{ChannelMap, WithChannel};
 use image::{GenericImage, GenericImageView, GrayImage, Luma, Pixel};
 use itertools::multizip;
@@ -155,40 +155,40 @@ fn gradient_magnitude(dx: f32, dy: f32) -> u16 {
     (dx.powi(2) + dy.powi(2)).sqrt() as u16
 }
 
-/// Convolves an image with the [`HORIZONTAL_SOBEL`](static.HORIZONTAL_SOBEL.html)
+/// Convolves an image with the [`SOBEL_HORIZONTAL_3X3`]
 /// kernel to detect horizontal gradients.
 pub fn horizontal_sobel(image: &GrayImage) -> Image<Luma<i16>> {
-    filter_clamped(image, kernel::SOBEL_HORIZONTAL_3X3)
+    filter_clamped(image, SOBEL_HORIZONTAL_3X3)
 }
 
-/// Convolves an image with the [`VERTICAL_SOBEL`](static.VERTICAL_SOBEL.html)
+/// Convolves an image with the [`SOBEL_VERTICAL_3X3`]
 /// kernel to detect vertical gradients.
 pub fn vertical_sobel(image: &GrayImage) -> Image<Luma<i16>> {
-    filter_clamped(image, kernel::SOBEL_VERTICAL_3X3)
+    filter_clamped(image, SOBEL_VERTICAL_3X3)
 }
 
-/// Convolves an image with the [`HORIZONTAL_SCHARR`](static.HORIZONTAL_SCHARR.html)
+/// Convolves an image with the [`SCHARR_HORIZONTAL_3X3`]
 /// kernel to detect horizontal gradients.
 pub fn horizontal_scharr(image: &GrayImage) -> Image<Luma<i16>> {
-    filter_clamped(image, kernel::SCHARR_HORIZONTAL_3X3)
+    filter_clamped(image, SCHARR_HORIZONTAL_3X3)
 }
 
-/// Convolves an image with the [`VERTICAL_SCHARR`](static.VERTICAL_SCHARR.html)
+/// Convolves an image with the [`SCHARR_VERTICAL_3X3`]
 /// kernel to detect vertical gradients.
 pub fn vertical_scharr(image: &GrayImage) -> Image<Luma<i16>> {
-    filter_clamped(image, kernel::SCHARR_VERTICAL_3X3)
+    filter_clamped(image, SCHARR_VERTICAL_3X3)
 }
 
-/// Convolves an image with the [`HORIZONTAL_PREWITT`](static.HORIZONTAL_PREWITT.html)
+/// Convolves an image with the [`PREWITT_HORIZONTAL_3X3`]
 /// kernel to detect horizontal gradients.
 pub fn horizontal_prewitt(image: &GrayImage) -> Image<Luma<i16>> {
-    filter_clamped(image, kernel::PREWITT_HORIZONTAL_3X3)
+    filter_clamped(image, PREWITT_HORIZONTAL_3X3)
 }
 
-/// Convolves an image with the [`VERTICAL_PREWITT`](static.VERTICAL_PREWITT.html)
+/// Convolves an image with the [`PREWITT_VERTICAL_3X3`]
 /// kernel to detect vertical gradients.
 pub fn vertical_prewitt(image: &GrayImage) -> Image<Luma<i16>> {
-    filter_clamped(image, kernel::PREWITT_VERTICAL_3X3)
+    filter_clamped(image, PREWITT_VERTICAL_3X3)
 }
 
 /// Returns the magnitudes of gradients in an image using Sobel filters.

--- a/src/integral_image.rs
+++ b/src/integral_image.rs
@@ -58,7 +58,7 @@ where
 /// Computes the 2d running sum of the squares of the intensities in an image. Channels are summed
 /// independently.
 ///
-/// See the [`integral_image`](fn.integral_image.html) documentation for more information on integral images.
+/// See the [`integral_image()`] documentation for more information on integral images.
 ///
 /// # Examples
 /// ```
@@ -246,7 +246,7 @@ where
 /// implements `Primitive`. In that case, this function returns `[T; 1]` for an image
 /// whose pixels are of type `Luma`, `[T; 3]` for `Rgb` pixels and `[T; 4]` for `Rgba` pixels.
 ///
-/// See the [`integral_image`](fn.integral_image.html) documentation for examples.
+/// See the [`integral_image()`] documentation for examples.
 pub fn sum_image_pixels<P>(
     integral_image: &Image<P>,
     left: u32,
@@ -272,7 +272,7 @@ where
 /// integral image of F and `integral_squared_image` is the integral image of the squares of the
 /// pixels in F.
 ///
-/// See the [`integral_image`](fn.integral_image.html) documentation for more information on integral images.
+/// See the [`integral_image()`] documentation for more information on integral images.
 ///
 ///# Examples
 /// ```

--- a/src/morphology.rs
+++ b/src/morphology.rs
@@ -174,7 +174,7 @@ pub fn erode_mut(image: &mut GrayImage, norm: Norm, k: u8) {
 
 /// Erosion followed by dilation.
 ///
-/// See the [`erode`](fn.erode.html) and [`dilate`](fn.dilate.html)
+/// See the [`erode()`] and [`dilate()`]
 /// documentation for definitions of dilation and erosion.
 ///
 /// # Examples
@@ -236,7 +236,7 @@ pub fn open_mut(image: &mut GrayImage, norm: Norm, k: u8) {
 
 /// Dilation followed by erosion.
 ///
-/// See the [`erode`](fn.erode.html) and [`dilate`](fn.dilate.html)
+/// See the [`erode()`] and [`dilate()`]
 /// documentation for definitions of dilation and erosion.
 ///
 /// # Examples
@@ -720,8 +720,8 @@ pub fn grayscale_erode(image: &GrayImage, mask: &Mask) -> GrayImage {
 
 /// Grayscale erosion followed by grayscale dilation.
 ///
-/// See the [`grayscale_dilate`](fn.grayscale_dilate.html)
-/// and [`grayscale_erode`](fn.grayscale_erode.html)
+/// See the [`grayscale_dilate()`]
+/// and [`grayscale_erode()`]
 /// documentation for definitions of dilation and erosion.
 ///
 ////// # Examples
@@ -762,8 +762,8 @@ pub fn grayscale_open(image: &GrayImage, mask: &Mask) -> GrayImage {
 
 /// Grayscale dilation followed by grayscale erosion.
 ///
-/// See the [`grayscale_dilate`](fn.grayscale_dilate.html)
-/// and [`grayscale_erode`](fn.grayscale_erode.html)
+/// See the [`grayscale_dilate()`]
+/// and [`grayscale_erode()`]
 /// documentation for definitions of dilation and erosion.
 ///
 ////// # Examples

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -39,35 +39,35 @@ impl Rect {
     /// Reduces possibility of confusing coordinates and dimensions
     /// when specifying rects.
     ///
-    /// See the [struct-level documentation](struct.Rect.html) for examples.
+    /// See the [struct-level documentation](Rect) for examples.
     pub fn at(x: i32, y: i32) -> RectPosition {
         RectPosition { left: x, top: y }
     }
 
     /// Smallest y-coordinate reached by rect.
     ///
-    /// See the [struct-level documentation](struct.Rect.html) for examples.
+    /// See the [struct-level documentation](Rect) for examples.
     pub fn top(&self) -> i32 {
         self.top
     }
 
     /// Smallest x-coordinate reached by rect.
     ///
-    /// See the [struct-level documentation](struct.Rect.html) for examples.
+    /// See the [struct-level documentation](Rect) for examples.
     pub fn left(&self) -> i32 {
         self.left
     }
 
     /// Greatest y-coordinate reached by rect.
     ///
-    /// See the [struct-level documentation](struct.Rect.html) for examples.
+    /// See the [struct-level documentation](Rect) for examples.
     pub fn bottom(&self) -> i32 {
         self.top + (self.height as i32) - 1
     }
 
     /// Greatest x-coordinate reached by rect.
     ///
-    /// See the [struct-level documentation](struct.Rect.html) for examples.
+    /// See the [struct-level documentation](Rect) for examples.
     pub fn right(&self) -> i32 {
         self.left + (self.width as i32) - 1
     }
@@ -139,7 +139,7 @@ impl Region<f32> for Rect {
 }
 
 /// Position of the top left of a rectangle.
-/// Only used when building a [`Rect`](struct.Rect.html).
+/// Only used when building a [`Rect`].
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct RectPosition {
     left: i32,
@@ -150,7 +150,7 @@ impl RectPosition {
     /// Construct a rectangle from a position and size. Width and height
     /// are required to be strictly positive.
     ///
-    /// See the [`Rect`](struct.Rect.html) documentation for examples.
+    /// See the [`Rect`] documentation for examples.
     pub fn of_size(self, width: u32, height: u32) -> Rect {
         assert!(width > 0, "width must be strictly positive");
         assert!(height > 0, "height must be strictly positive");


### PR DESCRIPTION
Fixes #677 