### PR TITLE
Update `CI`

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,15 @@
+name: Lint GitHub Actions workflows
+on: [push, pull_request]
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download actionlint
+        id: get_actionlint
+        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+        shell: bash
+      - name: Check workflow files
+        run: ${{ steps.get_actionlint.outputs.executable }} -color
+        shell: bash

--- a/.github/workflows/safety.yml
+++ b/.github/workflows/safety.yml
@@ -2,6 +2,7 @@
 # removed. Runs:
 # - address sanitizer - detects memory errors
 # - leak sanitizer - detects memory leaks
+# - miri - detects undefined behavior and memory leaks
 # See check.yml for information about how the concurrency cancellation and workflow triggering works
 permissions:
   contents: read

--- a/.github/workflows/safety.yml
+++ b/.github/workflows/safety.yml
@@ -62,7 +62,7 @@ jobs:
         with:
           submodules: true
       - run: |
-          echo "NIGHTLY=nightly-$(curl -s https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/miri)" >> $GITHUB_ENV
+          echo "NIGHTLY=nightly-$(curl -s https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/miri)" >> "$GITHUB_ENV"
       - name: Install ${{ env.NIGHTLY }}
         uses: dtolnay/rust-toolchain@master
         with:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,11 @@
 #![deny(missing_docs)]
 #![cfg_attr(test, feature(test))]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
-#![allow(clippy::zero_prefixed_literal, clippy::needless_range_loop)]
+#![allow(
+    clippy::too_long_first_doc_paragraph,
+    clippy::zero_prefixed_literal,
+    clippy::needless_range_loop
+)]
 
 #[cfg(test)]
 extern crate test;


### PR DESCRIPTION
This PR fixes a new clippy [lint](https://rust-lang.github.io/rust-clippy/master/index.html#/too_long_first_doc_paragraph) and adds a [job](https://github.com/rhysd/actionlint) to check the gh-workflows syntax