### PR TITLE
Add `rotate_about_center_no_crop` to prevent pixel loss during image rotations

### DIFF
--- a/src/geometric_transformations.rs
+++ b/src/geometric_transformations.rs
@@ -317,6 +317,56 @@ where
     warp(image, &projection, interpolation, default)
 }
 
+/// Rotates an image clockwise about its center, writing to a provided output.
+/// Output pixels whose pre-image lies outside the input image are set to `default`.
+pub fn rotate_about_center_into<P>(
+    image: &Image<P>,
+    theta: f32,
+    interpolation: Interpolation,
+    default: P,
+    out: &mut Image<P>,
+) where
+    P: Pixel + Send + Sync,
+    <P as Pixel>::Subpixel: Send + Sync,
+    <P as Pixel>::Subpixel: Into<f32> + Clamp<f32>,
+{
+    let (w, h) = image.dimensions();
+    let (ow, oh) = out.dimensions();
+    rotate_into(
+        image,
+        (w as f32 / 2.0, h as f32 / 2.0),
+        (ow as f32 / 2.0, oh as f32 / 2.0),
+        theta,
+        interpolation,
+        default,
+        out,
+    )
+}
+
+/// Rotates an image clockwise about the provided center by theta radians, writing to a provided output.
+/// Output pixels whose pre-image lies outside the input image are set to `default`.
+pub fn rotate_into<P>(
+    image: &Image<P>,
+    center: (f32, f32),
+    out_center: (f32, f32),
+    theta: f32,
+    interpolation: Interpolation,
+    default: P,
+    out: &mut Image<P>,
+) where
+    P: Pixel + Send + Sync,
+    <P as Pixel>::Subpixel: Send + Sync,
+    <P as Pixel>::Subpixel: Into<f32> + Clamp<f32>,
+{
+    let (cx, cy) = center;
+    let (ocx, ocy) = out_center;
+    let projection = Projection::translate(ocx, ocy)
+        * Projection::rotate(theta)
+        * Projection::translate(-cx, -cy);
+
+    warp_into(image, &projection, interpolation, default, out);
+}
+
 /// Rotates an image 90 degrees clockwise.
 ///
 /// # Examples

--- a/src/geometric_transformations.rs
+++ b/src/geometric_transformations.rs
@@ -317,6 +317,41 @@ where
     warp(image, &projection, interpolation, default)
 }
 
+/// Rotates an image clockwise about its center without cropping.
+/// The output image has dimensions calculated to fit the entire rotated image.
+/// Output pixels whose pre-image lies outside the input image are set to `default`.
+pub fn rotate_about_center_no_crop<P>(
+    image: &Image<P>,
+    theta: f32,
+    interpolation: Interpolation,
+    default: P,
+) -> Image<P> 
+where
+    P: Pixel + Send + Sync,
+    <P as Pixel>::Subpixel: Send + Sync,
+    <P as Pixel>::Subpixel: Into<f32> + Clamp<f32>,
+{
+    let (width, height) = image.dimensions();
+
+    let cos = theta.cos();
+    let sin = theta.sin();
+
+    let new_width = (height as f32 * sin.abs() + width as f32 * cos.abs()).ceil() as u32;
+    let new_height = (height as f32 * cos.abs() + width as f32 * sin.abs()).ceil() as u32;
+
+    let mut out_img = Image::new(new_width, new_height);
+
+    rotate_about_center_into(
+        image,
+        theta,
+        interpolation,
+        default,
+        &mut out_img,
+    );
+
+    out_img
+}
+
 /// Rotates an image clockwise about its center, writing to a provided output.
 /// Output pixels whose pre-image lies outside the input image are set to `default`.
 pub fn rotate_about_center_into<P>(

--- a/src/geometric_transformations.rs
+++ b/src/geometric_transformations.rs
@@ -325,7 +325,7 @@ pub fn rotate_about_center_no_crop<P>(
     theta: f32,
     interpolation: Interpolation,
     default: P,
-) -> Image<P> 
+) -> Image<P>
 where
     P: Pixel + Send + Sync,
     <P as Pixel>::Subpixel: Send + Sync,
@@ -341,13 +341,7 @@ where
 
     let mut out_img = Image::new(new_width, new_height);
 
-    rotate_about_center_into(
-        image,
-        theta,
-        interpolation,
-        default,
-        &mut out_img,
-    );
+    rotate_about_center_into(image, theta, interpolation, default, &mut out_img);
 
     out_img
 }


### PR DESCRIPTION
This PR introduces a new method, `rotate_about_center_no_crop`, that rotates an image about its center without cropping, ensuring no pixel data is lost in the process. The function calculates the new dimensions to fully accommodate the rotated image and fills any empty space outside the original image boundaries with a user-defined default pixel value.

To support this new method, two auxiliary functions are included:

1. `rotate_about_center_into`: Same as `rotate_about_center_into` except it writes the output to an image passed as a mutable reference. Dimensions of the input image and the output do not have to be the same.
2. `rotate_into`: Same as `rotate_into` except it writes the output to an image passed as a mutable reference. Dimensions of the input image and the output do not have to be the same.