### PR TITLE
Detailed error message for generic type parameter of find_contours_with_threshold (#694)

### DIFF
--- a/src/contours.rs
+++ b/src/contours.rs
@@ -147,8 +147,10 @@ where
                     let mut pos3 = curr;
 
                     loop {
-                        contour_points
-                            .push(Point::new(cast(pos3.x).unwrap(), cast(pos3.y).unwrap()));
+                        contour_points.push(Point::new(
+                            cast(pos3.x).expect("Generic Type Parameter T should be bigger than width."),
+                            cast(pos3.y).expect("Generic Type Parameter T should be bigger than height."),
+                        ));
                         rotate_to_value(&mut diffs, pos2.to_i32() - pos3.to_i32());
                         let pos4 = diffs
                             .iter()


### PR DESCRIPTION
Below code does not help developers in case of an error with the size set using generic type parameter:

`
contour_points.push(Point::new(cast(pos3.x).unwrap(), cast(pos3.y).unwrap()));
`

To help developers understand the error easily, code is updated with the error message like below:

`
contour_points.push(Point::new(
    cast(pos3.x).expect("Generic Type Parameter T should be bigger than width."),
    cast(pos3.y).expect("Generic Type Parameter T should be bigger than height."),
));
`