### PR TITLE
Lock the nightly channel for `clippy` action

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        toolchain: [nightly]
+        toolchain: [nightly-2024-11-15]
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
It fails for `2024-11-16` (new lint)