### PR TITLE
fix: correct text alpha blending

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -98,7 +98,7 @@ jobs:
     # https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability
     strategy:
       matrix:
-        msrv: ["1.80.1"] # Don't forget to update the `rust-version` in Cargo.toml as well
+        msrv: ["1.81.0"] # Don't forget to update the `rust-version` in Cargo.toml as well
     name: ubuntu / ${{ matrix.msrv }}
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ rand = { version = "0.8.5", default-features = false, features = [
     "std_rng",
 ] }
 rand_distr = { version = "0.4.3", default-features = false }
-rayon = { version = "1.8.0", optional = true, default-features = false }
+rayon = { version = "1.10.0", optional = true, default-features = false }
 sdl2 = { version = "0.36", optional = true, default-features = false, features = [
     "bundled",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,9 @@ homepage = "https://github.com/image-rs/imageproc"
 exclude = [".github/*", "examples/*", "tests/*"]
 
 [features]
-default = ["rayon"]
+default = ["rayon", "image/default"]
 display-window = ["sdl2"]
-rayon = ["dep:rayon"]
+rayon = ["dep:rayon", "image/rayon"]
 
 [dependencies]
 ab_glyph = { version = "0.2.23", default-features = false, features = ["std"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "imageproc"
-version = "0.26.0"
+version = "0.26.1"
 authors = ["theotherphil"]
 # note: when changed, also update `msrv` in `.github/workflows/check.yml`
-rust-version = "1.80.1"
+rust-version = "1.81.0"
 edition = "2021"
 license = "MIT"
 description = "Image processing operations"
@@ -13,14 +13,13 @@ homepage = "https://github.com/image-rs/imageproc"
 exclude = [".github/*", "examples/*", "tests/*"]
 
 [features]
-default = ["rayon", "image/default"]
+default = ["rayon"]
 display-window = ["sdl2"]
-rayon = ["dep:rayon", "image/rayon"]
+rayon = ["dep:rayon"]
 
 [dependencies]
 ab_glyph = { version = "0.2.23", default-features = false, features = ["std"] }
 approx = { version = "0.5", default-features = false }
-image = { version = "0.25.0", default-features = false }
 itertools = { version = "0.13.0", default-features = false, features = [
     "use_std",
 ] }
@@ -37,6 +36,7 @@ sdl2 = { version = "0.36", optional = true, default-features = false, features =
 ] }
 katexit = { version = "0.1.4", optional = true, default-features = false }
 rustdct = "0.7.1"
+image = "0.25.6"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", default-features = false, features = ["js"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ rayon = ["dep:rayon"]
 [dependencies]
 ab_glyph = { version = "0.2.23", default-features = false, features = ["std"] }
 approx = { version = "0.5", default-features = false }
+image = { version = "0.25.0", default-features = false }
 itertools = { version = "0.13.0", default-features = false, features = [
     "use_std",
 ] }
@@ -36,7 +37,6 @@ sdl2 = { version = "0.36", optional = true, default-features = false, features =
 ] }
 katexit = { version = "0.1.4", optional = true, default-features = false }
 rustdct = "0.7.1"
-image = "0.25.6"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", default-features = false, features = ["js"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ rayon = ["dep:rayon", "image/rayon"]
 [dependencies]
 ab_glyph = { version = "0.2.23", default-features = false, features = ["std"] }
 approx = { version = "0.5", default-features = false }
-image = { version = "0.25.0", default-features = false }
+image = { version = "0.25.6", default-features = false }
 itertools = { version = "0.13.0", default-features = false, features = [
     "use_std",
 ] }

--- a/src/contrast.rs
+++ b/src/contrast.rs
@@ -462,6 +462,7 @@ fn histogram_lut(source_histc: &[u32; 256], target_histc: &[u32; 256]) -> [usize
     lut
 }
 
+#[cfg(not(miri))]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/drawing/text.rs
+++ b/src/drawing/text.rs
@@ -88,10 +88,7 @@ pub fn draw_text_mut<C>(
     let image_width = canvas.width() as i32;
     let image_height = canvas.height() as i32;
 
-    let has_alpha = match C::Pixel::COLOR_MODEL {
-        "RGBA" | "YA" => true,
-        _ => false,
-    };
+    let has_alpha = matches!(C::Pixel::COLOR_MODEL, "RGBA" | "YA");
 
     layout_glyphs(scale, font, text, |g, bb| {
         let x_shift = x + bb.min.x.round() as i32;

--- a/src/template_matching.rs
+++ b/src/template_matching.rs
@@ -392,7 +392,7 @@ mod methods {
     }
 
     fn square_sum(input: &GrayImage) -> f32 {
-        input.iter().map(|&x| (x as f32 * x as f32)).sum()
+        input.iter().map(|&x| x as f32 * x as f32).sum()
     }
     fn mult_square_sum(a: &GrayImage, b: &GrayImage) -> f32 {
         a.iter()


### PR DESCRIPTION
## FIx draw text with alpha.

The previous version of the function added a white outline to the text. When attempting to render semi-transparent text (e.g., using alpha = 125), the text ended up cutting out the background instead of blending with it.


See the examples below:
— The top label is rendered using the old function.
— The bottom label shows the result after my changes.

<img width="512" height="512" alt="output_alpha_225_in_text" src="https://github.com/user-attachments/assets/b10e566f-6f24-455a-8c0e-96debb5fde29" />

- rgb alpha 255 text

---

<img width="512" height="512" alt="Frame 10" src="https://github.com/user-attachments/assets/f26b391d-8023-4ed0-9538-d7633cb3947a" />

- rgb alpha 125 text ( old function cuts the image )

---


<img width="512" height="512" alt="output_luma_alpha_225_in_text" src="https://github.com/user-attachments/assets/cc742d98-e7b1-47e2-914d-9ec6a86050a7" />

- luma alpha 225 text

---


<img width="512" height="512" alt="output_luma_alpha_125_in_text" src="https://github.com/user-attachments/assets/4e3a92f7-658d-4502-9630-4599d5b6bc9e" />

- luma alpha 125 text

---


Suggestions:

To compute a `has_alpha: bool` flag, I based my logic on [this](https://github.com/image-rs/image/blob/main/src/color.rs#L411).
It may be useful to expose this logic via `Pixel::has_alpha()` method inside the `image` crate
