### PR TITLE
Bilateral speedup

### DIFF
--- a/src/filter/bilateral.rs
+++ b/src/filter/bilateral.rs
@@ -20,10 +20,19 @@ pub struct GaussianEuclideanColorDistance {
     sigma_squared: f32,
 }
 impl GaussianEuclideanColorDistance {
-    /// Creates a new [`GaussianEuclideanColorDistance`] using a given sigma value.
+    /// Creates a new [`GaussianEuclideanColorDistance`] using a given sigma value, which
+    /// must be positive.
     ///
     /// Internally, this is stored as sigma squared for performance.
+    ///
+    /// # Panics
+    ///
+    /// 1. If `sigma <= 0`
     pub fn new(sigma: f32) -> Self {
+        assert!(
+            sigma > 0.0,
+            "GaussianEuclideanColorDistance sigma must be positive"
+        );
         GaussianEuclideanColorDistance {
             sigma_squared: sigma.powi(2),
         }
@@ -55,7 +64,7 @@ where
 /// * `radius` - The radius of the kernel used for the filtering. 0 -> 1x1, 1 -> 3x3, 2 -> 5x5, 3
 ///     -> 7x7, etc..
 /// * `spatial_sigma` - Standard deviation for euclidean spatial distance. A larger value results in
-///     averaging of pixels with larger spatial distances.
+///     averaging of pixels with larger spatial distances. Must be positive.
 /// * `color_distance` - A type which implements [`ColorDistance`]. This defines the metric used to
 ///     define how different two pixels are based on their colors. Common examples may include simple
 ///     absolute difference for greyscale pixels or cartesian distance in the CIE-Lab color space
@@ -77,6 +86,7 @@ where
 /// 2. If `image.height() > i32::MAX as u32`.
 /// 3. If `image.width() == 0`
 /// 4. If `image.height() == 0`
+/// 5. If `spatial_sigma <= 0`
 ///
 /// # Examples
 ///
@@ -112,6 +122,7 @@ where
     assert!(!image.height() > i32::MAX as u32);
     assert_ne!(image.width(), 0);
     assert_ne!(image.height(), 0);
+    assert!(spatial_sigma > 0.0, "spatial_sigma must be positive");
 
     let radius = i16::from(radius);
 
@@ -302,13 +313,16 @@ mod proptests {
     use image::Rgb;
     use proptest::prelude::*;
 
+    // Avoid small values which can cause NaNs in the filter calculations, which trigger assertions
+    const SIGMA_RANGE: std::ops::Range<f32> = 1e-12..1e32;
+
     proptest! {
         #[test]
         fn proptest_bilateral_filter_greyscale(
             img in arbitrary_image::<Luma<u8>>(1..40, 1..40),
             radius in 0..5u8,
-            color_sigma in any::<f32>(),
-            spatial_sigma in any::<f32>(),
+            color_sigma in SIGMA_RANGE,
+            spatial_sigma in SIGMA_RANGE,
         ) {
             let out = bilateral_filter(&img, radius, spatial_sigma, GaussianEuclideanColorDistance::new(color_sigma));
             prop_assert_eq!(out.dimensions(), img.dimensions());
@@ -318,8 +332,8 @@ mod proptests {
         fn proptest_bilateral_filter_rgb(
             img in arbitrary_image::<Rgb<u8>>(1..40, 1..40),
             radius in 0..5u8,
-            color_sigma in any::<f32>(),
-            spatial_sigma in any::<f32>(),
+            color_sigma in SIGMA_RANGE,
+            spatial_sigma in SIGMA_RANGE,
         ) {
             let out = bilateral_filter(&img, radius, spatial_sigma, GaussianEuclideanColorDistance::new(color_sigma));
             prop_assert_eq!(out.dimensions(), img.dimensions());

--- a/src/filter/bilateral.rs
+++ b/src/filter/bilateral.rs
@@ -194,6 +194,8 @@ fn gaussian_weight(x_squared: f32, sigma_squared: f32) -> f32 {
 /// Maximum relative error is ~4% in the range used by the bilateral filter.
 #[inline]
 fn fast_exp_negative(x: f32) -> f32 {
+    debug_assert!(x <= 0.0, "fast_exp_negative only valid for negative inputs");
+
     // 2^23 / ln(2) ≈ 12102203.0
     const A: f32 = 12102203.0;
     // 2^23 * 127 (IEEE 754 exponent bias), with Schraudolph's adjustment for reduced avg error

--- a/src/filter/bilateral.rs
+++ b/src/filter/bilateral.rs
@@ -1,7 +1,6 @@
 //! Bilateral Filter and associated items.
 
 use image::{GenericImage, Pixel};
-use itertools::Itertools;
 use num::cast::AsPrimitive;
 
 use crate::definitions::Image;
@@ -111,30 +110,31 @@ where
 
     let radius = i16::from(radius);
 
-    let window_range = -radius..=radius;
-    let spatial_distance_lookup = window_range
-        .clone()
-        .cartesian_product(window_range.clone())
-        .map(|(w_y, w_x)| {
-            //The gaussian of the euclidean spatial distance
-            gaussian_weight(
-                <f32 as From<i16>>::from(w_x).powi(2) + <f32 as From<i16>>::from(w_y).powi(2),
-                spatial_sigma.powi(2),
-            )
-        })
-        .collect_vec();
+    let spatial_sigma_squared = spatial_sigma.powi(2);
+    let mut spatial_distance_lookup =
+        Vec::with_capacity(((2 * radius + 1) * (2 * radius + 1)) as usize);
+    for w_y in -radius..=radius {
+        for w_x in -radius..=radius {
+            spatial_distance_lookup.push(gaussian_weight(
+                (w_x as f32).powi(2) + (w_y as f32).powi(2),
+                spatial_sigma_squared,
+            ));
+        }
+    }
 
     let (width, height) = image.dimensions();
+    let window_len = 2 * radius + 1;
+
     let bilateral_pixel_filter = |x, y| {
         debug_assert!(image.in_bounds(x, y));
         // Safety: `Image::from_fn` yields `col` in [0, width) and `row` in [0, height).
         let center_pixel = unsafe { image.unsafe_get_pixel(x, y) };
 
-        let window_len = 2 * radius + 1;
-        let weights_and_values = window_range
-            .clone()
-            .cartesian_product(window_range.clone())
-            .map(|(w_y, w_x)| {
+        let mut channel_sums = [0f32; 4];
+        let mut weight_sum = 0f32;
+
+        for w_y in -radius..=radius {
+            for w_x in -radius..=radius {
                 // these casts will always be correct due to asserts made at the beginning of the
                 // function about the image width/height
                 //
@@ -148,52 +148,28 @@ where
                 // Safety: we clamped `window_x` and `window_y` to be in bounds.
                 let window_pixel = unsafe { image.unsafe_get_pixel(window_x, window_y) };
 
-                let spatial_distance = spatial_distance_lookup
+                let spatial_weight = spatial_distance_lookup
                     [(window_len * (w_y + radius) + (w_x + radius)) as usize];
-                let color_distance = color_distance.color_distance(&center_pixel, &window_pixel);
-                let weight = spatial_distance * color_distance;
+                let color_weight = color_distance.color_distance(&center_pixel, &window_pixel);
+                let weight = spatial_weight * color_weight;
 
-                (weight, window_pixel)
-            });
+                weight_sum += weight;
+                for (i, c) in window_pixel.channels().iter().enumerate() {
+                    channel_sums[i] += weight * f32::from(*c);
+                }
+            }
+        }
 
-        weighted_average(weights_and_values)
+        let mut out_pixel = center_pixel;
+        let num_channels = P::CHANNEL_COUNT as usize;
+        let out_channels = out_pixel.channels_mut();
+        for i in 0..num_channels {
+            out_channels[i] = (channel_sums[i] / weight_sum).as_();
+        }
+        out_pixel
     };
 
     Image::from_fn(width, height, bilateral_pixel_filter)
-}
-
-fn weighted_average<P>(weights_and_values: impl Iterator<Item = (f32, P)>) -> P
-where
-    P: Pixel,
-    <P as image::Pixel>::Subpixel: 'static,
-    f32: From<P::Subpixel> + AsPrimitive<P::Subpixel>,
-{
-    let (weights_sum, weighted_channel_sums) = weights_and_values
-        .map(|(w, v)| {
-            (
-                w,
-                v.channels().iter().map(|s| w * f32::from(*s)).collect_vec(),
-            )
-        })
-        .reduce(|(w1, channels1), (w2, channels2)| {
-            (
-                w1 + w2,
-                channels1
-                    .into_iter()
-                    .zip_eq(channels2)
-                    .map(|(c1, c2)| c1 + c2)
-                    .collect_vec(),
-            )
-        })
-        .expect("cannot find a weighted average given no weights and values");
-
-    let channel_averages = weighted_channel_sums.iter().map(|x| x / weights_sum);
-
-    *P::from_slice(
-        &channel_averages
-            .map(<f32 as AsPrimitive<P::Subpixel>>::as_)
-            .collect_vec(),
-    )
 }
 
 /// Un-normalized Gaussian Weight

--- a/src/filter/bilateral.rs
+++ b/src/filter/bilateral.rs
@@ -185,17 +185,24 @@ fn gaussian_weight(x_squared: f32, sigma_squared: f32) -> f32 {
 /// Exploits the IEEE 754 float layout: reinterprets `a * x + b` as the bit pattern of an f32,
 /// where `a` and `b` are chosen so the exponent and mantissa fields approximate `exp(x)`.
 ///
-/// Valid for `x` in roughly `[-87, 0]`. Returns 0 for `x < -87` (where true exp underflows).
+/// Valid for negative values of `x`. Returns 0 for `x < -87` (where true exp underflows anyway).
 /// Maximum relative error is ~4% in the range used by the bilateral filter.
 #[inline]
 fn fast_exp_negative(x: f32) -> f32 {
-    if x < -87.0 {
-        return 0.0;
-    }
     // 2^23 / ln(2) ≈ 12102203.0
     const A: f32 = 12102203.0;
     // 2^23 * 127 (IEEE 754 exponent bias), with Schraudolph's adjustment for reduced avg error
     const B: f32 = 1065353216.0 - 486411.0;
+
+    // Casting explanation:
+    // - A * x + B is a positive float for x in [-87, 0], and fits in the positive range of i32.
+    // - x < -87 → A * x + B is negative but still fits in i32. `exp` underflows to 0, we clamp.
+    // - x << -87 → A * x + B exceeds i32::MIN but we saturate to i32::MIN per rust saturating-cast
+    //     rules, then clamp to 0.
+    // - x = -INF → A * x + B exceeds i32::MIN but we saturate to i32::MIN per rust saturating-cast
+    //     rules, then clamp to 0.
+    // - x = NaN → A * x + B is NaN, which saturates to 0 per rust saturating-cast rules, then
+    //     clamp to 0.
     let bits = ((A * x + B) as i32).max(0) as u32;
     f32::from_bits(bits)
 }
@@ -219,6 +226,63 @@ mod tests {
             6, 7, 7);
 
         assert_pixels_eq!(actual, expect);
+    }
+
+    /// Exhaustively walks every representable f32 in [-87.0, 0.0] using
+    /// `next_up`, comparing `fast_exp_negative(x)` against `x.exp()`.
+    /// Reports max/mean relative error and the x at which max occurs.
+    ///
+    /// ~1.12B iterations -> several seconds. Opt in with `cargo test -- --ignored`.
+    #[ignore = "exhaustive sweep over ~1.12B f32 values; run with --ignored"]
+    #[cfg_attr(miri, ignore = "slow")]
+    #[test]
+    fn fast_exp_negative_accuracy_sweep() {
+        let mut x = -87.0_f32;
+        let end = 0.0_f32;
+
+        let mut max_rel_err = 0.0_f32;
+        let mut max_rel_at = 0.0_f32;
+        let mut sum_rel_err = 0.0_f64; // f64 to avoid summation drift over 1B terms
+        let mut max_abs_err = 0.0_f32;
+        let mut count_rel: u64 = 0;
+        let mut count_total: u64 = 0;
+
+        while x <= end {
+            let approx = fast_exp_negative(x);
+            let truth = x.exp();
+            let abs_err = (approx - truth).abs();
+            if abs_err > max_abs_err {
+                max_abs_err = abs_err;
+            }
+            // Only score relative error where the true value is a normal float;
+            // in the subnormal tail near x = -87 both values collapse toward 0
+            // and relative error is not meaningful.
+            if truth >= f32::MIN_POSITIVE {
+                let rel = abs_err / truth;
+                if rel > max_rel_err {
+                    max_rel_err = rel;
+                    max_rel_at = x;
+                }
+                sum_rel_err += rel as f64;
+                count_rel += 1;
+            }
+            count_total += 1;
+            x = x.next_up();
+        }
+
+        let mean_rel_err = sum_rel_err / count_rel as f64;
+        println!(
+            "fast_exp_negative sweep: {count_total} samples ({count_rel} scored) \
+             max_rel_err={max_rel_err:e} at x={max_rel_at} \
+             mean_rel_err={mean_rel_err:e} max_abs_err={max_abs_err:e}"
+        );
+
+        // Schraudolph's bias-shifted approximation is documented at ~4% peak
+        // relative error. Allow a little headroom but catch real regressions.
+        assert!(
+            max_rel_err < 0.04,
+            "max relative error {max_rel_err} exceeded 4% threshold at x={max_rel_at}"
+        );
     }
 }
 

--- a/src/filter/bilateral.rs
+++ b/src/filter/bilateral.rs
@@ -43,7 +43,7 @@ where
             .map(|(c1, c2)| (f32::from(*c1) - f32::from(*c2)).powi(2))
             .sum::<f32>();
 
-        gaussian_weight(euclidean_distance_squared, self.sigma_squared)
+        fast_exp_negative(-0.5 * euclidean_distance_squared / self.sigma_squared)
     }
 }
 
@@ -175,6 +175,29 @@ where
 /// Un-normalized Gaussian Weight
 fn gaussian_weight(x_squared: f32, sigma_squared: f32) -> f32 {
     (-0.5 * x_squared / sigma_squared).exp()
+}
+
+/// Fast approximation of `exp(x)` for negative `x` using Schraudolph's method.
+///
+/// Based on: N. Schraudolph, "A Fast, Compact Approximation of the Exponential Function",
+/// Neural Computation 11(4), 1999.
+///
+/// Exploits the IEEE 754 float layout: reinterprets `a * x + b` as the bit pattern of an f32,
+/// where `a` and `b` are chosen so the exponent and mantissa fields approximate `exp(x)`.
+///
+/// Valid for `x` in roughly `[-87, 0]`. Returns 0 for `x < -87` (where true exp underflows).
+/// Maximum relative error is ~4% in the range used by the bilateral filter.
+#[inline]
+fn fast_exp_negative(x: f32) -> f32 {
+    if x < -87.0 {
+        return 0.0;
+    }
+    // 2^23 / ln(2) ≈ 12102203.0
+    const A: f32 = 12102203.0;
+    // 2^23 * 127 (IEEE 754 exponent bias), with Schraudolph's adjustment for reduced avg error
+    const B: f32 = 1065353216.0 - 486411.0;
+    let bits = ((A * x + B) as i32).max(0) as u32;
+    f32::from_bits(bits)
 }
 
 #[cfg(test)]

--- a/src/filter/bilateral.rs
+++ b/src/filter/bilateral.rs
@@ -103,6 +103,11 @@ where
     <P as image::Pixel>::Subpixel: 'static,
     f32: From<P::Subpixel> + AsPrimitive<P::Subpixel>,
 {
+    const MAX_CHANNELS: usize = 4;
+    assert!(
+        P::CHANNEL_COUNT as usize <= MAX_CHANNELS,
+        "bilateral_filter only supports up to 4 channel images"
+    );
     assert!(!image.width() > i32::MAX as u32);
     assert!(!image.height() > i32::MAX as u32);
     assert_ne!(image.width(), 0);
@@ -130,7 +135,7 @@ where
         // Safety: `Image::from_fn` yields `col` in [0, width) and `row` in [0, height).
         let center_pixel = unsafe { image.unsafe_get_pixel(x, y) };
 
-        let mut channel_sums = [0f32; 4];
+        let mut channel_sums = [0f32; MAX_CHANNELS];
         let mut weight_sum = 0f32;
 
         for w_y in -radius..=radius {


### PR DESCRIPTION
At \<dayjob\>  we noticed a pretty serious regression in performance in the bilateral filter when upgrading from 0.25 to 0.26. So I worked on speeding it up.

Not allocating more than necessary is by far the most significant improvement. The `cartesian_product` helper has some noticeable overhead (10s of ms). I also tried a well-known approximation for the `exp()`, I'm a little more skeptical of adding that one though. LMK

```
Baseline:
gray 500x500 r=5:
  median:   901.39ms  mean:   901.54ms  min:   900.65ms  max:   903.81ms
rgb  500x500 r=5:
  median:   939.59ms  mean:   940.08ms  min:   938.23ms  max:   942.73ms

Skip allocations and cartesian_product:
gray 500x500 r=5:
  median:   101.20ms  mean:   101.27ms  min:   101.12ms  max:   101.59ms
rgb  500x500 r=5:
  median:   155.27ms  mean:   155.30ms  min:   155.15ms  max:   155.53ms

exp approximation (+ previous optimizations)
gray 500x500 r=5:
  median:    74.99ms  mean:    75.01ms  min:    74.90ms  max:    75.14ms
rgb  500x500 r=5:
  median:   123.16ms  mean:   123.19ms  min:   122.96ms  max:   123.66ms
```


