### PR TITLE
Rework of filter boundary behaviour

### DIFF
--- a/examples/bilateral.rs
+++ b/examples/bilateral.rs
@@ -1,7 +1,10 @@
 use std::env;
 
 use image::open;
-use imageproc::filter::{bilateral::GaussianEuclideanColorDistance, bilateral_filter};
+use imageproc::{
+    filter::{bilateral::GaussianEuclideanColorDistance, bilateral_filter},
+    geometric_transformations::Border,
+};
 
 fn main() {
     if env::args().len() != 2 {
@@ -25,12 +28,14 @@ fn main() {
         radius,
         spatial_sigma,
         GaussianEuclideanColorDistance::new(color_sigma),
+        Border::Replicate,
     );
     let bilateral_color = bilateral_filter(
         &image_color,
         radius,
         spatial_sigma,
         GaussianEuclideanColorDistance::new(color_sigma),
+        Border::Replicate,
     );
 
     bilateral_grey.save("bilateral_grey.png").unwrap();

--- a/examples/gradients.rs
+++ b/examples/gradients.rs
@@ -7,6 +7,7 @@
 use image::{GrayImage, open};
 use imageproc::{
     filter::filter_clamped,
+    geometric_transformations::Border,
     kernel::{self, Kernel},
     map::map_subpixels,
 };
@@ -20,8 +21,8 @@ fn save_gradients(
     name: &str,
     scale: i16,
 ) {
-    let horizontal_gradients = filter_clamped(input, horizontal_kernel);
-    let vertical_gradients = filter_clamped(input, vertical_kernel);
+    let horizontal_gradients = filter_clamped(input, horizontal_kernel, Border::Replicate);
+    let vertical_gradients = filter_clamped(input, vertical_kernel, Border::Replicate);
 
     let horizontal_scaled = map_subpixels(&horizontal_gradients, |p: i16| (p.abs() / scale) as u8);
     let vertical_scaled = map_subpixels(&vertical_gradients, |p: i16| (p.abs() / scale) as u8);

--- a/examples/hog.rs
+++ b/examples/hog.rs
@@ -2,6 +2,7 @@
 
 use image::open;
 use imageproc::definitions::Image;
+use imageproc::geometric_transformations::Border;
 use imageproc::hog::*;
 use std::env;
 use std::path::Path;
@@ -43,7 +44,7 @@ fn create_hog_image(input: &Path, signed: bool) {
     cropped.save(input.with_file_name("cropped.png")).unwrap();
 
     let spec = HogSpec::from_options(cropped_width, cropped_height, opts).unwrap();
-    let mut hist = cell_histograms(&cropped, spec);
+    let mut hist = cell_histograms(&cropped, spec, Border::Replicate);
 
     let star_side = 20;
     let hog = render_hist_grid(star_side, &hist.view_mut(), signed);

--- a/examples/seam_carving.rs
+++ b/examples/seam_carving.rs
@@ -1,5 +1,6 @@
 use image::{GrayImage, Luma, Pixel, open};
 use imageproc::definitions::Clamp;
+use imageproc::geometric_transformations::Border;
 use imageproc::gradients::gradients;
 use imageproc::kernel;
 use imageproc::map::map_pixels;
@@ -64,6 +65,7 @@ fn main() {
         &input_image,
         kernel::SOBEL_HORIZONTAL_3X3,
         kernel::SOBEL_VERTICAL_3X3,
+        Border::Replicate,
         |p| {
             let mean = (p[0] + p[1] + p[2]) / 3;
             Luma([mean as u32])

--- a/src/definitions.rs
+++ b/src/definitions.rs
@@ -33,25 +33,23 @@ pub trait BoundaryAccess<P: Pixel> {
     /// Computes convolution with the specified horizontal kernel, accumulating into `acc`.
     /// The coordinate points to the location where the center of the kernel is matched.
     /// It is assumed that `acc` is filled with `K::zero()`.
-    /// It is assumed that `y` is within image bounds; no assumptions are made about `x`.
     fn convolve_horizontal_at<K: Copy + Num>(
         &self,
         kernel: &[K],
         acc: &mut [K],
         x: i64,
-        y: u32,
+        y: i64,
         extend: Border<P>,
     ) where
         P::Subpixel: Into<K>;
     /// Computes convolution with the specified vertical kernel, accumulating into `acc`.
     /// The coordinate points to the location where the center of the kernel is matched.
     /// It is assumed that `acc` is filled with `K::zero()`.
-    /// It is assumed that `x` is within image bounds; no assumptions are made about `y`.
     fn convolve_vertical_at<K: Copy + Num>(
         &self,
         kernel: &[K],
         acc: &mut [K],
-        x: u32,
+        x: i64,
         y: i64,
         extend: Border<P>,
     ) where
@@ -174,93 +172,6 @@ impl<P: Pixel, I: GenericImageView<Pixel = P>> BoundaryAccess<P> for I {
         kernel: &[K],
         acc: &mut [K],
         x: i64,
-        y: u32,
-        extend: Border<P>,
-    ) where
-        P::Subpixel: Into<K>,
-    {
-        fn accumulate<P: Pixel, K: Copy + Num>(acc: &mut [K], pixel: &P, weight: K)
-        where
-            P::Subpixel: Into<K>,
-        {
-            acc.iter_mut().zip(pixel.channels()).for_each(|(a, &c)| {
-                *a = *a + c.into() * weight;
-            });
-        }
-        let w = self.width() as i64;
-        let k_width = kernel.len() as i64;
-        let x = x - k_width / 2;
-        let check_left = x < 0;
-        let check_right = x + k_width >= w;
-        match extend {
-            Border::Constant(default) => {
-                let k_x_min = (x.max(0) - x) as usize;
-                let k_x_max = ((x + k_width).min(w) - x).max(0) as usize;
-                for k_x in 0..k_x_min {
-                    accumulate(acc, &default, kernel[k_x]);
-                }
-                // pixels intersecting with the kernel
-                for k_x in k_x_min..k_x_max {
-                    let pixel = unsafe { self.unsafe_get_pixel((x + k_x as i64) as u32, y) };
-                    accumulate(acc, &pixel, kernel[k_x]);
-                }
-                for k_x in k_x_max..k_width as usize {
-                    accumulate(acc, &default, kernel[k_x]);
-                }
-            }
-            Border::Replicate => match (check_left, check_right) {
-                (false, false) => {
-                    for (k_x, &k) in kernel.iter().enumerate() {
-                        let x_p = (x + k_x as i64) as u32;
-                        let pixel = unsafe { self.unsafe_get_pixel(x_p, y) };
-                        accumulate(acc, &pixel, k);
-                    }
-                }
-                (false, true) => {
-                    for (k_x, &k) in kernel.iter().enumerate() {
-                        let x_p = (x + k_x as i64).min(w - 1) as u32;
-                        let pixel = unsafe { self.unsafe_get_pixel(x_p, y) };
-                        accumulate(acc, &pixel, k);
-                    }
-                }
-                (true, false) => {
-                    for (k_x, &k) in kernel.iter().enumerate() {
-                        let x_p = (x + k_x as i64).max(0) as u32;
-                        let pixel = unsafe { self.unsafe_get_pixel(x_p, y) };
-                        accumulate(acc, &pixel, k);
-                    }
-                }
-                (true, true) => {
-                    for (k_x, &k) in kernel.iter().enumerate() {
-                        let x_p = (x + k_x as i64).clamp(0, w - 1) as u32;
-                        let pixel = unsafe { self.unsafe_get_pixel(x_p, y) };
-                        accumulate(acc, &pixel, k);
-                    }
-                }
-            },
-            Border::Wrap => match (check_left, check_right) {
-                (false, false) => {
-                    for (k_x, &k) in kernel.iter().enumerate() {
-                        let x_p = (x + k_x as i64) as u32;
-                        let pixel = unsafe { self.unsafe_get_pixel(x_p, y) };
-                        accumulate(acc, &pixel, k);
-                    }
-                }
-                _ => {
-                    for (k_x, &k) in kernel.iter().enumerate() {
-                        let x_p = (x + k_x as i64).rem_euclid(w) as u32;
-                        let pixel = unsafe { self.unsafe_get_pixel(x_p, y) };
-                        accumulate(acc, &pixel, k);
-                    }
-                }
-            },
-        }
-    }
-    fn convolve_vertical_at<K: Copy + Num>(
-        &self,
-        kernel: &[K],
-        acc: &mut [K],
-        x: u32,
         y: i64,
         extend: Border<P>,
     ) where
@@ -274,73 +185,188 @@ impl<P: Pixel, I: GenericImageView<Pixel = P>> BoundaryAccess<P> for I {
                 *a = *a + c.into() * weight;
             });
         }
-        let h = self.height() as i64;
+        let (w, h) = self.dimensions();
+        let (w, h) = (w as i64, h as i64);
+        let k_width = kernel.len() as i64;
+        let x = x - k_width / 2;
+        let check_left = x < 0;
+        let check_right = x + k_width >= w;
+        match extend {
+            Border::Constant(default) => {
+                if (0..h).contains(&y) {
+                    let k_x_min = (x.max(0) - x) as usize;
+                    let k_x_max = ((x + k_width).min(w) - x).max(0) as usize;
+                    for k_x in 0..k_x_min {
+                        accumulate(acc, &default, kernel[k_x]);
+                    }
+                    // pixels intersecting with the kernel
+                    for k_x in k_x_min..k_x_max {
+                        let pixel =
+                            unsafe { self.unsafe_get_pixel((x + k_x as i64) as u32, y as u32) };
+                        accumulate(acc, &pixel, kernel[k_x]);
+                    }
+                    for k_x in k_x_max..k_width as usize {
+                        accumulate(acc, &default, kernel[k_x]);
+                    }
+                } else {
+                    for k_x in 0..k_width as usize {
+                        accumulate(acc, &default, kernel[k_x]);
+                    }
+                }
+            }
+            Border::Replicate => {
+                let y = y.clamp(0, h - 1) as u32;
+                match (check_left, check_right) {
+                    (false, false) => {
+                        for (k_x, &k) in kernel.iter().enumerate() {
+                            let x_p = (x + k_x as i64) as u32;
+                            let pixel = unsafe { self.unsafe_get_pixel(x_p, y) };
+                            accumulate(acc, &pixel, k);
+                        }
+                    }
+                    (false, true) => {
+                        for (k_x, &k) in kernel.iter().enumerate() {
+                            let x_p = (x + k_x as i64).min(w - 1) as u32;
+                            let pixel = unsafe { self.unsafe_get_pixel(x_p, y) };
+                            accumulate(acc, &pixel, k);
+                        }
+                    }
+                    (true, false) => {
+                        for (k_x, &k) in kernel.iter().enumerate() {
+                            let x_p = (x + k_x as i64).max(0) as u32;
+                            let pixel = unsafe { self.unsafe_get_pixel(x_p, y) };
+                            accumulate(acc, &pixel, k);
+                        }
+                    }
+                    (true, true) => {
+                        for (k_x, &k) in kernel.iter().enumerate() {
+                            let x_p = (x + k_x as i64).clamp(0, w - 1) as u32;
+                            let pixel = unsafe { self.unsafe_get_pixel(x_p, y) };
+                            accumulate(acc, &pixel, k);
+                        }
+                    }
+                }
+            }
+            Border::Wrap => {
+                let y = y.rem_euclid(h) as u32;
+                match (check_left, check_right) {
+                    (false, false) => {
+                        for (k_x, &k) in kernel.iter().enumerate() {
+                            let x_p = (x + k_x as i64) as u32;
+                            let pixel = unsafe { self.unsafe_get_pixel(x_p, y) };
+                            accumulate(acc, &pixel, k);
+                        }
+                    }
+                    _ => {
+                        for (k_x, &k) in kernel.iter().enumerate() {
+                            let x_p = (x + k_x as i64).rem_euclid(w) as u32;
+                            let pixel = unsafe { self.unsafe_get_pixel(x_p, y) };
+                            accumulate(acc, &pixel, k);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    fn convolve_vertical_at<K: Copy + Num>(
+        &self,
+        kernel: &[K],
+        acc: &mut [K],
+        x: i64,
+        y: i64,
+        extend: Border<P>,
+    ) where
+        P::Subpixel: Into<K>,
+    {
+        fn accumulate<P: Pixel, K: Copy + Num>(acc: &mut [K], pixel: &P, weight: K)
+        where
+            P::Subpixel: Into<K>,
+        {
+            acc.iter_mut().zip(pixel.channels()).for_each(|(a, &c)| {
+                *a = *a + c.into() * weight;
+            });
+        }
+        let (w, h) = self.dimensions();
+        let (w, h) = (w as i64, h as i64);
         let k_height = kernel.len() as i64;
         let y = y - k_height / 2;
         let check_up = y < 0;
         let check_down = y + k_height >= h;
         match extend {
             Border::Constant(default) => {
-                let k_y_min = (y.max(0) - y) as usize;
-                let k_y_max = ((y + k_height).min(h) - y).max(0) as usize;
-                for k_y in 0..k_y_min {
-                    accumulate(acc, &default, kernel[k_y]);
-                }
-                // pixels intersecting with the kernel
-                for k_y in k_y_min..k_y_max {
-                    let pixel = unsafe { self.unsafe_get_pixel(x, (y + k_y as i64) as u32) };
-                    accumulate(acc, &pixel, kernel[k_y]);
-                }
-                for k_y in k_y_max..k_height as usize {
-                    accumulate(acc, &default, kernel[k_y]);
+                if (0..w).contains(&x) {
+                    let k_y_min = (y.max(0) - y) as usize;
+                    let k_y_max = ((y + k_height).min(h) - y).max(0) as usize;
+                    for k_y in 0..k_y_min {
+                        accumulate(acc, &default, kernel[k_y]);
+                    }
+                    // pixels intersecting with the kernel
+                    for k_y in k_y_min..k_y_max {
+                        let pixel =
+                            unsafe { self.unsafe_get_pixel(x as u32, (y + k_y as i64) as u32) };
+                        accumulate(acc, &pixel, kernel[k_y]);
+                    }
+                    for k_y in k_y_max..k_height as usize {
+                        accumulate(acc, &default, kernel[k_y]);
+                    }
+                } else {
+                    for k_y in 0..k_height as usize {
+                        accumulate(acc, &default, kernel[k_y]);
+                    }
                 }
             }
-            Border::Replicate => match (check_up, check_down) {
-                (false, false) => {
-                    for (k_y, &k) in kernel.iter().enumerate() {
-                        let y_p = (y + k_y as i64) as u32;
-                        let pixel = unsafe { self.unsafe_get_pixel(x, y_p) };
-                        accumulate(acc, &pixel, k);
+            Border::Replicate => {
+                let x = x.clamp(0, w - 1) as u32;
+                match (check_up, check_down) {
+                    (false, false) => {
+                        for (k_y, &k) in kernel.iter().enumerate() {
+                            let y_p = (y + k_y as i64) as u32;
+                            let pixel = unsafe { self.unsafe_get_pixel(x, y_p) };
+                            accumulate(acc, &pixel, k);
+                        }
+                    }
+                    (false, true) => {
+                        for (k_y, &k) in kernel.iter().enumerate() {
+                            let y_p = (y + k_y as i64).min(h - 1) as u32;
+                            let pixel = unsafe { self.unsafe_get_pixel(x, y_p) };
+                            accumulate(acc, &pixel, k);
+                        }
+                    }
+                    (true, false) => {
+                        for (k_y, &k) in kernel.iter().enumerate() {
+                            let y_p = (y + k_y as i64).max(0) as u32;
+                            let pixel = unsafe { self.unsafe_get_pixel(x, y_p) };
+                            accumulate(acc, &pixel, k);
+                        }
+                    }
+                    (true, true) => {
+                        for (k_y, &k) in kernel.iter().enumerate() {
+                            let y_p = (y + k_y as i64).clamp(0, h - 1) as u32;
+                            let pixel = unsafe { self.unsafe_get_pixel(x, y_p) };
+                            accumulate(acc, &pixel, k);
+                        }
                     }
                 }
-                (false, true) => {
-                    for (k_y, &k) in kernel.iter().enumerate() {
-                        let y_p = (y + k_y as i64).min(h - 1) as u32;
-                        let pixel = unsafe { self.unsafe_get_pixel(x, y_p) };
-                        accumulate(acc, &pixel, k);
+            }
+            Border::Wrap => {
+                let x = x.rem_euclid(w) as u32;
+                match (check_up, check_down) {
+                    (false, false) => {
+                        for (k_y, &k) in kernel.iter().enumerate() {
+                            let y_p = (y + k_y as i64) as u32;
+                            let pixel = unsafe { self.unsafe_get_pixel(x, y_p) };
+                            accumulate(acc, &pixel, k);
+                        }
+                    }
+                    _ => {
+                        for (k_y, &k) in kernel.iter().enumerate() {
+                            let y_p = (y + k_y as i64).rem_euclid(h) as u32;
+                            let pixel = unsafe { self.unsafe_get_pixel(x, y_p) };
+                            accumulate(acc, &pixel, k);
+                        }
                     }
                 }
-                (true, false) => {
-                    for (k_y, &k) in kernel.iter().enumerate() {
-                        let y_p = (y + k_y as i64).max(0) as u32;
-                        let pixel = unsafe { self.unsafe_get_pixel(x, y_p) };
-                        accumulate(acc, &pixel, k);
-                    }
-                }
-                (true, true) => {
-                    for (k_y, &k) in kernel.iter().enumerate() {
-                        let y_p = (y + k_y as i64).clamp(0, h - 1) as u32;
-                        let pixel = unsafe { self.unsafe_get_pixel(x, y_p) };
-                        accumulate(acc, &pixel, k);
-                    }
-                }
-            },
-            Border::Wrap => match (check_up, check_down) {
-                (false, false) => {
-                    for (k_y, &k) in kernel.iter().enumerate() {
-                        let y_p = (y + k_y as i64) as u32;
-                        let pixel = unsafe { self.unsafe_get_pixel(x, y_p) };
-                        accumulate(acc, &pixel, k);
-                    }
-                }
-                _ => {
-                    for (k_y, &k) in kernel.iter().enumerate() {
-                        let y_p = (y + k_y as i64).rem_euclid(h) as u32;
-                        let pixel = unsafe { self.unsafe_get_pixel(x, y_p) };
-                        accumulate(acc, &pixel, k);
-                    }
-                }
-            },
+            }
         }
     }
 }

--- a/src/definitions.rs
+++ b/src/definitions.rs
@@ -65,18 +65,18 @@ impl<P: Pixel> BoundaryAccess<P> for Image<P> {
                 if x < 0 || x >= w as i64 || y < 0 || y >= h as i64 {
                     default
                 } else {
-                    *self.get_pixel(x as u32, y as u32)
+                    unsafe { self.unsafe_get_pixel(x as u32, y as u32) }
                 }
             }
             Border::Replicate => {
                 let x = x.clamp(0, w as i64 - 1) as u32;
                 let y = y.clamp(0, h as i64 - 1) as u32;
-                *self.get_pixel(x, y)
+                unsafe { self.unsafe_get_pixel(x, y) }
             }
             Border::Wrap => {
                 let x = x.rem_euclid(w as i64) as u32;
                 let y = y.rem_euclid(h as i64) as u32;
-                *self.get_pixel(x, y)
+                unsafe { self.unsafe_get_pixel(x, y) }
             }
         }
     }

--- a/src/definitions.rs
+++ b/src/definitions.rs
@@ -1,7 +1,9 @@
 //! Trait definitions and type aliases.
 
 use crate::geometric_transformations::Border;
-use image::{ImageBuffer, Luma, LumaA, Pixel, Rgb, Rgba};
+use crate::kernel::Kernel;
+use image::{GenericImageView, ImageBuffer, Luma, LumaA, Pixel, Rgb, Rgba};
+use num::Num;
 
 /// An `ImageBuffer` containing Pixels of type P with storage `Vec<P::Subpixel>`.
 /// Most operations in this library only support inputs of type `Image`, rather
@@ -16,6 +18,44 @@ pub type Image<P> = ImageBuffer<P, Vec<<P as Pixel>::Subpixel>>;
 pub trait BoundaryAccess<P: Pixel> {
     /// Returns the pixel or falls back to the implementation defined by [`Border`].
     fn get_pixel_or_extend(&self, x: i64, y: i64, extend: Border<P>) -> P;
+    /// Computes convolution with the specified kernel, accumulating into `acc`.
+    /// The coordinate points to the location where the center of the kernel is matched.
+    /// It is assumed that `acc` is filled with `K::zero()`.
+    fn convolve_at<K: Copy + Num>(
+        &self,
+        kernel: Kernel<K>,
+        acc: &mut [K],
+        x: i64,
+        y: i64,
+        extend: Border<P>,
+    ) where
+        P::Subpixel: Into<K>;
+    /// Computes convolution with the specified horizontal kernel, accumulating into `acc`.
+    /// The coordinate points to the location where the center of the kernel is matched.
+    /// It is assumed that `acc` is filled with `K::zero()`.
+    /// It is assumed that `y` is within image bounds; no assumptions are made about `x`.
+    fn convolve_horizontal_at<K: Copy + Num>(
+        &self,
+        kernel: &[K],
+        acc: &mut [K],
+        x: i64,
+        y: u32,
+        extend: Border<P>,
+    ) where
+        P::Subpixel: Into<K>;
+    /// Computes convolution with the specified vertical kernel, accumulating into `acc`.
+    /// The coordinate points to the location where the center of the kernel is matched.
+    /// It is assumed that `acc` is filled with `K::zero()`.
+    /// It is assumed that `x` is within image bounds; no assumptions are made about `y`.
+    fn convolve_vertical_at<K: Copy + Num>(
+        &self,
+        kernel: &[K],
+        acc: &mut [K],
+        x: u32,
+        y: i64,
+        extend: Border<P>,
+    ) where
+        P::Subpixel: Into<K>;
 }
 impl<P: Pixel> BoundaryAccess<P> for Image<P> {
     fn get_pixel_or_extend(&self, x: i64, y: i64, extend: Border<P>) -> P {
@@ -38,6 +78,269 @@ impl<P: Pixel> BoundaryAccess<P> for Image<P> {
                 let y = y.rem_euclid(h as i64) as u32;
                 *self.get_pixel(x, y)
             }
+        }
+    }
+    fn convolve_at<K: Copy + Num>(
+        &self,
+        kernel: Kernel<K>,
+        acc: &mut [K],
+        x: i64,
+        y: i64,
+        extend: Border<P>,
+    ) where
+        P::Subpixel: Into<K>,
+    {
+        fn accumulate<P: Pixel, K: Copy + Num>(acc: &mut [K], pixel: &P, weight: K)
+        where
+            P::Subpixel: Into<K>,
+        {
+            acc.iter_mut().zip(pixel.channels()).for_each(|(a, &c)| {
+                *a = *a + c.into() * weight;
+            });
+        }
+        let (w, h) = self.dimensions();
+        let (w, h) = (w as i64, h as i64);
+        let (k_width, k_height) = (kernel.width as i64, kernel.height as i64);
+        let (x, y) = (x - k_width / 2, y - k_height / 2);
+        match extend {
+            Border::Constant(default) => {
+                let k_y_min = y.max(0) - y;
+                let k_y_max = (y + k_height).min(h) - y;
+                let k_x_min = x.max(0) - x;
+                let k_x_max = (x + k_width).min(w) - x;
+                for k_y in 0..k_y_min {
+                    for k_x in 0..k_width {
+                        accumulate(acc, &default, unsafe {
+                            kernel.get_unchecked(k_x as u32, k_y as u32)
+                        });
+                    }
+                }
+                for k_y in k_y_min..k_y_max {
+                    for k_x in 0..k_x_min {
+                        accumulate(acc, &default, unsafe {
+                            kernel.get_unchecked(k_x as u32, k_y as u32)
+                        });
+                    }
+                    // pixels intersecting with the kernel
+                    for k_x in k_x_min..k_x_max {
+                        let pixel =
+                            unsafe { self.unsafe_get_pixel((x + k_x) as u32, (y + k_y) as u32) };
+                        accumulate(acc, &pixel, unsafe {
+                            kernel.get_unchecked(k_x as u32, k_y as u32)
+                        });
+                    }
+                    for k_x in k_x_max..k_width {
+                        accumulate(acc, &default, unsafe {
+                            kernel.get_unchecked(k_x as u32, k_y as u32)
+                        });
+                    }
+                }
+                for k_y in k_y_max..k_height {
+                    for k_x in 0..k_width {
+                        accumulate(acc, &default, unsafe {
+                            kernel.get_unchecked(k_x as u32, k_y as u32)
+                        });
+                    }
+                }
+            }
+            Border::Replicate => {
+                for k_y in 0..k_height {
+                    let y_p = (y + k_y).clamp(0, h - 1) as u32;
+                    for k_x in 0..k_width {
+                        let x_p = (x + k_x).clamp(0, w - 1) as u32;
+                        let pixel = unsafe { self.unsafe_get_pixel(x_p, y_p) };
+                        accumulate(acc, &pixel, unsafe {
+                            kernel.get_unchecked(k_x as u32, k_y as u32)
+                        });
+                    }
+                }
+            }
+            Border::Wrap => {
+                for k_y in 0..k_height {
+                    let y_p = (y + k_y).rem_euclid(h) as u32;
+                    for k_x in 0..k_width {
+                        let x_p = (x + k_x).rem_euclid(w) as u32;
+                        let pixel = unsafe { self.unsafe_get_pixel(x_p, y_p) };
+                        accumulate(acc, &pixel, unsafe {
+                            kernel.get_unchecked(k_x as u32, k_y as u32)
+                        });
+                    }
+                }
+            }
+        }
+    }
+    fn convolve_horizontal_at<K: Copy + Num>(
+        &self,
+        kernel: &[K],
+        acc: &mut [K],
+        x: i64,
+        y: u32,
+        extend: Border<P>,
+    ) where
+        P::Subpixel: Into<K>,
+    {
+        fn accumulate<P: Pixel, K: Copy + Num>(acc: &mut [K], pixel: &P, weight: K)
+        where
+            P::Subpixel: Into<K>,
+        {
+            acc.iter_mut().zip(pixel.channels()).for_each(|(a, &c)| {
+                *a = *a + c.into() * weight;
+            });
+        }
+        let w = self.width() as i64;
+        let k_width = kernel.len() as i64;
+        let x = x - k_width / 2;
+        let check_left = x < 0;
+        let check_right = x + k_width >= w;
+        match extend {
+            Border::Constant(default) => {
+                let k_x_min = (x.max(0) - x) as usize;
+                let k_x_max = ((x + k_width).min(w) - x) as usize;
+                for k_x in 0..k_x_min {
+                    accumulate(acc, &default, kernel[k_x]);
+                }
+                // pixels intersecting with the kernel
+                for k_x in k_x_min..k_x_max {
+                    let pixel = unsafe { self.unsafe_get_pixel((x + k_x as i64) as u32, y) };
+                    accumulate(acc, &pixel, kernel[k_x]);
+                }
+                for k_x in k_x_max..k_width as usize {
+                    accumulate(acc, &default, kernel[k_x]);
+                }
+            }
+            Border::Replicate => match (check_left, check_right) {
+                (false, false) => {
+                    for (k_x, &k) in kernel.iter().enumerate() {
+                        let x_p = (x + k_x as i64) as u32;
+                        let pixel = unsafe { self.unsafe_get_pixel(x_p, y) };
+                        accumulate(acc, &pixel, k);
+                    }
+                }
+                (false, true) => {
+                    for (k_x, &k) in kernel.iter().enumerate() {
+                        let x_p = (x + k_x as i64).min(w - 1) as u32;
+                        let pixel = unsafe { self.unsafe_get_pixel(x_p, y) };
+                        accumulate(acc, &pixel, k);
+                    }
+                }
+                (true, false) => {
+                    for (k_x, &k) in kernel.iter().enumerate() {
+                        let x_p = (x + k_x as i64).max(0) as u32;
+                        let pixel = unsafe { self.unsafe_get_pixel(x_p, y) };
+                        accumulate(acc, &pixel, k);
+                    }
+                }
+                (true, true) => {
+                    for (k_x, &k) in kernel.iter().enumerate() {
+                        let x_p = (x + k_x as i64).clamp(0, w - 1) as u32;
+                        let pixel = unsafe { self.unsafe_get_pixel(x_p, y) };
+                        accumulate(acc, &pixel, k);
+                    }
+                }
+            },
+            Border::Wrap => match (check_left, check_right) {
+                (false, false) => {
+                    for (k_x, &k) in kernel.iter().enumerate() {
+                        let x_p = (x + k_x as i64) as u32;
+                        let pixel = unsafe { self.unsafe_get_pixel(x_p, y) };
+                        accumulate(acc, &pixel, k);
+                    }
+                }
+                _ => {
+                    for (k_x, &k) in kernel.iter().enumerate() {
+                        let x_p = (x + k_x as i64).rem_euclid(w) as u32;
+                        let pixel = unsafe { self.unsafe_get_pixel(x_p, y) };
+                        accumulate(acc, &pixel, k);
+                    }
+                }
+            },
+        }
+    }
+    fn convolve_vertical_at<K: Copy + Num>(
+        &self,
+        kernel: &[K],
+        acc: &mut [K],
+        x: u32,
+        y: i64,
+        extend: Border<P>,
+    ) where
+        P::Subpixel: Into<K>,
+    {
+        fn accumulate<P: Pixel, K: Copy + Num>(acc: &mut [K], pixel: &P, weight: K)
+        where
+            P::Subpixel: Into<K>,
+        {
+            acc.iter_mut().zip(pixel.channels()).for_each(|(a, &c)| {
+                *a = *a + c.into() * weight;
+            });
+        }
+        let h = self.height() as i64;
+        let k_height = kernel.len() as i64;
+        let y = y - k_height / 2;
+        let check_up = y < 0;
+        let check_down = y + k_height >= h;
+        match extend {
+            Border::Constant(default) => {
+                let k_y_min = (y.max(0) - y) as usize;
+                let k_y_max = ((y + k_height).min(h) - y) as usize;
+                for k_y in 0..k_y_min {
+                    accumulate(acc, &default, kernel[k_y]);
+                }
+                // pixels intersecting with the kernel
+                for k_y in k_y_min..k_y_max {
+                    let pixel = unsafe { self.unsafe_get_pixel(x, (y + k_y as i64) as u32) };
+                    accumulate(acc, &pixel, kernel[k_y]);
+                }
+                for k_y in k_y_max..k_height as usize {
+                    accumulate(acc, &default, kernel[k_y]);
+                }
+            }
+            Border::Replicate => match (check_up, check_down) {
+                (false, false) => {
+                    for (k_y, &k) in kernel.iter().enumerate() {
+                        let y_p = (y + k_y as i64) as u32;
+                        let pixel = unsafe { self.unsafe_get_pixel(x, y_p) };
+                        accumulate(acc, &pixel, k);
+                    }
+                }
+                (false, true) => {
+                    for (k_y, &k) in kernel.iter().enumerate() {
+                        let y_p = (y + k_y as i64).min(h - 1) as u32;
+                        let pixel = unsafe { self.unsafe_get_pixel(x, y_p) };
+                        accumulate(acc, &pixel, k);
+                    }
+                }
+                (true, false) => {
+                    for (k_y, &k) in kernel.iter().enumerate() {
+                        let y_p = (y + k_y as i64).max(0) as u32;
+                        let pixel = unsafe { self.unsafe_get_pixel(x, y_p) };
+                        accumulate(acc, &pixel, k);
+                    }
+                }
+                (true, true) => {
+                    for (k_y, &k) in kernel.iter().enumerate() {
+                        let y_p = (y + k_y as i64).clamp(0, h - 1) as u32;
+                        let pixel = unsafe { self.unsafe_get_pixel(x, y_p) };
+                        accumulate(acc, &pixel, k);
+                    }
+                }
+            },
+            Border::Wrap => match (check_up, check_down) {
+                (false, false) => {
+                    for (k_y, &k) in kernel.iter().enumerate() {
+                        let y_p = (y + k_y as i64) as u32;
+                        let pixel = unsafe { self.unsafe_get_pixel(x, y_p) };
+                        accumulate(acc, &pixel, k);
+                    }
+                }
+                _ => {
+                    for (k_y, &k) in kernel.iter().enumerate() {
+                        let y_p = (y + k_y as i64).rem_euclid(h) as u32;
+                        let pixel = unsafe { self.unsafe_get_pixel(x, y_p) };
+                        accumulate(acc, &pixel, k);
+                    }
+                }
+            },
         }
     }
 }

--- a/src/definitions.rs
+++ b/src/definitions.rs
@@ -105,9 +105,9 @@ impl<P: Pixel> BoundaryAccess<P> for Image<P> {
         match extend {
             Border::Constant(default) => {
                 let k_y_min = y.max(0) - y;
-                let k_y_max = (y + k_height).min(h) - y;
+                let k_y_max = ((y + k_height).min(h) - y).max(0);
                 let k_x_min = x.max(0) - x;
-                let k_x_max = (x + k_width).min(w) - x;
+                let k_x_max = ((x + k_width).min(w) - x).max(0);
                 for k_y in 0..k_y_min {
                     for k_x in 0..k_width {
                         accumulate(acc, &default, unsafe {
@@ -195,7 +195,7 @@ impl<P: Pixel> BoundaryAccess<P> for Image<P> {
         match extend {
             Border::Constant(default) => {
                 let k_x_min = (x.max(0) - x) as usize;
-                let k_x_max = ((x + k_width).min(w) - x) as usize;
+                let k_x_max = ((x + k_width).min(w) - x).max(0) as usize;
                 for k_x in 0..k_x_min {
                     accumulate(acc, &default, kernel[k_x]);
                 }
@@ -282,7 +282,7 @@ impl<P: Pixel> BoundaryAccess<P> for Image<P> {
         match extend {
             Border::Constant(default) => {
                 let k_y_min = (y.max(0) - y) as usize;
-                let k_y_max = ((y + k_height).min(h) - y) as usize;
+                let k_y_max = ((y + k_height).min(h) - y).max(0) as usize;
                 for k_y in 0..k_y_min {
                     accumulate(acc, &default, kernel[k_y]);
                 }

--- a/src/definitions.rs
+++ b/src/definitions.rs
@@ -57,7 +57,7 @@ pub trait BoundaryAccess<P: Pixel> {
     ) where
         P::Subpixel: Into<K>;
 }
-impl<P: Pixel> BoundaryAccess<P> for Image<P> {
+impl<P: Pixel, I: GenericImageView<Pixel = P>> BoundaryAccess<P> for I {
     fn get_pixel_or_extend(&self, x: i64, y: i64, extend: Border<P>) -> P {
         let (w, h) = self.dimensions();
         match extend {

--- a/src/edges.rs
+++ b/src/edges.rs
@@ -2,6 +2,7 @@
 
 use crate::definitions::{HasBlack, HasWhite, Image};
 use crate::filter::{filter_clamped, gaussian_blur_f32};
+use crate::geometric_transformations::Border;
 use crate::kernel::{self};
 use image::{GenericImageView, GrayImage, Luma};
 use std::f32;
@@ -32,11 +33,11 @@ pub fn canny(image: &GrayImage, low_threshold: f32, high_threshold: f32) -> Gray
     // Heavily based on the implementation proposed by wikipedia.
     // 1. Gaussian blur.
     const SIGMA: f32 = 1.4;
-    let blurred = gaussian_blur_f32(image, SIGMA);
+    let blurred = gaussian_blur_f32(image, SIGMA, Border::Replicate);
 
     // 2. Intensity of gradients.
-    let gx = filter_clamped(&blurred, kernel::SOBEL_HORIZONTAL_3X3);
-    let gy = filter_clamped(&blurred, kernel::SOBEL_VERTICAL_3X3);
+    let gx = filter_clamped(&blurred, kernel::SOBEL_HORIZONTAL_3X3, Border::Replicate);
+    let gy = filter_clamped(&blurred, kernel::SOBEL_VERTICAL_3X3, Border::Replicate);
     let g: Vec<f32> = gx
         .iter()
         .zip(gy.iter())

--- a/src/filter/bilateral.rs
+++ b/src/filter/bilateral.rs
@@ -62,6 +62,7 @@ where
 ///     define how different two pixels are based on their colors. Common examples may include simple
 ///     absolute difference for greyscale pixels or cartesian distance in the CIE-Lab color space
 ///     \[1\].
+/// * `extend` - Enum specifying how to sample pixels outside of image boundaries.
 ///
 /// This filter averages pixels based on their spatial distance as well as their color
 /// distance. Spatial distance is measured by the Gaussian function of the Euclidean distance

--- a/src/filter/bilateral.rs
+++ b/src/filter/bilateral.rs
@@ -4,7 +4,8 @@ use image::{GenericImage, Pixel};
 use itertools::Itertools;
 use num::cast::AsPrimitive;
 
-use crate::definitions::Image;
+use crate::definitions::{BoundaryAccess, Image};
+use crate::geometric_transformations::Border;
 
 /// A trait which provides a distance metric between two pixels based on their colors.
 ///
@@ -83,11 +84,12 @@ where
 ///
 /// ```
 /// use imageproc::filter::bilateral::{bilateral_filter, GaussianEuclideanColorDistance};
+/// use imageproc::geometric_transformations::Border;
 /// use imageproc::utils::gray_bench_image;
 ///
 /// let image = gray_bench_image(50, 50);
 ///
-/// let filtered = bilateral_filter(&image, 2, 3., GaussianEuclideanColorDistance::new(10.0));
+/// let filtered = bilateral_filter(&image, 2, 3., GaussianEuclideanColorDistance::new(10.0), Border::Replicate);
 /// ```
 #[must_use = "the function does not modify the original image"]
 #[allow(clippy::doc_overindented_list_items)]
@@ -96,6 +98,7 @@ pub fn bilateral_filter<I, P, C>(
     radius: u8,
     spatial_sigma: f32,
     color_distance: C,
+    extend: Border<P>,
 ) -> Image<P>
 where
     I: GenericImage<Pixel = P>,
@@ -135,18 +138,8 @@ where
             .clone()
             .cartesian_product(window_range.clone())
             .map(|(w_y, w_x)| {
-                // these casts will always be correct due to asserts made at the beginning of the
-                // function about the image width/height
-                //
-                // the subtraction will also never overflow due to the `is_empty()` assert
-                let window_y = (i32::from(w_y) + (y as i32)).clamp(0, (height as i32) - 1);
-                let window_x = (i32::from(w_x) + (x as i32)).clamp(0, (width as i32) - 1);
-
-                let (window_y, window_x) = (window_y as u32, window_x as u32);
-
-                debug_assert!(image.in_bounds(window_x, window_y));
-                // Safety: we clamped `window_x` and `window_y` to be in bounds.
-                let window_pixel = unsafe { image.unsafe_get_pixel(window_x, window_y) };
+                let window_pixel =
+                    image.get_pixel_or_extend(x as i64 + w_x as i64, y as i64 + w_y as i64, extend);
 
                 let spatial_distance = spatial_distance_lookup
                     [(window_len * (w_y + radius) + (w_x + radius)) as usize];
@@ -212,7 +205,13 @@ mod tests {
             1, 2, 3;
             4, 5, 6;
             7, 8, 9);
-        let actual = bilateral_filter(&image, 1, 3.0, GaussianEuclideanColorDistance::new(10.0));
+        let actual = bilateral_filter(
+            &image,
+            1,
+            3.0,
+            GaussianEuclideanColorDistance::new(10.0),
+            Border::Replicate,
+        );
 
         let expect = gray_image!(
             2, 2, 3;
@@ -240,7 +239,7 @@ mod proptests {
             color_sigma in any::<f32>(),
             spatial_sigma in any::<f32>(),
         ) {
-            let out = bilateral_filter(&img, radius, spatial_sigma, GaussianEuclideanColorDistance::new(color_sigma));
+            let out = bilateral_filter(&img, radius, spatial_sigma, GaussianEuclideanColorDistance::new(color_sigma), Border::Replicate);
             prop_assert_eq!(out.dimensions(), img.dimensions());
         }
 
@@ -251,7 +250,7 @@ mod proptests {
             color_sigma in any::<f32>(),
             spatial_sigma in any::<f32>(),
         ) {
-            let out = bilateral_filter(&img, radius, spatial_sigma, GaussianEuclideanColorDistance::new(color_sigma));
+            let out = bilateral_filter(&img, radius, spatial_sigma, GaussianEuclideanColorDistance::new(color_sigma), Border::Replicate);
             prop_assert_eq!(out.dimensions(), img.dimensions());
         }
     }
@@ -268,8 +267,13 @@ mod benches {
     fn bench_bilateral_filter_greyscale(b: &mut Bencher) {
         let image = gray_bench_image(100, 100);
         b.iter(|| {
-            let filtered =
-                bilateral_filter(&image, 5, 3., GaussianEuclideanColorDistance::new(10.0));
+            let filtered = bilateral_filter(
+                &image,
+                5,
+                3.,
+                GaussianEuclideanColorDistance::new(10.0),
+                Border::Replicate,
+            );
             black_box(filtered);
         });
     }
@@ -278,8 +282,13 @@ mod benches {
     fn bench_bilateral_filter_rgb(b: &mut Bencher) {
         let image = rgb_bench_image(100, 100);
         b.iter(|| {
-            let filtered =
-                bilateral_filter(&image, 5, 3., GaussianEuclideanColorDistance::new(10.0));
+            let filtered = bilateral_filter(
+                &image,
+                5,
+                3.,
+                GaussianEuclideanColorDistance::new(10.0),
+                Border::Replicate,
+            );
             black_box(filtered);
         });
     }

--- a/src/filter/box_filter.rs
+++ b/src/filter/box_filter.rs
@@ -9,8 +9,7 @@ use crate::integral_image::{column_running_sum, row_running_sum};
 /// sum to one. i.e. each output pixel is the unweighted mean of
 /// a rectangular region surrounding its corresponding input pixel.
 /// We handle locations where the kernel would extend past the image's
-/// boundary by treating the image as if its boundary pixels were
-/// repeated indefinitely.
+/// boundary according to `extend`.
 // TODO: for small kernels we probably want to do the convolution
 // TODO: directly instead of using an integral image.
 // TODO: more formats!

--- a/src/filter/box_filter.rs
+++ b/src/filter/box_filter.rs
@@ -1,9 +1,8 @@
 use image::{GenericImage, GenericImageView, GrayImage, Luma};
 
-use crate::{
-    definitions::Image,
-    integral_image::{column_running_sum, row_running_sum},
-};
+use crate::definitions::Image;
+use crate::geometric_transformations::Border;
+use crate::integral_image::{column_running_sum, row_running_sum};
 
 /// Convolves an 8bpp grayscale image with a kernel of width (2 * `x_radius` + 1)
 /// and height (2 * `y_radius` + 1) whose entries are equal and
@@ -16,7 +15,12 @@ use crate::{
 // TODO: directly instead of using an integral image.
 // TODO: more formats!
 #[must_use = "the function does not modify the original image"]
-pub fn box_filter(image: &GrayImage, x_radius: u32, y_radius: u32) -> Image<Luma<u8>> {
+pub fn box_filter(
+    image: &GrayImage,
+    x_radius: u32,
+    y_radius: u32,
+    extend: Border<Luma<u8>>,
+) -> Image<Luma<u8>> {
     let (width, height) = image.dimensions();
     let mut out = Image::new(width, height);
     if width == 0 || height == 0 {
@@ -28,7 +32,7 @@ pub fn box_filter(image: &GrayImage, x_radius: u32, y_radius: u32) -> Image<Luma
 
     let mut row_buffer = vec![0; (width + 2 * x_radius) as usize];
     for y in 0..height {
-        row_running_sum(image, y, &mut row_buffer, x_radius);
+        row_running_sum(image, y, &mut row_buffer, x_radius, extend);
         let val = row_buffer[(2 * x_radius) as usize] / kernel_width;
         unsafe {
             debug_assert!(out.in_bounds(0, y));
@@ -49,7 +53,7 @@ pub fn box_filter(image: &GrayImage, x_radius: u32, y_radius: u32) -> Image<Luma
 
     let mut col_buffer = vec![0; (height + 2 * y_radius) as usize];
     for x in 0..width {
-        column_running_sum(&out, x, &mut col_buffer, y_radius);
+        column_running_sum(&out, x, &mut col_buffer, y_radius, extend);
         let val = col_buffer[(2 * y_radius) as usize] / kernel_height;
         unsafe {
             debug_assert!(out.in_bounds(x, 0));
@@ -76,9 +80,9 @@ mod tests {
 
     #[test]
     fn test_box_filter_handles_empty_images() {
-        let _ = box_filter(&GrayImage::new(0, 0), 3, 3);
-        let _ = box_filter(&GrayImage::new(1, 0), 3, 3);
-        let _ = box_filter(&GrayImage::new(0, 1), 3, 3);
+        let _ = box_filter(&GrayImage::new(0, 0), 3, 3, Border::Replicate);
+        let _ = box_filter(&GrayImage::new(1, 0), 3, 3, Border::Replicate);
+        let _ = box_filter(&GrayImage::new(0, 1), 3, 3, Border::Replicate);
     }
 
     #[test]
@@ -97,7 +101,7 @@ mod tests {
             4, 5, 5;
             6, 7, 7);
 
-        assert_pixels_eq!(box_filter(&image, 1, 1), expected);
+        assert_pixels_eq!(box_filter(&image, 1, 1, Border::Replicate), expected);
     }
 }
 
@@ -115,7 +119,7 @@ mod proptests {
             x_radius in 0..100u32,
             y_radius in 0..100u32,
         ) {
-            let out = box_filter(&img, x_radius, y_radius);
+            let out = box_filter(&img, x_radius, y_radius, Border::Replicate);
             prop_assert_eq!(out.dimensions(), img.dimensions());
         }
     }
@@ -132,7 +136,7 @@ mod benches {
     fn bench_box_filter(b: &mut Bencher) {
         let image = gray_bench_image(500, 500);
         b.iter(|| {
-            let filtered = box_filter(&image, 7, 7);
+            let filtered = box_filter(&image, 7, 7, Border::Replicate);
             black_box(filtered);
         });
     }

--- a/src/filter/median.rs
+++ b/src/filter/median.rs
@@ -5,7 +5,8 @@ use image::Pixel;
 /// Applies a median filter of given dimensions to an image. Each output pixel is the median
 /// of the pixels in a `(2 * x_radius + 1) * (2 * y_radius + 1)` kernel of pixels in the input image.
 ///
-/// Pads by continuity. Performs O(max(x_radius, y_radius)) operations per pixel.
+/// Sampling outside of image boundaries is controlled by `extend`.
+/// Performs O(max(x_radius, y_radius)) operations per pixel.
 ///
 /// # Examples
 /// ```
@@ -34,6 +35,9 @@ use image::Pixel;
 /// //   9 |   9   100    11 |  11
 /// //      -----------------
 /// //   9     9   100    11    11
+/// //
+/// // Here we choose `Border<P>` corresponding to it:
+/// let extend = Border::Replicate;
 ///
 /// let filtered = gray_image!(
 ///     2,  3,  3;
@@ -41,7 +45,7 @@ use image::Pixel;
 ///     9, 11, 11
 /// );
 ///
-/// assert_pixels_eq!(median_filter(&image, 1, 1, Border::Replicate), filtered);
+/// assert_pixels_eq!(median_filter(&image, 1, 1, extend), filtered);
 /// # }
 /// ```
 ///
@@ -323,7 +327,7 @@ impl HistSet {
         }
     }
 
-    /// Safety: requires pixel.channels.len() <= self.data.len()
+    /// Safety: requires P::CHANNEL_COUNT <= self.data.len()
     unsafe fn incr<P: Pixel<Subpixel = u8>>(&mut self, pixel: P) {
         let channels = pixel.channels();
         unsafe {
@@ -335,7 +339,7 @@ impl HistSet {
         }
     }
 
-    /// Safety: requires pixel.channels.len() <= self.data.len()
+    /// Safety: requires P::CHANNEL_COUNT <= self.data.len()
     unsafe fn decr<P: Pixel<Subpixel = u8>>(&mut self, pixel: P) {
         let channels = pixel.channels();
         unsafe {
@@ -347,7 +351,7 @@ impl HistSet {
         }
     }
 
-    /// Safety: requires pixel.channels.len() <= self.data.len()
+    /// Safety: requires P::CHANNEL_COUNT <= self.data.len()
     unsafe fn set_to_median<P: Pixel<Subpixel = u8>>(&self, pixel: &mut P) {
         let channels = pixel.channels_mut();
         unsafe {

--- a/src/filter/median.rs
+++ b/src/filter/median.rs
@@ -1,6 +1,6 @@
-use crate::definitions::Image;
-use image::{GenericImageView, Pixel};
-use std::cmp::{max, min};
+use crate::definitions::{BoundaryAccess, Image};
+use crate::geometric_transformations::Border;
+use image::Pixel;
 
 /// Applies a median filter of given dimensions to an image. Each output pixel is the median
 /// of the pixels in a `(2 * x_radius + 1) * (2 * y_radius + 1)` kernel of pixels in the input image.
@@ -14,6 +14,7 @@ use std::cmp::{max, min};
 /// # extern crate imageproc;
 /// # fn main() {
 /// use imageproc::filter::median_filter;
+/// use imageproc::geometric_transformations::Border;
 ///
 /// let image = gray_image!(
 ///     1,   2,   3;
@@ -40,7 +41,7 @@ use std::cmp::{max, min};
 ///     9, 11, 11
 /// );
 ///
-/// assert_pixels_eq!(median_filter(&image, 1, 1), filtered);
+/// assert_pixels_eq!(median_filter(&image, 1, 1, Border::Replicate), filtered);
 /// # }
 /// ```
 ///
@@ -50,6 +51,7 @@ use std::cmp::{max, min};
 /// # extern crate imageproc;
 /// # fn main() {
 /// use imageproc::filter::median_filter;
+/// use imageproc::geometric_transformations::Border;
 ///
 /// // Image channels are handled independently.
 /// // This example sets the red channel to have the same
@@ -72,7 +74,7 @@ use std::cmp::{max, min};
 ///     [ 9,  2, 10], [11,  3, 10], [11,  3, 10]
 /// );
 ///
-/// assert_pixels_eq!(median_filter(&image, 1, 1), filtered);
+/// assert_pixels_eq!(median_filter(&image, 1, 1, Border::Replicate), filtered);
 /// # }
 /// ```
 ///
@@ -82,6 +84,7 @@ use std::cmp::{max, min};
 /// # extern crate imageproc;
 /// # fn main() {
 /// use imageproc::filter::median_filter;
+/// use imageproc::geometric_transformations::Border;
 ///
 /// // This example uses a kernel with x_radius sets to 2
 /// // and y_radius sets to 1, which leads to 5 * 3 kernel size.
@@ -102,11 +105,16 @@ use std::cmp::{max, min};
 ///     15, 15, 21, 45, 45
 /// );
 ///
-/// assert_pixels_eq!(median_filter(&image, 2, 1), filtered);
+/// assert_pixels_eq!(median_filter(&image, 2, 1, Border::Replicate), filtered);
 /// # }
 /// ```
 #[must_use = "the function does not modify the original image"]
-pub fn median_filter<P>(image: &Image<P>, x_radius: u32, y_radius: u32) -> Image<P>
+pub fn median_filter<P>(
+    image: &Image<P>,
+    x_radius: u32,
+    y_radius: u32,
+    extend: Border<P>,
+) -> Image<P>
 where
     P: Pixel<Subpixel = u8>,
 {
@@ -123,16 +131,16 @@ where
     }
 
     let mut out = Image::<P>::new(width, height);
-    let mut hist = initialise_histogram_for_top_left_pixel(image, x_radius, y_radius);
-    slide_down_column(&mut hist, image, &mut out, 0, x_radius, y_radius);
+    let mut hist = initialise_histogram_for_top_left_pixel(image, x_radius, y_radius, extend);
+    slide_down_column(&mut hist, image, &mut out, 0, x_radius, y_radius, extend);
 
     for x in 1..width {
         if x % 2 == 0 {
-            slide_right(&mut hist, image, x, 0, x_radius, y_radius);
-            slide_down_column(&mut hist, image, &mut out, x, x_radius, y_radius);
+            slide_right(&mut hist, image, x, 0, x_radius, y_radius, extend);
+            slide_down_column(&mut hist, image, &mut out, x, x_radius, y_radius, extend);
         } else {
-            slide_right(&mut hist, image, x, height - 1, x_radius, y_radius);
-            slide_up_column(&mut hist, image, &mut out, x, x_radius, y_radius);
+            slide_right(&mut hist, image, x, height - 1, x_radius, y_radius, extend);
+            slide_up_column(&mut hist, image, &mut out, x, x_radius, y_radius, extend);
         }
     }
     out
@@ -142,30 +150,23 @@ fn initialise_histogram_for_top_left_pixel<P>(
     image: &Image<P>,
     x_radius: u32,
     y_radius: u32,
+    extend: Border<P>,
 ) -> HistSet
 where
     P: Pixel<Subpixel = u8>,
 {
-    let (width, height) = image.dimensions();
-
     let kernel_size = (2 * x_radius + 1) * (2 * y_radius + 1);
     let num_channels = P::CHANNEL_COUNT;
 
     let mut hist = HistSet::new(num_channels, kernel_size);
-    let rx = x_radius as i32;
-    let ry = y_radius as i32;
+    let rx = x_radius as i64;
+    let ry = y_radius as i64;
 
     for dy in -ry..(ry + 1) {
-        // Safety note: 0 <= py <= height - 1
-        let py = min(max(0, dy), height as i32 - 1) as u32;
-
         for dx in -rx..(rx + 1) {
-            // Safety note: 0 <= px <= width - 1
-            let px = min(max(0, dx), width as i32 - 1) as u32;
-
-            // Safety: px and py are in bounds as explained in the 'Safety note' comments above
+            let pixel = image.get_pixel_or_extend(dx, dy, extend);
             unsafe {
-                hist.incr(image, px, py);
+                hist.incr(pixel);
             }
         }
     }
@@ -173,36 +174,35 @@ where
     hist
 }
 
-fn slide_right<P>(hist: &mut HistSet, image: &Image<P>, x: u32, y: u32, rx: u32, ry: u32)
-where
+fn slide_right<P>(
+    hist: &mut HistSet,
+    image: &Image<P>,
+    x: u32,
+    y: u32,
+    rx: u32,
+    ry: u32,
+    extend: Border<P>,
+) where
     P: Pixel<Subpixel = u8>,
 {
-    let (width, height) = image.dimensions();
+    let rx = rx as i64;
+    let ry = ry as i64;
 
-    // Safety note: unchecked indexing below relies on x and y being in bounds
-    assert!(x < width);
-    assert!(y < height);
-
-    // Safety note: rx and ry are both >= 0 by construction
-    let rx = rx as i32;
-    let ry = ry as i32;
-
-    // Safety note: 0 <= prev_x < width - rx - 1 < width
-    let prev_x = max(0, x as i32 - rx - 1) as u32;
-    // Safety note: 0 <= x + rx <= next_x <= width - 1
-    let next_x = min(x as i32 + rx, width as i32 - 1) as u32;
+    let prev_x = x as i64 - rx - 1;
+    let next_x = x as i64 + rx;
 
     for dy in -ry..(ry + 1) {
-        // Safety note: 0 <= py <= height - 1
-        let py = min(max(0, y as i32 + dy), (height - 1) as i32) as u32;
+        let py = y as i64 + dy;
 
-        // Safety: prev_x and py are in bounds based on the 'Safety note' comments above
+        let prev_pixel = image.get_pixel_or_extend(prev_x, py, extend);
+        // Safety: hist.data.len() == P::CHANNEL_COUNT by construction
         unsafe {
-            hist.decr(image, prev_x, py);
+            hist.decr(prev_pixel);
         }
-        // Safety: next_x and py are in bounds based on the 'Safety note' comments above
+        let next_pixel = image.get_pixel_or_extend(next_x, py, extend);
+        // Safety: hist.data.len() == P::CHANNEL_COUNT by construction
         unsafe {
-            hist.incr(image, next_x, py);
+            hist.incr(next_pixel);
         }
     }
 }
@@ -214,47 +214,43 @@ fn slide_down_column<P>(
     x: u32,
     rx: u32,
     ry: u32,
+    extend: Border<P>,
 ) where
     P: Pixel<Subpixel = u8>,
 {
-    let (width, height) = image.dimensions();
-
-    // Safety note: unchecked indexing below relies on x being in bounds
-    assert!(x < width);
-
-    // Safety note: rx and ry are both >= 0 by construction
-    let rx = rx as i32;
-    let ry = ry as i32;
+    let rx = rx as i64;
+    let ry = ry as i64;
 
     // Safety: hist.data.len() == P::CHANNEL_COUNT by construction
     unsafe {
-        hist.set_to_median(out, x, 0);
+        let pixel = out.get_pixel_mut(x, 0);
+        hist.set_to_median(pixel);
     }
 
-    for y in 1..height {
-        // Safety note: 0 <= prev_y < height - ry - 1 < height
-        let prev_y = max(0, y as i32 - ry - 1) as u32;
-        // Safety note: 0 < 1 + ry <= next_y < height
-        let next_y = min(y as i32 + ry, height as i32 - 1) as u32;
+    for y in 1..image.height() {
+        let prev_y = y as i64 - ry - 1;
+        let next_y = y as i64 + ry;
 
         for dx in -rx..(rx + 1) {
-            // Safety note: 0 <= px < width
-            let px = min(max(0, x as i32 + dx), (width - 1) as i32) as u32;
+            let px = x as i64 + dx;
 
-            // Safety: px and prev_y are in bounds based on the 'Safety note' comments above
+            let prev_pixel = image.get_pixel_or_extend(px, prev_y, extend);
+            // Safety: hist.data.len() == P::CHANNEL_COUNT by construction
             unsafe {
-                hist.decr(image, px, prev_y);
+                hist.decr(prev_pixel);
             }
 
-            // Safety: px and next_y are in bounds based on the 'Safety note' comments above
+            let next_pixel = image.get_pixel_or_extend(px, next_y, extend);
+            // Safety: hist.data.len() == P::CHANNEL_COUNT by construction
             unsafe {
-                hist.incr(image, px, next_y);
+                hist.incr(next_pixel);
             }
         }
 
         // Safety: hist.data.len() == P::CHANNEL_COUNT by construction
         unsafe {
-            hist.set_to_median(out, x, y);
+            let pixel = out.get_pixel_mut(x, y);
+            hist.set_to_median(pixel);
         }
     }
 }
@@ -266,46 +262,44 @@ fn slide_up_column<P>(
     x: u32,
     rx: u32,
     ry: u32,
+    extend: Border<P>,
 ) where
     P: Pixel<Subpixel = u8>,
 {
-    let (width, height) = image.dimensions();
+    let height = image.height();
 
-    // Safety note: unchecked indexing below relies on x being in bounds
-    assert!(x < width);
-
-    // Safety note: rx and ry are both >= 0 by construction
-    let rx = rx as i32;
-    let ry = ry as i32;
+    let rx = rx as i64;
+    let ry = ry as i64;
 
     // Safety: hist.data.len() == P::CHANNEL_COUNT by construction
     unsafe {
-        hist.set_to_median(out, x, height - 1);
+        let pixel = out.get_pixel_mut(x, height - 1);
+        hist.set_to_median(pixel);
     }
 
     for y in (0..(height - 1)).rev() {
-        // Safety note: 0 < ry + 1 <= prev_y <= height - 1
-        let prev_y = min(y as i32 + ry + 1, height as i32 - 1) as u32;
-        // Safety note: 0 <= next_y < height - 1 - ry < height
-        let next_y = max(0, y as i32 - ry) as u32;
+        let prev_y = y as i64 + ry + 1;
+        let next_y = y as i64 - ry;
 
         for dx in -rx..(rx + 1) {
-            // Safety note: 0 <= px <= width - 1
-            let px = min(max(0, x as i32 + dx), (width - 1) as i32) as u32;
+            let px = x as i64 + dx;
 
-            // Safety: px and prev_y are in bounds based on the 'Safety note' comments above
+            let prev_pixel = image.get_pixel_or_extend(px, prev_y, extend);
+            // Safety: hist.data.len() == P::CHANNEL_COUNT by construction
             unsafe {
-                hist.decr(image, px, prev_y);
+                hist.decr(prev_pixel);
             }
-            // Safety: px and next_y are in bounds based on the 'Safety note' comments above
+            let next_pixel = image.get_pixel_or_extend(px, next_y, extend);
+            // Safety: hist.data.len() == P::CHANNEL_COUNT by construction
             unsafe {
-                hist.incr(image, px, next_y);
+                hist.incr(next_pixel);
             }
         }
 
         // Safety: hist.data.len() == P::CHANNEL_COUNT by construction
         unsafe {
-            hist.set_to_median(out, x, y);
+            let pixel = out.get_pixel_mut(x, y);
+            hist.set_to_median(pixel);
         }
     }
 }
@@ -324,19 +318,15 @@ struct HistSet {
 impl HistSet {
     fn new(num_channels: u8, expected_count: u32) -> HistSet {
         HistSet {
-            data: vec![[0u32; 256]; num_channels.into()],
+            data: vec![[0u32; 256]; num_channels as usize],
             expected_count,
         }
     }
 
-    /// Safety: requires x and y to be within image bounds and P::CHANNEL_COUNT <= self.data.len()
-    unsafe fn incr<P>(&mut self, image: &Image<P>, x: u32, y: u32)
-    where
-        P: Pixel<Subpixel = u8>,
-    {
+    /// Safety: requires pixel.channels.len() <= self.data.len()
+    unsafe fn incr<P: Pixel<Subpixel = u8>>(&mut self, pixel: P) {
+        let channels = pixel.channels();
         unsafe {
-            let pixel = image.unsafe_get_pixel(x, y);
-            let channels = pixel.channels();
             for c in 0..channels.len() {
                 let p = *channels.get_unchecked(c) as usize;
                 let hist = self.data.get_unchecked_mut(c);
@@ -345,14 +335,10 @@ impl HistSet {
         }
     }
 
-    /// Safety: requires x and y to be within image bounds and P::CHANNEL_COUNT <= self.data.len()
-    unsafe fn decr<P>(&mut self, image: &Image<P>, x: u32, y: u32)
-    where
-        P: Pixel<Subpixel = u8>,
-    {
+    /// Safety: requires pixel.channels.len() <= self.data.len()
+    unsafe fn decr<P: Pixel<Subpixel = u8>>(&mut self, pixel: P) {
+        let channels = pixel.channels();
         unsafe {
-            let pixel = image.unsafe_get_pixel(x, y);
-            let channels = pixel.channels();
             for c in 0..channels.len() {
                 let p = *channels.get_unchecked(c) as usize;
                 let hist = self.data.get_unchecked_mut(c);
@@ -361,14 +347,10 @@ impl HistSet {
         }
     }
 
-    /// Safety: requires P::CHANNEL_COUNT <= self.data.len()
-    unsafe fn set_to_median<P>(&self, image: &mut Image<P>, x: u32, y: u32)
-    where
-        P: Pixel<Subpixel = u8>,
-    {
+    /// Safety: requires pixel.channels.len() <= self.data.len()
+    unsafe fn set_to_median<P: Pixel<Subpixel = u8>>(&self, pixel: &mut P) {
+        let channels = pixel.channels_mut();
         unsafe {
-            let target = image.get_pixel_mut(x, y);
-            let channels = target.channels_mut();
             for c in 0..channels.len() {
                 *channels.get_unchecked_mut(c) = self.channel_median(c as u8);
             }
@@ -404,7 +386,7 @@ mod benches {
             fn $name(b: &mut Bencher) {
                 let image = gray_bench_image($s, $s);
                 b.iter(|| {
-                    let filtered = median_filter(&image, $rx, $ry);
+                    let filtered = median_filter(&image, $rx, $ry, Border::Replicate);
                     black_box(filtered);
                 })
             }
@@ -482,7 +464,7 @@ mod proptests {
         #[test]
         fn test_median_filter_matches_reference_implementation(image in arbitrary_image::<Luma<u8>>(0..10, 0..10), x_radius in 0_u32..5, y_radius in 0_u32..5) {
             let expected = reference_median_filter(&image, x_radius, y_radius);
-            let actual = median_filter(&image, x_radius, y_radius);
+            let actual = median_filter(&image, x_radius, y_radius, Border::Replicate);
 
             prop_assert_eq!(actual, expected);
         }

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -11,14 +11,14 @@ pub use self::sharpen::*;
 mod box_filter;
 pub use self::box_filter::box_filter;
 
-use image::{GenericImageView, GrayImage, Luma, Pixel, Primitive};
+use image::{GrayImage, Luma, Pixel, Primitive};
 
-use crate::definitions::{Clamp, Image};
+use crate::definitions::{BoundaryAccess, Clamp, Image};
+use crate::geometric_transformations::Border;
 use crate::kernel::{self, Kernel};
 use crate::map::{ChannelMap, WithChannel};
 use num::Num;
 
-use std::cmp::{max, min};
 use std::f32;
 
 /// Returns 2d correlation of an image. Intermediate calculations are performed
@@ -41,23 +41,12 @@ where
     let (width, height) = image.dimensions();
     let mut out = Image::<Q>::new(width, height);
     let mut acc = vec![zero; num_channels];
-    let (k_width, k_height) = (kernel.width as i64, kernel.height as i64);
     let (width, height) = (width as i64, height as i64);
+    let extend = Border::<P>::Replicate;
 
     for y in 0..height {
         for x in 0..width {
-            for k_y in 0..k_height {
-                let y_p = min(height - 1, max(0, y + k_y - k_height / 2)) as u32;
-                for k_x in 0..k_width {
-                    let x_p = min(width - 1, max(0, x + k_x - k_width / 2)) as u32;
-
-                    debug_assert!(image.in_bounds(x_p, y_p));
-                    let pixel = unsafe { image.unsafe_get_pixel(x_p, y_p) };
-                    accumulate(&mut acc, &pixel, unsafe {
-                        kernel.get_unchecked(k_x as u32, k_y as u32)
-                    });
-                }
-            }
+            image.convolve_at(kernel, &mut acc, x, y, extend);
             let out_channels = out.get_pixel_mut(x as u32, y as u32).channels_mut();
             for (a, c) in acc.iter_mut().zip(out_channels) {
                 *c = f(*a);
@@ -84,8 +73,8 @@ where
     assert_eq!(P::CHANNEL_COUNT, Q::CHANNEL_COUNT);
     let num_channels = P::CHANNEL_COUNT as usize;
 
-    let (k_width, k_height) = (kernel.width as i64, kernel.height as i64);
     let (width, height) = (image.width() as i64, image.height() as i64);
+    let extend = Border::<P>::Replicate;
 
     let out_rows: Vec<Vec<_>> = (0..height)
         .into_par_iter()
@@ -95,18 +84,7 @@ where
             let mut acc = vec![K::zero(); num_channels];
 
             for x in 0..width {
-                for k_y in 0..k_height {
-                    let y_p = min(height - 1, max(0, y + k_y - k_height / 2)) as u32;
-                    for k_x in 0..k_width {
-                        let x_p = min(width - 1, max(0, x + k_x - k_width / 2)) as u32;
-
-                        debug_assert!(image.in_bounds(x_p, y_p));
-                        let pixel = unsafe { image.unsafe_get_pixel(x_p, y_p) };
-                        accumulate(&mut acc, &pixel, unsafe {
-                            kernel.get_unchecked(k_x as u32, k_y as u32)
-                        });
-                    }
-                }
+                image.convolve_at(kernel, &mut acc, x, y, extend);
                 for (a, c) in acc.iter_mut().zip(out_pixel.iter_mut()) {
                     *c = f(*a);
                     *a = K::zero();
@@ -242,69 +220,11 @@ where
     let mut out = Image::<P>::new(width, height);
     let zero = K::zero();
     let mut acc = vec![zero; P::CHANNEL_COUNT as usize];
-    let k_width = kernel.len() as i32;
-    let half_k = k_width / 2;
-
-    // Typically the image side will be much larger than the kernel length.
-    // In that case we can remove a lot of bounds checks for most pixels.
-    if k_width >= width as i32 {
-        for y in 0..height {
-            for x in 0..width {
-                for (i, k) in kernel.iter().enumerate() {
-                    let x_unchecked = (x as i32) + i as i32 - half_k;
-                    let x_p = max(0, min(x_unchecked, width as i32 - 1)) as u32;
-                    debug_assert!(image.in_bounds(x_p, y));
-                    let p = unsafe { image.unsafe_get_pixel(x_p, y) };
-                    accumulate(&mut acc, &p, *k);
-                }
-
-                let out_channels = out.get_pixel_mut(x, y).channels_mut();
-                clamp_and_reset::<P, K>(&mut acc, out_channels, zero);
-            }
-        }
-
-        return out;
-    }
+    let extend = Border::Replicate;
 
     for y in 0..height {
-        // Left margin - need to check lower bound only
-        for x in 0..half_k {
-            for (i, k) in kernel.iter().enumerate() {
-                let x_unchecked = x + i as i32 - half_k;
-                let x_p = max(0, x_unchecked) as u32;
-                debug_assert!(image.in_bounds(x_p, y));
-                let p = unsafe { image.unsafe_get_pixel(x_p, y) };
-                accumulate(&mut acc, &p, *k);
-            }
-
-            let out_channels = out.get_pixel_mut(x as u32, y).channels_mut();
-            clamp_and_reset::<P, K>(&mut acc, out_channels, zero);
-        }
-
-        // Neither margin - don't need bounds check on either side
-        for x in half_k..(width as i32 - half_k) {
-            for (i, k) in kernel.iter().enumerate() {
-                let x_unchecked = x + i as i32 - half_k;
-                let x_p = x_unchecked as u32;
-                debug_assert!(image.in_bounds(x_p, y));
-                let p = unsafe { image.unsafe_get_pixel(x_p, y) };
-                accumulate(&mut acc, &p, *k);
-            }
-
-            let out_channels = out.get_pixel_mut(x as u32, y).channels_mut();
-            clamp_and_reset::<P, K>(&mut acc, out_channels, zero);
-        }
-
-        // Right margin - need to check upper bound only
-        for x in (width as i32 - half_k)..(width as i32) {
-            for (i, k) in kernel.iter().enumerate() {
-                let x_unchecked = x + i as i32 - half_k;
-                let x_p = min(x_unchecked, width as i32 - 1) as u32;
-                debug_assert!(image.in_bounds(x_p, y));
-                let p = unsafe { image.unsafe_get_pixel(x_p, y) };
-                accumulate(&mut acc, &p, *k);
-            }
-
+        for x in 0..width {
+            image.convolve_horizontal_at(kernel, &mut acc, x as i64, y, extend);
             let out_channels = out.get_pixel_mut(x as u32, y).channels_mut();
             clamp_and_reset::<P, K>(&mut acc, out_channels, zero);
         }
@@ -329,90 +249,17 @@ where
     let mut out = Image::<P>::new(width, height);
     let zero = K::zero();
     let mut acc = vec![zero; P::CHANNEL_COUNT as usize];
-    let k_height = kernel.len() as i32;
-    let half_k = k_height / 2;
+    let extend = Border::Replicate;
 
-    // Typically the image side will be much larger than the kernel length.
-    // In that case we can remove a lot of bounds checks for most pixels.
-    if k_height >= height as i32 {
-        for y in 0..height {
-            for x in 0..width {
-                for (i, k) in kernel.iter().enumerate() {
-                    let y_unchecked = (y as i32) + i as i32 - half_k;
-                    let y_p = max(0, min(y_unchecked, height as i32 - 1)) as u32;
-                    debug_assert!(image.in_bounds(x, y_p));
-                    let p = unsafe { image.unsafe_get_pixel(x, y_p) };
-                    accumulate(&mut acc, &p, *k);
-                }
-
-                let out_channels = out.get_pixel_mut(x, y).channels_mut();
-                clamp_and_reset::<P, K>(&mut acc, out_channels, zero);
-            }
-        }
-
-        return out;
-    }
-
-    // Top margin - need to check lower bound only
-    for y in 0..half_k {
+    for y in 0..height {
         for x in 0..width {
-            for (i, k) in kernel.iter().enumerate() {
-                let y_unchecked = y + i as i32 - half_k;
-                let y_p = max(0, y_unchecked) as u32;
-                debug_assert!(image.in_bounds(x, y_p));
-                let p = unsafe { image.unsafe_get_pixel(x, y_p) };
-                accumulate(&mut acc, &p, *k);
-            }
-
-            let out_channels = out.get_pixel_mut(x, y as u32).channels_mut();
-            clamp_and_reset::<P, K>(&mut acc, out_channels, zero);
-        }
-    }
-
-    // Neither margin - don't need bounds check on either side
-    for y in half_k..(height as i32 - half_k) {
-        for x in 0..width {
-            for (i, k) in kernel.iter().enumerate() {
-                let y_unchecked = y + i as i32 - half_k;
-                let y_p = y_unchecked as u32;
-                debug_assert!(image.in_bounds(x, y_p));
-                let p = unsafe { image.unsafe_get_pixel(x, y_p) };
-                accumulate(&mut acc, &p, *k);
-            }
-
-            let out_channels = out.get_pixel_mut(x, y as u32).channels_mut();
-            clamp_and_reset::<P, K>(&mut acc, out_channels, zero);
-        }
-    }
-
-    // Right margin - need to check upper bound only
-    for y in (height as i32 - half_k)..(height as i32) {
-        for x in 0..width {
-            for (i, k) in kernel.iter().enumerate() {
-                let y_unchecked = y + i as i32 - half_k;
-                let y_p = min(y_unchecked, height as i32 - 1) as u32;
-                debug_assert!(image.in_bounds(x, y_p));
-                let p = unsafe { image.unsafe_get_pixel(x, y_p) };
-                accumulate(&mut acc, &p, *k);
-            }
-
-            let out_channels = out.get_pixel_mut(x, y as u32).channels_mut();
+            image.convolve_vertical_at(kernel, &mut acc, x, y as i64, extend);
+            let out_channels = out.get_pixel_mut(x, y).channels_mut();
             clamp_and_reset::<P, K>(&mut acc, out_channels, zero);
         }
     }
 
     out
-}
-
-fn accumulate<P, K>(acc: &mut [K], pixel: &P, weight: K)
-where
-    P: Pixel,
-    P::Subpixel: Into<K>,
-    K: Num + Copy,
-{
-    acc.iter_mut().zip(pixel.channels()).for_each(|(a, &c)| {
-        *a = *a + c.into() * weight;
-    });
 }
 
 fn clamp_and_reset<P, K>(acc: &mut [K], out_channels: &mut [P::Subpixel], zero: K)
@@ -876,7 +723,7 @@ mod benches {
     use crate::definitions::Image;
     use crate::utils::{gray_bench_image, rgb_bench_image};
     use image::imageops::blur;
-    use image::{GenericImage, Luma, Rgb};
+    use image::{GenericImage, GenericImageView, Luma, Rgb};
     use test::{Bencher, black_box};
 
     #[bench]

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -26,7 +26,12 @@ use std::f32;
 ///
 /// # Panics
 /// If `P::CHANNEL_COUNT != Q::CHANNEL_COUNT`
-pub fn filter<P, K, F, Q>(image: &Image<P>, kernel: Kernel<K>, mut f: F) -> Image<Q>
+pub fn filter<P, K, F, Q>(
+    image: &Image<P>,
+    kernel: Kernel<K>,
+    extend: Border<P>,
+    mut f: F,
+) -> Image<Q>
 where
     P: Pixel,
     <P as Pixel>::Subpixel: Into<K>,
@@ -42,7 +47,6 @@ where
     let mut out = Image::<Q>::new(width, height);
     let mut acc = vec![zero; num_channels];
     let (width, height) = (width as i64, height as i64);
-    let extend = Border::<P>::Replicate;
 
     for y in 0..height {
         for x in 0..width {
@@ -59,7 +63,12 @@ where
 
 #[cfg(feature = "rayon")]
 #[doc = generate_parallel_doc_comment!("filter")]
-pub fn filter_parallel<P, K, F, Q>(image: &Image<P>, kernel: Kernel<K>, f: F) -> Image<Q>
+pub fn filter_parallel<P, K, F, Q>(
+    image: &Image<P>,
+    kernel: Kernel<K>,
+    extend: Border<P>,
+    f: F,
+) -> Image<Q>
 where
     P: Pixel + Sync,
     P::Subpixel: Into<K> + Sync,
@@ -74,7 +83,6 @@ where
     let num_channels = P::CHANNEL_COUNT as usize;
 
     let (width, height) = (image.width() as i64, image.height() as i64);
-    let extend = Border::<P>::Replicate;
 
     let out_rows: Vec<Vec<_>> = (0..height)
         .into_par_iter()
@@ -131,20 +139,25 @@ fn gaussian_kernel_f32(sigma: f32) -> Vec<f32> {
 /// Panics if `sigma <= 0.0`.
 // TODO: Integer type kernel, approximations via repeated box filter.
 #[must_use = "the function does not modify the original image"]
-pub fn gaussian_blur_f32<P>(image: &Image<P>, sigma: f32) -> Image<P>
+pub fn gaussian_blur_f32<P>(image: &Image<P>, sigma: f32, extend: Border<P>) -> Image<P>
 where
     P: Pixel,
     <P as Pixel>::Subpixel: Into<f32> + Clamp<f32>,
 {
     assert!(sigma > 0.0, "sigma must be > 0.0");
     let kernel = gaussian_kernel_f32(sigma);
-    separable_filter_equal(image, &kernel)
+    separable_filter_equal(image, &kernel, extend)
 }
 
 /// Returns 2d correlation of view with the outer product of the 1d
 /// kernels `h_kernel` and `v_kernel`.
 #[must_use = "the function does not modify the original image"]
-pub fn separable_filter<P, K>(image: &Image<P>, h_kernel: &[K], v_kernel: &[K]) -> Image<P>
+pub fn separable_filter<P, K>(
+    image: &Image<P>,
+    h_kernel: &[K],
+    v_kernel: &[K],
+    extend: Border<P>,
+) -> Image<P>
 where
     P: Pixel,
     <P as Pixel>::Subpixel: Into<K> + Clamp<K>,
@@ -156,20 +169,20 @@ where
         "the two 1D kernels must be the same length"
     );
 
-    let h = horizontal_filter(image, h_kernel);
-    vertical_filter(&h, v_kernel)
+    let h = horizontal_filter(image, h_kernel, extend);
+    vertical_filter(&h, v_kernel, extend)
 }
 
 /// Returns 2d correlation of an image with the outer product of the 1d
 /// kernel filter with itself.
 #[must_use = "the function does not modify the original image"]
-pub fn separable_filter_equal<P, K>(image: &Image<P>, kernel: &[K]) -> Image<P>
+pub fn separable_filter_equal<P, K>(image: &Image<P>, kernel: &[K], extend: Border<P>) -> Image<P>
 where
     P: Pixel,
     <P as Pixel>::Subpixel: Into<K> + Clamp<K>,
     K: Num + Copy,
 {
-    separable_filter(image, kernel, kernel)
+    separable_filter(image, kernel, kernel, extend)
 }
 
 /// Returns 2d correlation of an image with a row-major kernel. Intermediate calculations are
@@ -177,14 +190,18 @@ where
 ///
 /// A parallelized version of this function exists with [`filter_clamped_parallel`] when
 /// the crate `rayon` feature is enabled.
-pub fn filter_clamped<P, K, S>(image: &Image<P>, kernel: Kernel<K>) -> Image<ChannelMap<P, S>>
+pub fn filter_clamped<P, K, S>(
+    image: &Image<P>,
+    kernel: Kernel<K>,
+    extend: Border<P>,
+) -> Image<ChannelMap<P, S>>
 where
     P: WithChannel<S>,
     P::Subpixel: Into<K>,
     K: Num + Copy + From<<P as image::Pixel>::Subpixel>,
     S: Clamp<K> + Primitive,
 {
-    filter(image, kernel, S::clamp)
+    filter(image, kernel, extend, S::clamp)
 }
 
 #[cfg(feature = "rayon")]
@@ -192,6 +209,7 @@ where
 pub fn filter_clamped_parallel<P, K, S>(
     image: &Image<P>,
     kernel: Kernel<K>,
+    extend: Border<P>,
 ) -> Image<ChannelMap<P, S>>
 where
     P: Sync + WithChannel<S>,
@@ -200,14 +218,14 @@ where
     K: Num + Copy + From<<P as image::Pixel>::Subpixel> + Sync,
     S: Clamp<K> + Primitive + Send,
 {
-    filter_parallel(image, kernel, S::clamp)
+    filter_parallel(image, kernel, extend, S::clamp)
 }
 
 /// Returns horizontal correlations between an image and a 1d kernel.
 /// Pads by continuity. Intermediate calculations are performed at
 /// type K.
 #[must_use = "the function does not modify the original image"]
-pub fn horizontal_filter<P, K>(image: &Image<P>, kernel: &[K]) -> Image<P>
+pub fn horizontal_filter<P, K>(image: &Image<P>, kernel: &[K], extend: Border<P>) -> Image<P>
 where
     P: Pixel,
     <P as Pixel>::Subpixel: Into<K> + Clamp<K>,
@@ -220,12 +238,11 @@ where
     let mut out = Image::<P>::new(width, height);
     let zero = K::zero();
     let mut acc = vec![zero; P::CHANNEL_COUNT as usize];
-    let extend = Border::Replicate;
 
     for y in 0..height {
         for x in 0..width {
             image.convolve_horizontal_at(kernel, &mut acc, x as i64, y, extend);
-            let out_channels = out.get_pixel_mut(x as u32, y).channels_mut();
+            let out_channels = out.get_pixel_mut(x, y).channels_mut();
             clamp_and_reset::<P, K>(&mut acc, out_channels, zero);
         }
     }
@@ -236,7 +253,7 @@ where
 /// Returns horizontal correlations between an image and a 1d kernel.
 /// Pads by continuity.
 #[must_use = "the function does not modify the original image"]
-pub fn vertical_filter<P, K>(image: &Image<P>, kernel: &[K]) -> Image<P>
+pub fn vertical_filter<P, K>(image: &Image<P>, kernel: &[K], extend: Border<P>) -> Image<P>
 where
     P: Pixel,
     <P as Pixel>::Subpixel: Into<K> + Clamp<K>,
@@ -249,7 +266,6 @@ where
     let mut out = Image::<P>::new(width, height);
     let zero = K::zero();
     let mut acc = vec![zero; P::CHANNEL_COUNT as usize];
-    let extend = Border::Replicate;
 
     for y in 0..height {
         for x in 0..width {
@@ -284,15 +300,15 @@ where
 /// 0, 1, 0
 /// ```
 #[must_use = "the function does not modify the original image"]
-pub fn laplacian_filter(image: &GrayImage) -> Image<Luma<i16>> {
-    filter_clamped(image, kernel::LAPLACIAN_3X3)
+pub fn laplacian_filter(image: &GrayImage, extend: Border<Luma<u8>>) -> Image<Luma<i16>> {
+    filter_clamped(image, kernel::LAPLACIAN_3X3, extend)
 }
 
 #[must_use = "the function does not modify the original image"]
 #[cfg(feature = "rayon")]
 #[doc = generate_parallel_doc_comment!("laplacian_filter")]
-pub fn laplacian_filter_parallel(image: &GrayImage) -> Image<Luma<i16>> {
-    filter_clamped_parallel(image, kernel::LAPLACIAN_3X3)
+pub fn laplacian_filter_parallel(image: &GrayImage, extend: Border<Luma<u8>>) -> Image<Luma<i16>> {
+    filter_clamped_parallel(image, kernel::LAPLACIAN_3X3, extend)
 }
 
 #[cfg(test)]
@@ -318,8 +334,8 @@ mod tests {
             0, 1, 0
         ], 3, 3);
 
-        let actual = laplacian_filter(&image);
-        let expected = filter_clamped::<_, _, i16>(&image, laplacian);
+        let actual = laplacian_filter(&image, Border::Replicate);
+        let expected = filter_clamped::<_, _, i16>(&image, laplacian, Border::Replicate);
         assert_eq!(actual.as_ref(), expected.as_ref());
     }
 
@@ -337,7 +353,7 @@ mod tests {
             6, 7, 7);
 
         let kernel = [1f32 / 3f32; 3];
-        let filtered = separable_filter_equal(&image, &kernel);
+        let filtered = separable_filter_equal(&image, &kernel, Border::Replicate);
 
         assert_pixels_eq!(filtered, expected);
     }
@@ -355,7 +371,7 @@ mod tests {
             57, 63, 69);
 
         let kernel = [1i32; 3];
-        let filtered = separable_filter_equal(&image, &kernel);
+        let filtered = separable_filter_equal(&image, &kernel, Border::Replicate);
 
         assert_pixels_eq!(filtered, expected);
     }
@@ -437,7 +453,7 @@ mod tests {
                                 (0..kernel_length).map(|i| i as f32 % 1.35).collect();
 
                             let expected = $reference_impl(&image, &kernel);
-                            let actual = $under_test(&image, &kernel);
+                            let actual = $under_test(&image, &kernel, Border::Replicate);
 
                             assert_pixels_eq!(actual, expected);
                         }
@@ -472,7 +488,7 @@ mod tests {
             2, 2, 2);
 
         let kernel = [1f32 / 3f32; 3];
-        let filtered = horizontal_filter(&image, &kernel);
+        let filtered = horizontal_filter(&image, &kernel, Border::Replicate);
 
         assert_pixels_eq!(filtered, expected);
     }
@@ -485,7 +501,7 @@ mod tests {
             1, 4, 1);
 
         let kernel = [1f32 / 10f32; 10];
-        black_box(horizontal_filter(&image, &kernel));
+        black_box(horizontal_filter(&image, &kernel, Border::Replicate));
     }
     #[test]
     fn test_vertical_filter() {
@@ -500,7 +516,7 @@ mod tests {
             2, 5, 2);
 
         let kernel = [1f32 / 3f32; 3];
-        let filtered = vertical_filter(&image, &kernel);
+        let filtered = vertical_filter(&image, &kernel, Border::Replicate);
 
         assert_pixels_eq!(filtered, expected);
     }
@@ -513,7 +529,7 @@ mod tests {
             1, 4, 1);
 
         let kernel = [1f32 / 10f32; 10];
-        black_box(vertical_filter(&image, &kernel));
+        black_box(vertical_filter(&image, &kernel, Border::Replicate));
     }
     #[test]
     fn test_filter_clamped_with_results_outside_input_channel_range() {
@@ -535,7 +551,7 @@ mod tests {
             -4, -8, -4
         );
 
-        let filtered = filter_clamped(&image, kernel);
+        let filtered = filter_clamped(&image, kernel, Border::Replicate);
         assert_pixels_eq!(filtered, expected);
     }
 
@@ -560,7 +576,7 @@ mod tests {
             -4, -8, -4
         );
 
-        let filtered = filter_clamped_parallel(&image, kernel);
+        let filtered = filter_clamped_parallel(&image, kernel, Border::Replicate);
         assert_pixels_eq!(filtered, expected);
     }
 
@@ -579,7 +595,7 @@ mod tests {
 
         let k = &[1u8, 2u8];
         let kernel = Kernel::new(k, 2, 1);
-        let filtered = filter(&image, kernel, |x| x);
+        let filtered = filter(&image, kernel, Border::Replicate, |x| x);
 
         let expected = gray_image!(
              9,  7;
@@ -594,7 +610,7 @@ mod tests {
 
         let k = &[2u8];
         let kernel = Kernel::new(k, 1, 1);
-        let filtered = filter(&image, kernel, |x| x);
+        let filtered = filter(&image, kernel, Border::Replicate, |x| x);
 
         let expected = gray_image!();
         assert_pixels_eq!(filtered, expected);
@@ -613,7 +629,8 @@ mod tests {
             0.1, 0.2, 0.1
         ];
         let kernel = Kernel::new(k, 3, 3);
-        let filtered: Image<Luma<u8>> = filter(&image, kernel, <u8 as Clamp<f32>>::clamp);
+        let filtered: Image<Luma<u8>> =
+            filter(&image, kernel, Border::Replicate, <u8 as Clamp<f32>>::clamp);
 
         let expected = gray_image!(
             11,  7;
@@ -629,7 +646,7 @@ mod tests {
             4, 5, 6;
             7, 8, 9
         );
-        let _ = gaussian_blur_f32(&image, 0.0);
+        let _ = gaussian_blur_f32(&image, 0.0, Border::Replicate);
     }
 
     #[test]
@@ -640,21 +657,21 @@ mod tests {
             4, 5, 6;
             7, 8, 9
         );
-        let _ = gaussian_blur_f32(&image, -0.5);
+        let _ = gaussian_blur_f32(&image, -0.5, Border::Replicate);
     }
 
     #[cfg_attr(miri, ignore = "assert fails")]
     #[test]
     fn test_gaussian_on_u8_white_idempotent() {
         let image = Image::<Luma<u8>>::from_pixel(12, 12, Luma([255]));
-        let image2 = gaussian_blur_f32(&image, 6f32);
+        let image2 = gaussian_blur_f32(&image, 6f32, Border::Replicate);
         assert_pixels_eq_within!(image2, image, 0);
     }
 
     #[test]
     fn test_gaussian_on_f32_white_idempotent() {
         let image = Image::<Luma<f32>>::from_pixel(12, 12, Luma([1.0]));
-        let image2 = gaussian_blur_f32(&image, 6f32);
+        let image2 = gaussian_blur_f32(&image, 6f32, Border::Replicate);
         assert_pixels_eq_within!(image2, image, 1e-6);
     }
 }
@@ -672,7 +689,7 @@ mod proptests {
             img in arbitrary_image::<Luma<u8>>(0..20, 0..20),
             sigma in (0.0..150f32).prop_filter("contract", |&x| x > 0.0),
         ) {
-            let out = gaussian_blur_f32(&img, sigma);
+            let out = gaussian_blur_f32(&img, sigma, Border::Replicate);
             prop_assert_eq!(out.dimensions(), img.dimensions());
         }
 
@@ -682,7 +699,7 @@ mod proptests {
             ker in arbitrary_image::<Luma<f32>>(1..20, 1..20),
         ) {
             let kernel = Kernel::new(&ker, ker.width(), ker.height());
-            let out: Image<Luma<f32>> = filter(&img, kernel, |x| {
+            let out: Image<Luma<f32>> = filter(&img, kernel, Border::Replicate, |x| {
                 x
             });
             prop_assert_eq!(out.dimensions(), img.dimensions());
@@ -693,7 +710,7 @@ mod proptests {
             img in arbitrary_image::<Luma<f32>>(0..50, 0..50),
             ker in proptest::collection::vec(any::<f32>(), 0..50),
         ) {
-            let out = horizontal_filter(&img, &ker);
+            let out = horizontal_filter(&img, &ker, Border::Replicate);
             prop_assert_eq!(out.dimensions(), img.dimensions());
         }
 
@@ -702,7 +719,7 @@ mod proptests {
             img in arbitrary_image::<Luma<f32>>(0..50, 0..50),
             ker in proptest::collection::vec(any::<f32>(), 0..50),
         ) {
-            let out = vertical_filter(&img, &ker);
+            let out = vertical_filter(&img, &ker, Border::Replicate);
             prop_assert_eq!(out.dimensions(), img.dimensions());
         }
 
@@ -710,7 +727,7 @@ mod proptests {
         fn proptest_laplacian_filter(
             img in arbitrary_image::<Luma<u8>>(0..120, 0..120),
         ) {
-            let out = laplacian_filter(&img);
+            let out = laplacian_filter(&img, Border::Replicate);
             prop_assert_eq!(out.dimensions(), img.dimensions());
         }
     }
@@ -732,7 +749,7 @@ mod benches {
         let h_kernel = [1f32 / 5f32; 5];
         let v_kernel = [0.1f32, 0.4f32, 0.3f32, 0.1f32, 0.1f32];
         b.iter(|| {
-            let filtered = separable_filter(&image, &h_kernel, &v_kernel);
+            let filtered = separable_filter(&image, &h_kernel, &v_kernel, Border::Replicate);
             black_box(filtered);
         });
     }
@@ -742,7 +759,7 @@ mod benches {
         let image = gray_bench_image(500, 500);
         let kernel = [1f32 / 5f32; 5];
         b.iter(|| {
-            let filtered = horizontal_filter(&image, &kernel);
+            let filtered = horizontal_filter(&image, &kernel, Border::Replicate);
             black_box(filtered);
         });
     }
@@ -752,7 +769,7 @@ mod benches {
         let image = gray_bench_image(500, 500);
         let kernel = [1f32 / 5f32; 5];
         b.iter(|| {
-            let filtered = vertical_filter(&image, &kernel);
+            let filtered = vertical_filter(&image, &kernel, Border::Replicate);
             black_box(filtered);
         });
     }
@@ -801,7 +818,8 @@ mod benches {
                 let kernel: Vec<i32> = (0..$kernel_size * $kernel_size).collect();
                 let kernel = Kernel::new(&kernel, $kernel_size, $kernel_size);
                 b.iter(|| {
-                    let filtered: Image<Luma<i16>> = $function_name::<_, _, i16>(&image, kernel);
+                    let filtered: Image<Luma<i16>> =
+                        $function_name::<_, _, i16>(&image, kernel, Border::Replicate);
                     black_box(filtered);
                 });
             }
@@ -815,7 +833,8 @@ mod benches {
                 let kernel: Vec<i32> = (0..$kernel_size * $kernel_size).collect();
                 let kernel = Kernel::new(&kernel, $kernel_size, $kernel_size);
                 b.iter(|| {
-                    let filtered: Image<Rgb<i16>> = $function_name::<_, _, i16>(&image, kernel);
+                    let filtered: Image<Rgb<i16>> =
+                        $function_name::<_, _, i16>(&image, kernel, Border::Replicate);
                     black_box(filtered);
                 });
             }
@@ -922,7 +941,7 @@ mod benches {
     fn bench_gaussian_f32_stdev_1(b: &mut Bencher) {
         let image = rgb_bench_image(100, 100);
         b.iter(|| {
-            let blurred = gaussian_blur_f32(&image, 1f32);
+            let blurred = gaussian_blur_f32(&image, 1f32, Border::Replicate);
             black_box(blurred);
         });
     }
@@ -931,7 +950,7 @@ mod benches {
     fn bench_gaussian_f32_stdev_3(b: &mut Bencher) {
         let image = rgb_bench_image(100, 100);
         b.iter(|| {
-            let blurred = gaussian_blur_f32(&image, 3f32);
+            let blurred = gaussian_blur_f32(&image, 3f32, Border::Replicate);
             black_box(blurred);
         });
     }
@@ -940,7 +959,7 @@ mod benches {
     fn bench_gaussian_f32_stdev_10(b: &mut Bencher) {
         let image = rgb_bench_image(100, 100);
         b.iter(|| {
-            let blurred = gaussian_blur_f32(&image, 10f32);
+            let blurred = gaussian_blur_f32(&image, 10f32, Border::Replicate);
             black_box(blurred);
         });
     }

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -22,7 +22,8 @@ use num::Num;
 use std::f32;
 
 /// Returns 2d correlation of an image. Intermediate calculations are performed
-/// at type K, and the results converted to pixel Q via f. Pads by continuity.
+/// at type K, and the results converted to pixel Q via f.
+/// Sampling outside of image boundaries is controlled by `extend`.
 ///
 /// # Panics
 /// If `P::CHANNEL_COUNT != Q::CHANNEL_COUNT`
@@ -186,7 +187,8 @@ where
 }
 
 /// Returns 2d correlation of an image with a row-major kernel. Intermediate calculations are
-/// performed at type K, and the results clamped to subpixel type S. Pads by continuity.
+/// performed at type K, and the results clamped to subpixel type S.
+/// Sampling outside of image boundaries is controlled by `extend`.
 ///
 /// A parallelized version of this function exists with [`filter_clamped_parallel`] when
 /// the crate `rayon` feature is enabled.
@@ -222,8 +224,8 @@ where
 }
 
 /// Returns horizontal correlations between an image and a 1d kernel.
-/// Pads by continuity. Intermediate calculations are performed at
-/// type K.
+/// Sampling outside of image boundaries is controlled by `extend`.
+/// Intermediate calculations are performed at type K.
 #[must_use = "the function does not modify the original image"]
 pub fn horizontal_filter<P, K>(image: &Image<P>, kernel: &[K], extend: Border<P>) -> Image<P>
 where
@@ -250,8 +252,9 @@ where
     out
 }
 
-/// Returns horizontal correlations between an image and a 1d kernel.
-/// Pads by continuity.
+/// Returns vertical correlations between an image and a 1d kernel.
+/// Sampling outside of image boundaries is controlled by `extend`.
+/// Intermediate calculations are performed at type K.
 #[must_use = "the function does not modify the original image"]
 pub fn vertical_filter<P, K>(image: &Image<P>, kernel: &[K], extend: Border<P>) -> Image<P>
 where

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -241,7 +241,7 @@ where
 
     for y in 0..height {
         for x in 0..width {
-            image.convolve_horizontal_at(kernel, &mut acc, x as i64, y, extend);
+            image.convolve_horizontal_at(kernel, &mut acc, x as i64, y as i64, extend);
             let out_channels = out.get_pixel_mut(x, y).channels_mut();
             clamp_and_reset::<P, K>(&mut acc, out_channels, zero);
         }
@@ -269,7 +269,7 @@ where
 
     for y in 0..height {
         for x in 0..width {
-            image.convolve_vertical_at(kernel, &mut acc, x, y as i64, extend);
+            image.convolve_vertical_at(kernel, &mut acc, x as i64, y as i64, extend);
             let out_channels = out.get_pixel_mut(x, y).channels_mut();
             clamp_and_reset::<P, K>(&mut acc, out_channels, zero);
         }

--- a/src/filter/sharpen.rs
+++ b/src/filter/sharpen.rs
@@ -3,6 +3,7 @@ use super::filter_clamped_parallel;
 use super::{filter_clamped, gaussian_blur_f32};
 use crate::{
     definitions::{Clamp, Image},
+    geometric_transformations::Border,
     kernel::Kernel,
     map::{map_pixels2, map_subpixels},
 };
@@ -10,16 +11,16 @@ use image::{GrayImage, Luma};
 
 /// Sharpens a grayscale image by applying a 3x3 approximation to the Laplacian.
 #[must_use = "the function does not modify the original image"]
-pub fn sharpen3x3(image: &GrayImage) -> GrayImage {
+pub fn sharpen3x3(image: &GrayImage, extend: Border<Luma<u8>>) -> GrayImage {
     let identity_minus_laplacian = Kernel::new(&[0, -1, 0, -1, 5, -1, 0, -1, 0], 3, 3);
-    filter_clamped(image, identity_minus_laplacian)
+    filter_clamped(image, identity_minus_laplacian, extend)
 }
 #[must_use = "the function does not modify the original image"]
 #[cfg(feature = "rayon")]
 #[doc = generate_parallel_doc_comment!("sharpen3x3")]
-pub fn sharpen3x3_parallel(image: &GrayImage) -> GrayImage {
+pub fn sharpen3x3_parallel(image: &GrayImage, extend: Border<Luma<u8>>) -> GrayImage {
     let identity_minus_laplacian = Kernel::new(&[0, -1, 0, -1, 5, -1, 0, -1, 0], 3, 3);
-    filter_clamped_parallel(image, identity_minus_laplacian)
+    filter_clamped_parallel(image, identity_minus_laplacian, extend)
 }
 
 /// Sharpens a grayscale image using a Gaussian as a low-pass filter.
@@ -28,9 +29,14 @@ pub fn sharpen3x3_parallel(image: &GrayImage) -> GrayImage {
 /// * `amount` controls the level of sharpening. `output = input + amount * edges`.
 // TODO: remove unnecessary allocations, support colour images
 #[must_use = "the function does not modify the original image"]
-pub fn sharpen_gaussian(image: &GrayImage, sigma: f32, amount: f32) -> GrayImage {
+pub fn sharpen_gaussian(
+    image: &GrayImage,
+    sigma: f32,
+    amount: f32,
+    extend: Border<Luma<f32>>,
+) -> GrayImage {
     let image = map_subpixels(image, |x| x as f32);
-    let smooth: Image<Luma<f32>> = gaussian_blur_f32(&image, sigma);
+    let smooth: Image<Luma<f32>> = gaussian_blur_f32(&image, sigma, extend);
     map_pixels2(&image, &smooth, |p, q| {
         let v = (1.0 + amount) * p[0] - amount * q[0];
         Luma([<u8 as Clamp<f32>>::clamp(v)])

--- a/src/gradients.rs
+++ b/src/gradients.rs
@@ -2,6 +2,7 @@
 
 use crate::definitions::{HasBlack, Image};
 use crate::filter::filter_clamped;
+use crate::geometric_transformations::Border;
 use crate::kernel::{
     self, Kernel, PREWITT_HORIZONTAL_3X3, PREWITT_VERTICAL_3X3, SCHARR_HORIZONTAL_3X3,
     SCHARR_VERTICAL_3X3, SOBEL_HORIZONTAL_3X3, SOBEL_VERTICAL_3X3,
@@ -16,8 +17,9 @@ pub fn gradients_grayscale(
     image: &GrayImage,
     horizontal_kernel: Kernel<i32>,
     vertical_kernel: Kernel<i32>,
+    extend: Border<Luma<u8>>,
 ) -> Image<Luma<u16>> {
-    gradients(image, horizontal_kernel, vertical_kernel, |p| p)
+    gradients(image, horizontal_kernel, vertical_kernel, extend, |p| p)
 }
 
 // TODO: Returns directions as well as magnitudes.
@@ -35,6 +37,7 @@ pub fn gradients_grayscale(
 /// # extern crate imageproc;
 /// # fn main() {
 /// use imageproc::gradients::gradients;
+/// use imageproc::geometric_transformations::Border;
 /// use imageproc::kernel::Kernel;
 /// use imageproc::kernel;
 /// use image::Luma;
@@ -58,9 +61,10 @@ pub fn gradients_grayscale(
 ///
 /// let horizontal_kernel = kernel::SOBEL_HORIZONTAL_3X3;
 /// let vertical_kernel = kernel::SOBEL_VERTICAL_3X3;
+/// let extend = Border::Replicate;
 ///
 /// assert_pixels_eq!(
-///     gradients(&input, horizontal_kernel, vertical_kernel, |p| p),
+///     gradients(&input, horizontal_kernel, vertical_kernel, extend, |p| p),
 ///     channel_gradient
 /// );
 ///
@@ -73,7 +77,7 @@ pub fn gradients_grayscale(
 /// );
 ///
 /// assert_pixels_eq!(
-///     gradients(&input, horizontal_kernel, vertical_kernel, |p| {
+///     gradients(&input, horizontal_kernel, vertical_kernel, extend, |p| {
 ///         let mean = (p[0] + p[1] + p[2]) / 3;
 ///         Luma([mean])
 ///     }),
@@ -89,7 +93,7 @@ pub fn gradients_grayscale(
 /// );
 ///
 /// assert_pixels_eq!(
-///     gradients(&input, horizontal_kernel, vertical_kernel, |p| {
+///     gradients(&input, horizontal_kernel, vertical_kernel, extend, |p| {
 ///         let max = cmp::max(cmp::max(p[0], p[1]), p[2]);
 ///         Luma([max])
 ///     }),
@@ -100,6 +104,7 @@ pub fn gradients<P, F, Q>(
     image: &Image<P>,
     horizontal_kernel: Kernel<i32>,
     vertical_kernel: Kernel<i32>,
+    extend: Border<P>,
     f: F,
 ) -> Image<Q>
 where
@@ -108,8 +113,8 @@ where
     ChannelMap<P, u16>: HasBlack,
     F: Fn(ChannelMap<P, u16>) -> Q,
 {
-    let horizontal = filter_clamped::<_, _, i16>(image, horizontal_kernel);
-    let vertical = filter_clamped::<_, _, i16>(image, vertical_kernel);
+    let horizontal = filter_clamped::<_, _, i16>(image, horizontal_kernel, extend);
+    let vertical = filter_clamped::<_, _, i16>(image, vertical_kernel, extend);
 
     let (width, height) = image.dimensions();
     let mut out = Image::<Q>::new(width, height);
@@ -160,55 +165,57 @@ fn gradient_magnitude(dx: f32, dy: f32) -> u16 {
 
 /// Convolves an image with the [`SOBEL_HORIZONTAL_3X3`]
 /// kernel to detect horizontal gradients.
-pub fn horizontal_sobel(image: &GrayImage) -> Image<Luma<i16>> {
-    filter_clamped(image, SOBEL_HORIZONTAL_3X3)
+pub fn horizontal_sobel(image: &GrayImage, extend: Border<Luma<u8>>) -> Image<Luma<i16>> {
+    filter_clamped(image, SOBEL_HORIZONTAL_3X3, extend)
 }
 
 /// Convolves an image with the [`SOBEL_VERTICAL_3X3`]
 /// kernel to detect vertical gradients.
-pub fn vertical_sobel(image: &GrayImage) -> Image<Luma<i16>> {
-    filter_clamped(image, SOBEL_VERTICAL_3X3)
+pub fn vertical_sobel(image: &GrayImage, extend: Border<Luma<u8>>) -> Image<Luma<i16>> {
+    filter_clamped(image, SOBEL_VERTICAL_3X3, extend)
 }
 
 /// Convolves an image with the [`SCHARR_HORIZONTAL_3X3`]
 /// kernel to detect horizontal gradients.
-pub fn horizontal_scharr(image: &GrayImage) -> Image<Luma<i16>> {
-    filter_clamped(image, SCHARR_HORIZONTAL_3X3)
+pub fn horizontal_scharr(image: &GrayImage, extend: Border<Luma<u8>>) -> Image<Luma<i16>> {
+    filter_clamped(image, SCHARR_HORIZONTAL_3X3, extend)
 }
 
 /// Convolves an image with the [`SCHARR_VERTICAL_3X3`]
 /// kernel to detect vertical gradients.
-pub fn vertical_scharr(image: &GrayImage) -> Image<Luma<i16>> {
-    filter_clamped(image, SCHARR_VERTICAL_3X3)
+pub fn vertical_scharr(image: &GrayImage, extend: Border<Luma<u8>>) -> Image<Luma<i16>> {
+    filter_clamped(image, SCHARR_VERTICAL_3X3, extend)
 }
 
 /// Convolves an image with the [`PREWITT_HORIZONTAL_3X3`]
 /// kernel to detect horizontal gradients.
-pub fn horizontal_prewitt(image: &GrayImage) -> Image<Luma<i16>> {
-    filter_clamped(image, PREWITT_HORIZONTAL_3X3)
+pub fn horizontal_prewitt(image: &GrayImage, extend: Border<Luma<u8>>) -> Image<Luma<i16>> {
+    filter_clamped(image, PREWITT_HORIZONTAL_3X3, extend)
 }
 
 /// Convolves an image with the [`PREWITT_VERTICAL_3X3`]
 /// kernel to detect vertical gradients.
-pub fn vertical_prewitt(image: &GrayImage) -> Image<Luma<i16>> {
-    filter_clamped(image, PREWITT_VERTICAL_3X3)
+pub fn vertical_prewitt(image: &GrayImage, extend: Border<Luma<u8>>) -> Image<Luma<i16>> {
+    filter_clamped(image, PREWITT_VERTICAL_3X3, extend)
 }
 
 /// Returns the magnitudes of gradients in an image using Sobel filters.
-pub fn sobel_gradients(image: &GrayImage) -> Image<Luma<u16>> {
+pub fn sobel_gradients(image: &GrayImage, extend: Border<Luma<u8>>) -> Image<Luma<u16>> {
     gradients_grayscale(
         image,
         kernel::SOBEL_HORIZONTAL_3X3,
         kernel::SOBEL_VERTICAL_3X3,
+        extend,
     )
 }
 
 /// Returns the magnitudes of gradients in an image using Prewitt filters.
-pub fn prewitt_gradients(image: &GrayImage) -> Image<Luma<u16>> {
+pub fn prewitt_gradients(image: &GrayImage, extend: Border<Luma<u8>>) -> Image<Luma<u16>> {
     gradients_grayscale(
         image,
         kernel::PREWITT_HORIZONTAL_3X3,
         kernel::PREWITT_VERTICAL_3X3,
+        extend,
     )
 }
 
@@ -222,6 +229,7 @@ pub fn prewitt_gradients(image: &GrayImage) -> Image<Luma<u16>> {
 /// # extern crate imageproc;
 /// # fn main() {
 /// use imageproc::gradients::{sobel_gradient_map};
+/// use imageproc::geometric_transformations::Border;
 /// use image::Luma;
 /// use std::cmp;
 ///
@@ -241,8 +249,10 @@ pub fn prewitt_gradients(image: &GrayImage) -> Image<Luma<u16>> {
 ///     [ 4,  0,  8], [ 8,  0,  8], [ 4,  0,  8]
 /// );
 ///
+/// let extend = Border::Replicate;
+///
 /// assert_pixels_eq!(
-///     sobel_gradient_map(&input, |p| p),
+///     sobel_gradient_map(&input, extend, |p| p),
 ///     channel_gradient
 /// );
 ///
@@ -255,7 +265,7 @@ pub fn prewitt_gradients(image: &GrayImage) -> Image<Luma<u16>> {
 /// );
 ///
 /// assert_pixels_eq!(
-///     sobel_gradient_map(&input, |p| {
+///     sobel_gradient_map(&input, extend, |p| {
 ///         let mean = (p[0] + p[1] + p[2]) / 3;
 ///         Luma([mean])
 ///     }),
@@ -271,14 +281,14 @@ pub fn prewitt_gradients(image: &GrayImage) -> Image<Luma<u16>> {
 /// );
 ///
 /// assert_pixels_eq!(
-///     sobel_gradient_map(&input, |p| {
+///     sobel_gradient_map(&input, extend, |p| {
 ///         let max = cmp::max(cmp::max(p[0], p[1]), p[2]);
 ///         Luma([max])
 ///     }),
 ///     max_gradient
 /// );
 /// # }
-pub fn sobel_gradient_map<P, F, Q>(image: &Image<P>, f: F) -> Image<Q>
+pub fn sobel_gradient_map<P, F, Q>(image: &Image<P>, extend: Border<P>, f: F) -> Image<Q>
 where
     P: Pixel<Subpixel = u8> + WithChannel<u16> + WithChannel<i16>,
     Q: Pixel,
@@ -289,6 +299,7 @@ where
         image,
         kernel::SOBEL_HORIZONTAL_3X3,
         kernel::SOBEL_VERTICAL_3X3,
+        extend,
         f,
     )
 }
@@ -312,6 +323,7 @@ mod tests {
                 &image,
                 kernel::SOBEL_HORIZONTAL_3X3,
                 kernel::SOBEL_VERTICAL_3X3,
+                Border::Replicate,
                 |p| p
             ),
             expected
@@ -327,6 +339,7 @@ mod tests {
                 &image,
                 kernel::SCHARR_HORIZONTAL_3X3,
                 kernel::SCHARR_VERTICAL_3X3,
+                Border::Replicate,
                 |p| p
             ),
             expected
@@ -342,6 +355,7 @@ mod tests {
                 &image,
                 kernel::PREWITT_HORIZONTAL_3X3,
                 kernel::PREWITT_VERTICAL_3X3,
+                Border::Replicate,
                 |p| p
             ),
             expected
@@ -357,6 +371,7 @@ mod tests {
                 &image,
                 kernel::ROBERTS_HORIZONTAL_2X2,
                 kernel::ROBERTS_VERTICAL_2X2,
+                Border::Replicate,
                 |p| p
             ),
             expected
@@ -375,7 +390,7 @@ mod tests {
             -4, -8, -4;
             -4, -8, -4);
 
-        let filtered = filter_clamped(&image, kernel::SOBEL_HORIZONTAL_3X3);
+        let filtered = filter_clamped(&image, kernel::SOBEL_HORIZONTAL_3X3, Border::Replicate);
         assert_pixels_eq!(filtered, expected);
     }
 
@@ -392,7 +407,8 @@ mod tests {
             -4, -8, -4;
             -4, -8, -4);
 
-        let filtered = filter_clamped_parallel(&image, kernel::SOBEL_HORIZONTAL_3X3);
+        let filtered =
+            filter_clamped_parallel(&image, kernel::SOBEL_HORIZONTAL_3X3, Border::Replicate);
         assert_pixels_eq!(filtered, expected);
     }
 
@@ -408,7 +424,7 @@ mod tests {
             -8, -8, -8;
             -4, -4, -4);
 
-        let filtered = filter_clamped(&image, kernel::SOBEL_VERTICAL_3X3);
+        let filtered = filter_clamped(&image, kernel::SOBEL_VERTICAL_3X3, Border::Replicate);
         assert_pixels_eq!(filtered, expected);
     }
 
@@ -425,7 +441,8 @@ mod tests {
             -8, -8, -8;
             -4, -4, -4);
 
-        let filtered = filter_clamped_parallel(&image, kernel::SOBEL_VERTICAL_3X3);
+        let filtered =
+            filter_clamped_parallel(&image, kernel::SOBEL_VERTICAL_3X3, Border::Replicate);
         assert_pixels_eq!(filtered, expected);
     }
 
@@ -441,7 +458,7 @@ mod tests {
             -16, -32, -16;
             -16, -32, -16);
 
-        let filtered = filter_clamped(&image, kernel::SCHARR_HORIZONTAL_3X3);
+        let filtered = filter_clamped(&image, kernel::SCHARR_HORIZONTAL_3X3, Border::Replicate);
         assert_pixels_eq!(filtered, expected);
     }
 
@@ -458,7 +475,8 @@ mod tests {
             -16, -32, -16;
             -16, -32, -16);
 
-        let filtered = filter_clamped_parallel(&image, kernel::SCHARR_HORIZONTAL_3X3);
+        let filtered =
+            filter_clamped_parallel(&image, kernel::SCHARR_HORIZONTAL_3X3, Border::Replicate);
         assert_pixels_eq!(filtered, expected);
     }
 
@@ -474,7 +492,7 @@ mod tests {
             -32, -32, -32;
             -16, -16, -16);
 
-        let filtered = filter_clamped(&image, kernel::SCHARR_VERTICAL_3X3);
+        let filtered = filter_clamped(&image, kernel::SCHARR_VERTICAL_3X3, Border::Replicate);
         assert_pixels_eq!(filtered, expected);
     }
 
@@ -491,7 +509,8 @@ mod tests {
             -32, -32, -32;
             -16, -16, -16);
 
-        let filtered = filter_clamped_parallel(&image, kernel::SCHARR_VERTICAL_3X3);
+        let filtered =
+            filter_clamped_parallel(&image, kernel::SCHARR_VERTICAL_3X3, Border::Replicate);
         assert_pixels_eq!(filtered, expected);
     }
 
@@ -507,7 +526,7 @@ mod tests {
             -3, -6, -3;
             -3, -6, -3);
 
-        let filtered = filter_clamped(&image, kernel::PREWITT_HORIZONTAL_3X3);
+        let filtered = filter_clamped(&image, kernel::PREWITT_HORIZONTAL_3X3, Border::Replicate);
         assert_pixels_eq!(filtered, expected);
     }
 
@@ -524,7 +543,8 @@ mod tests {
             -3, -6, -3;
             -3, -6, -3);
 
-        let filtered = filter_clamped_parallel(&image, kernel::PREWITT_HORIZONTAL_3X3);
+        let filtered =
+            filter_clamped_parallel(&image, kernel::PREWITT_HORIZONTAL_3X3, Border::Replicate);
         assert_pixels_eq!(filtered, expected);
     }
 
@@ -541,7 +561,7 @@ mod tests {
             -6, -6, -6;
             -3, -3, -3);
 
-        let filtered = filter_clamped(&image, kernel::PREWITT_VERTICAL_3X3);
+        let filtered = filter_clamped(&image, kernel::PREWITT_VERTICAL_3X3, Border::Replicate);
         assert_pixels_eq!(filtered, expected);
     }
 
@@ -558,7 +578,8 @@ mod tests {
             -6, -6, -6;
             -3, -3, -3);
 
-        let filtered = filter_clamped_parallel(&image, kernel::PREWITT_VERTICAL_3X3);
+        let filtered =
+            filter_clamped_parallel(&image, kernel::PREWITT_VERTICAL_3X3, Border::Replicate);
         assert_pixels_eq!(filtered, expected);
     }
 
@@ -574,7 +595,7 @@ mod tests {
             1, -2, -2;
             1, -2, -2);
 
-        let filtered = filter_clamped(&image, kernel::ROBERTS_HORIZONTAL_2X2);
+        let filtered = filter_clamped(&image, kernel::ROBERTS_HORIZONTAL_2X2, Border::Replicate);
         assert_pixels_eq!(filtered, expected);
     }
 
@@ -591,7 +612,8 @@ mod tests {
             1, -2, -2;
             1, -2, -2);
 
-        let filtered = filter_clamped_parallel(&image, kernel::ROBERTS_HORIZONTAL_2X2);
+        let filtered =
+            filter_clamped_parallel(&image, kernel::ROBERTS_HORIZONTAL_2X2, Border::Replicate);
         assert_pixels_eq!(filtered, expected);
     }
 
@@ -607,7 +629,7 @@ mod tests {
             1, 4, 4;
             1, 4, 4);
 
-        let filtered = filter_clamped(&image, kernel::ROBERTS_VERTICAL_2X2);
+        let filtered = filter_clamped(&image, kernel::ROBERTS_VERTICAL_2X2, Border::Replicate);
         assert_pixels_eq!(filtered, expected);
     }
 
@@ -624,7 +646,8 @@ mod tests {
             1, 4, 4;
             1, 4, 4);
 
-        let filtered = filter_clamped_parallel(&image, kernel::ROBERTS_VERTICAL_2X2);
+        let filtered =
+            filter_clamped_parallel(&image, kernel::ROBERTS_VERTICAL_2X2, Border::Replicate);
         assert_pixels_eq!(filtered, expected);
     }
 }
@@ -644,6 +667,7 @@ mod benches {
                 &image,
                 kernel::SOBEL_HORIZONTAL_3X3,
                 kernel::SOBEL_VERTICAL_3X3,
+                Border::Replicate,
                 |p| p,
             );
             black_box(gradients);

--- a/src/gradients.rs
+++ b/src/gradients.rs
@@ -249,6 +249,7 @@ pub fn prewitt_gradients(image: &GrayImage, extend: Border<Luma<u8>>) -> Image<L
 ///     [ 4,  0,  8], [ 8,  0,  8], [ 4,  0,  8]
 /// );
 ///
+/// // Padding by continuity.
 /// let extend = Border::Replicate;
 ///
 /// assert_pixels_eq!(

--- a/src/hog.rs
+++ b/src/hog.rs
@@ -3,6 +3,7 @@
 
 use crate::definitions::{Clamp, Image};
 use crate::filter::filter_clamped;
+use crate::geometric_transformations::Border;
 use crate::kernel::{self};
 use crate::math::l2_norm;
 use image::{GenericImage, GrayImage, Luma};
@@ -193,7 +194,7 @@ pub fn hog(image: &GrayImage, options: HogOptions) -> Result<Vec<f32>, String> {
     match HogSpec::from_options(image.width(), image.height(), options) {
         Err(e) => Err(e),
         Ok(spec) => {
-            let mut grid: Array3d<f32> = cell_histograms(image, spec);
+            let mut grid: Array3d<f32> = cell_histograms(image, spec, Border::Replicate);
             let grid_view = grid.view_mut();
             let descriptor = hog_descriptor_from_hist_grid(grid_view, spec);
             Ok(descriptor)
@@ -253,14 +254,14 @@ fn copy<T: Copy>(from: &[T], to: &mut [T]) {
 
 /// Computes orientation histograms for each cell of an image. Assumes that
 /// the provided dimensions are valid.
-pub fn cell_histograms(image: &GrayImage, spec: HogSpec) -> Array3d<f32> {
+pub fn cell_histograms(image: &GrayImage, spec: HogSpec, extend: Border<Luma<u8>>) -> Array3d<f32> {
     let (width, height) = image.dimensions();
     let mut grid = Array3d::new(spec.cell_grid_lengths());
     let cell_area = spec.cell_area() as f32;
     let cell_side = spec.options.cell_side as f32;
 
-    let horizontal = filter_clamped::<_, _, i32>(image, kernel::SOBEL_HORIZONTAL_3X3);
-    let vertical = filter_clamped::<_, _, i32>(image, kernel::SOBEL_VERTICAL_3X3);
+    let horizontal = filter_clamped::<_, _, i32>(image, kernel::SOBEL_HORIZONTAL_3X3, extend);
+    let vertical = filter_clamped::<_, _, i32>(image, kernel::SOBEL_VERTICAL_3X3, extend);
     let interval = orientation_bin_width(spec.options);
     let range = direction_range(spec.options);
 
@@ -553,7 +554,7 @@ mod tests {
             block_stride: 2,
         };
         let expected = "Invalid HoG options: block stride 2 does not evenly divide (cells wide 7 - block side 4), \
-			block stride 2 does not evenly divide (cells high 7 - block side 4)";
+            block stride 2 does not evenly divide (cells high 7 - block side 4)";
         assert_eq!(
             HogSpec::from_options(21, 21, opts),
             Err(expected.to_owned())
@@ -659,9 +660,9 @@ mod tests {
     #[test]
     fn test_direction_interpolation_within_bounds() {
         let image = gray_image!(
-			2, 1, 0;
-			2, 1, 0;
-			2, 1, 0);
+            2, 1, 0;
+            2, 1, 0;
+            2, 1, 0);
 
         let opts_signed = HogOptions {
             orientations: 8,

--- a/src/integral_image.rs
+++ b/src/integral_image.rs
@@ -317,7 +317,7 @@ pub fn variance(
 }
 
 /// Computes the running sum of one row of image, padded
-/// at the beginning and end. The padding is by continuity.
+/// at the beginning and end. Padding method is controlled by `extend`.
 /// Takes a reference to buffer so that this can be reused
 /// for all rows in an image.
 ///
@@ -388,7 +388,7 @@ pub fn row_running_sum(
 }
 
 /// Computes the running sum of one column of image, padded
-/// at the top and bottom. The padding is by continuity.
+/// at the top and bottom. Padding method is controlled by `extend`.
 /// Takes a reference to buffer so that this can be reused
 /// for all columns in an image.
 ///

--- a/src/integral_image.rs
+++ b/src/integral_image.rs
@@ -1,7 +1,8 @@
 //! Functions for computing [integral images](https://en.wikipedia.org/wiki/Summed_area_table)
 //! and running sums of rows and columns.
 
-use crate::definitions::Image;
+use crate::definitions::{BoundaryAccess, Image};
+use crate::geometric_transformations::Border;
 use crate::map::{ChannelMap, WithChannel};
 use image::{GenericImageView, GrayImage, Luma, Pixel, Primitive, Rgb, Rgba};
 use std::ops::AddAssign;
@@ -332,6 +333,7 @@ pub fn variance(
 /// # extern crate imageproc;
 /// # fn main() {
 /// use imageproc::integral_image::row_running_sum;
+/// use imageproc::geometric_transformations::Border;
 ///
 /// let image = gray_image!(
 ///     1, 2, 3;
@@ -339,13 +341,19 @@ pub fn variance(
 ///
 /// // Buffer has length two greater than image width, hence padding of 1
 /// let mut buffer = [0; 5];
-/// row_running_sum(&image, 0, &mut buffer, 1);
+/// row_running_sum(&image, 0, &mut buffer, 1, Border::Replicate);
 ///
 /// // The image is padded by continuity on either side
 /// assert_eq!(buffer, [1, 2, 4, 7, 10]);
 /// # }
 /// ```
-pub fn row_running_sum(image: &GrayImage, row: u32, buffer: &mut [u32], padding: u32) {
+pub fn row_running_sum(
+    image: &GrayImage,
+    row: u32,
+    buffer: &mut [u32],
+    padding: u32,
+    extend: Border<Luma<u8>>,
+) {
     // TODO: faster, more formats
     let (width, height) = image.dimensions();
     let (width, padding) = (width as usize, padding as usize);
@@ -360,21 +368,21 @@ pub fn row_running_sum(image: &GrayImage, row: u32, buffer: &mut [u32], padding:
     assert!(width > 0, "image is empty");
 
     let row_data = &(**image)[width * row as usize..][..width];
-    let first = row_data[0] as u32;
-    let last = row_data[width - 1] as u32;
+    //let first = row_data[0] as u32;
+    //let last = row_data[width - 1] as u32;
 
     let mut sum = 0;
 
-    for b in &mut buffer[..padding] {
-        sum += first;
+    for (i, b) in &mut buffer[..padding].iter_mut().enumerate() {
+        sum += image.get_pixel_or_extend(-(i as i64), row as i64, extend)[0] as u32;
         *b = sum;
     }
     for (b, p) in buffer[padding..].iter_mut().zip(row_data) {
         sum += *p as u32;
         *b = sum;
     }
-    for b in &mut buffer[padding + width..] {
-        sum += last;
+    for (i, b) in &mut buffer[padding + width..].iter_mut().enumerate() {
+        sum += image.get_pixel_or_extend((width + i) as i64, row as i64, extend)[0] as u32;
         *b = sum;
     }
 }
@@ -396,6 +404,7 @@ pub fn row_running_sum(image: &GrayImage, row: u32, buffer: &mut [u32], padding:
 /// # extern crate imageproc;
 /// # fn main() {
 /// use imageproc::integral_image::column_running_sum;
+/// use imageproc::geometric_transformations::Border;
 ///
 /// let image = gray_image!(
 ///     1, 4;
@@ -404,13 +413,19 @@ pub fn row_running_sum(image: &GrayImage, row: u32, buffer: &mut [u32], padding:
 ///
 /// // Buffer has length two greater than image height, hence padding of 1
 /// let mut buffer = [0; 5];
-/// column_running_sum(&image, 0, &mut buffer, 1);
+/// column_running_sum(&image, 0, &mut buffer, 1, Border::Replicate);
 ///
 /// // The image is padded by continuity on top and bottom
 /// assert_eq!(buffer, [1, 2, 4, 7, 10]);
 /// # }
 /// ```
-pub fn column_running_sum(image: &GrayImage, column: u32, buffer: &mut [u32], padding: u32) {
+pub fn column_running_sum(
+    image: &GrayImage,
+    column: u32,
+    buffer: &mut [u32],
+    padding: u32,
+    extend: Border<Luma<u8>>,
+) {
     // TODO: faster, more formats
 
     assert!(image.height() > 0, "image is empty");
@@ -438,12 +453,12 @@ pub fn column_running_sum(image: &GrayImage, column: u32, buffer: &mut [u32], pa
     debug_assert_eq!(height, middle.len(),);
     debug_assert_eq!(padding, tail.len());
 
-    let first = image.get_pixel(column, 0)[0] as u32;
-    let last = image.get_pixel(column, image.height() - 1)[0] as u32;
+    //let first = image.get_pixel(column, 0)[0] as u32;
+    //let last = image.get_pixel(column, image.height() - 1)[0] as u32;
 
     let mut sum = 0;
-    for b in head {
-        sum += first;
+    for (i, b) in head.iter_mut().enumerate() {
+        sum += image.get_pixel_or_extend(column as i64, -(i as i64), extend)[0] as u32;
         *b = sum;
     }
     for (y, b) in (0..image.height()).zip(middle) {
@@ -456,8 +471,8 @@ pub fn column_running_sum(image: &GrayImage, column: u32, buffer: &mut [u32], pa
         sum += unsafe { image.unsafe_get_pixel(column, y) }[0] as u32;
         *b = sum;
     }
-    for b in tail {
-        sum += last;
+    for (i, b) in tail.iter_mut().enumerate() {
+        sum += image.get_pixel_or_extend(column as i64, (height + i) as i64, extend)[0] as u32;
         *b = sum;
     }
 }
@@ -556,7 +571,7 @@ mod tests {
     fn test_column_running_sum() {
         let get_column_running_sum = |image: &GrayImage, column, padding| -> Vec<u32> {
             let mut buffer = vec![0u32; (image.height() + 2 * padding) as usize];
-            column_running_sum(image, column, &mut buffer, padding);
+            column_running_sum(image, column, &mut buffer, padding, Border::Replicate);
             buffer
         };
 
@@ -632,7 +647,7 @@ mod proptests {
                 actual.fill(0);
                 expected.fill(0);
 
-                column_running_sum(&image, col, &mut actual, padding);
+                column_running_sum(&image, col, &mut actual, padding, Border::Replicate);
                 column_running_sum_reference(&image, col, &mut expected, padding);
                 prop_assert_eq!(&actual, &expected);
             }
@@ -709,7 +724,7 @@ mod benches {
         let image = gray_bench_image(1000, 1);
         let mut buffer = [0; 1010];
         b.iter(|| {
-            row_running_sum(&image, 0, &mut buffer, 5);
+            row_running_sum(&image, 0, &mut buffer, 5, Border::Replicate);
         });
     }
 
@@ -718,7 +733,7 @@ mod benches {
         let image = gray_bench_image(100, 1000);
         let mut buffer = [0; 1010];
         b.iter(|| {
-            column_running_sum(&image, 0, &mut buffer, 5);
+            column_running_sum(&image, 0, &mut buffer, 5, Border::Replicate);
         });
     }
 }

--- a/src/seam_carving.rs
+++ b/src/seam_carving.rs
@@ -4,6 +4,7 @@
 //! [seam carving]: https://en.wikipedia.org/wiki/Seam_carving
 
 use crate::definitions::{HasBlack, Image};
+use crate::geometric_transformations::Border;
 use crate::gradients::gradients;
 use crate::kernel::{self};
 use crate::map::{WithChannel, map_pixels};
@@ -59,6 +60,7 @@ where
         image,
         kernel::SOBEL_HORIZONTAL_3X3,
         kernel::SOBEL_VERTICAL_3X3,
+        Border::Replicate,
         |p| {
             let gradient_sum: u16 = p.channels().iter().sum();
             let gradient_mean: u16 = gradient_sum / P::CHANNEL_COUNT as u16;

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -517,6 +517,7 @@ fn test_sobel_gradients() {
                 image,
                 kernel::SOBEL_HORIZONTAL_3X3,
                 kernel::SOBEL_VERTICAL_3X3,
+                Border::Replicate,
                 |p| p,
             ),
             <u8 as Clamp<u16>>::clamp,
@@ -527,13 +528,15 @@ fn test_sobel_gradients() {
 
 #[test]
 fn test_sharpen3x3() {
-    compare_to_truth("robin.png", "robin_sharpen3x3.png", sharpen3x3);
+    compare_to_truth("robin.png", "robin_sharpen3x3.png", |image| {
+        sharpen3x3(image, Border::Replicate)
+    });
 }
 
 #[test]
 fn test_sharpen_gaussian() {
     fn sharpen(image: &GrayImage) -> GrayImage {
-        imageproc::filter::sharpen_gaussian(image, 0.7, 7.0)
+        imageproc::filter::sharpen_gaussian(image, 0.7, 7.0, Border::Replicate)
     }
     compare_to_truth("robin.png", "robin_sharpen_gaussian.png", sharpen);
 }
@@ -562,14 +565,14 @@ fn test_canny() {
 #[test]
 fn test_gaussian_blur_stdev_3() {
     compare_to_truth("zebra.png", "zebra_gaussian_3.png", |image: &GrayImage| {
-        gaussian_blur_f32(image, 3f32)
+        gaussian_blur_f32(image, 3f32, Border::Replicate)
     });
 }
 
 #[test]
 fn test_gaussian_blur_stdev_10() {
     compare_to_truth("zebra.png", "zebra_gaussian_10.png", |image: &GrayImage| {
-        gaussian_blur_f32(image, 10f32)
+        gaussian_blur_f32(image, 10f32, Border::Replicate)
     });
 }
 

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -1032,7 +1032,13 @@ fn test_hough_line_detection() {
 #[test]
 fn test_bilateral_filter() {
     fn filter(image: &GrayImage) -> GrayImage {
-        bilateral_filter(image, 2, 10.0, GaussianEuclideanColorDistance::new(10.0))
+        bilateral_filter(
+            image,
+            2,
+            10.0,
+            GaussianEuclideanColorDistance::new(10.0),
+            Border::Replicate,
+        )
     }
 
     compare_to_truth_with_tolerance("lumaphant.png", "lumaphant_bilateral.png", filter, 1)


### PR DESCRIPTION
This extends the work started in #769 (specifying boundary behaviour with `Border<P>`) to `filter*()` functions and friends. Refactoring all of them while keeping track of performance might take a while.

Closes #2.